### PR TITLE
Add temple plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -497,5 +497,13 @@
         "description": "Settings plugin for the California Coast theme.",
         "repo": "mgmeyers/obsidian-california-coast-settings",
         "branch": "main"
+    },
+    {
+        "id": "obsidian-temple",
+        "name": "Temple",
+        "author": "garyng",
+        "description": "A plugin for templating in Obsidian, powered by Nunjucks.",
+        "repo": "garyng/obsidian-temple",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
[Temple](https://github.com/garyng/obsidian-temple) is a templating plugin that uses nunjucks under the hood. Serves as a more extensible alternative to https://github.com/SilentVoid13/Templater.