### PR TITLE
Add Export To Tex plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -450,5 +450,12 @@
         "author": "Matt Sessions",
         "description": "This plugin will automatically reveal the currently active file in the side navigation.",
         "repo": "shichongrui/obsidian-reveal-active-file"
+    },
+    {
+        "id": "obsidian-export-to-tex",
+        "name": "Export To TeX",
+        "author": "Zach Raines",
+        "description": "Export vault files in a format amenable to pasting into a TeX document",
+        "repo": "raineszm/obsidian-export-to-tex"
     }
 ]


### PR DESCRIPTION
This plugin adds basic functionally for converting obsidian files to TeX format.