### PR TITLE
Adding a 'hotfix' for the code-block-copy plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -443,5 +443,12 @@
         "author": "Matt Sessions",
         "description": "This plugin will rollover any unchecked checkboxes from your last daily note into today's note",
         "repo": "shichongrui/obsidian-rollover-daily-todos"
+    },
+    {
+        "id": "code-block-copy",
+        "name": "Copy button for code blocks",
+        "author": "Daniel Brandenburg",
+        "description": "Copy button for code blocks. Forked & created hotfix release 0.2.1 to get rid of persistent update notification on source project (https:\/\/github.com\/jdbrice\/obsidian-code-block-copy)",
+        "repo": "natpalmer-e4o4/obsidian-code-block-copy"
     }
 ]


### PR DESCRIPTION
Fork with hotfix release 0.2.1 to get rid of persistent update notification on source project (https://github.com/jdbrice/obsidian-code-block-copy)

See open issues on source project for more details.