### PR TITLE
Add tab anywhere plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -436,5 +436,12 @@
         "author": "Pseudonium",
         "description": "This is an Anki integration plugin! Designed for efficient bulk exporting.",
         "repo": "Pseudonium/Obsidian_to_Anki"
+    },
+    {
+        "id": "obsidian-tab-anywhere-plugin",
+        "name": "Tab Anywhere",
+        "author": "Nadav Spiegelman",
+        "description": "Configures the tab key to indent the current line from anywhere in the line, not just the beginning.",
+        "repo": "nadavspi/obsidian-tab-anywhere-plugin"
     }
 ]


### PR DESCRIPTION
https://github.com/nadavspi/obsidian-tab-anywhere-plugin

Not sure if there's already a way to configure Code Mirror via the UI, but I didn't find it. 
Let me know if you have a suggestion for how to set the option right away since it seems like the codemirror event only executes when CodeMirror is first initialized. 