### PR TITLE
Add Extended MathJax plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -457,5 +457,12 @@
         "author": "Zach Raines",
         "description": "Export vault files in a format amenable to pasting into a TeX document",
         "repo": "raineszm/obsidian-export-to-tex"
+    }, 
+    {
+        "id": "obsidian-latex",
+        "name": "Extended MathJax",
+        "author": "Xavier Denis",
+        "description": "Enables additional MathJax packages and adds a global preamble for MathJax",
+        "repo": "xldenis/obsidian-latex"
     }
 ]


### PR DESCRIPTION
Adds an Extended MathJax plugin which has a fixed global preamble as well as support for additional mathjax packages (for now `mdchem` and `bussproofs`). I'm reserving the name `obsidian-latex` because I'm working on an additional feature which would allow actually calling latex for math rendering instead of mathjax in a future release. 