### PR TITLE
Add Latex Environments plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -185,5 +185,13 @@
         "author": "Noureddine Haouari",
         "description": "Allow inserting text context search results on the active note, the plugin is based on the plugin mrj-text-expand-witb-text of MrJackphil.",
         "repo": "nhaouari/searchpp"
+    },
+    {
+        "id": "obsidian-latex-environments",
+        "name": "Latex Environments",
+        "author": "Zach Raines",
+        "description": "Allows to quickly insert and change latex environments within math environments.",
+        "repo": "raineszm/obsidian-latex-environments"
     }
+
 ]


### PR DESCRIPTION
A plug-in to allow easy insertion and renaming of latex environments in math blocks. 