### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -293,4 +293,11 @@
         "description": "Open random notes with greater control",
         "repo": "erichalldev/obsidian-smart-random-note"
     }
+    {
+        "id": "cycle-through-panes",
+        "name": "Cycle through Panes",
+        "author": "Vinadon & Rythm",
+        "description": "Cycle through your open Panes with `ctrl + Tab`, just like with Tabs in your Browser!",
+        "repo": "phibr0/cycle-through-panes"
+    }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -292,7 +292,7 @@
         "author": "Eric Hall",
         "description": "Open random notes with greater control",
         "repo": "erichalldev/obsidian-smart-random-note"
-    }
+    },
     {
         "id": "cycle-through-panes",
         "name": "Cycle through Panes",


### PR DESCRIPTION
# Add Cycle through Panes Plugin

This Plugin allows the User to switch between active/open Tabs in Obsidian using `ctrl + Tab`, just like in a Browser!