### PR TITLE
Remove obsidian-latex-preamble-plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -289,13 +289,6 @@
         "branch": "main"
     },
     {
-        "id": "obsidian-latex-preamble-plugin",
-        "name": "Latex preamble",
-        "author": "Pokey Rule",
-        "description": "Adds support for a global latex preamble",
-        "repo": "pokey/obsidian-latex-preamble-plugin"
-    },
-    {
         "id": "wikilinks-to-mdlinks-obsidian",
         "name": "Wikilinks to MDLinks (Markdown Links)",
         "author": "Agatha Uy",


### PR DESCRIPTION
Deprecating in favour of `obsidian-latex`