### PR TITLE
Adds PDF Highlights plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -458,7 +458,7 @@
         "author": "Zach Raines",
         "description": "Export vault files in a format amenable to pasting into a TeX document",
         "repo": "raineszm/obsidian-export-to-tex"
-    }, 
+    },
     {
         "id": "obsidian-latex",
         "name": "Extended MathJax",
@@ -553,11 +553,18 @@
         "description": "Fine-grained control of Discordian Theme",
         "repo": "radekkozak/discordian-plugin"
     },
-        {
+    {
         "id": "completed-task-display",
         "name": "Completed Task Display",
         "author": "Ben Lee-Cohen",
         "description": "Provides controls for displaying or hiding completed tasks",
         "repo": "heliostatic/completed-task-display"
+    },
+    {
+        "id": "obsidian-extract-pdf-highlights",
+        "name": "PDF Highlights",
+        "author": "Alexis Rondeau",
+        "description": "Extract highlights, underlines and annotations from your PDFs into Obsidian",
+        "repo": "akaalias/obsidian-extract-pdf-highlights"
     }
 ]


### PR DESCRIPTION
Hi @lishid!

I'm super excited about this plugin and would love to share it with the community. 

Since we spoke about using Obsidian's PDFJS – In this case here, that won't be possible because I had to create a really customized version of PDFJS in order to retrieve the annotation text. I'm using my fork from `https://github.com/akaalias/pdfjs-dist` to get it done. 

Question here: How can I import it so it doesn't overload Obsidian's PDFJS? 

Currently I'm doing: 

``` 
import pdfjsCustom from "node_modules/pdfjs-dist/build/pdf";
import worker from "node_modules/pdfjs-dist/build/pdf.worker.entry";
... 

pdfjsCustom.GlobalWorkerOptions.workerSrc = worker;
...
var loadingTask = pdfjsCustom.getDocument(arrayBuffer);
...
```

I've also re-used your suggestion on file-handling from before:

```
let file = this.app.workspace.getActiveFile();
if (file === null) return;
if (file.extension !== 'pdf') return;
let arrayBuffer = await this.app.vault.readBinary(file);
```

Much nicer. 

Anyways, when you do have the time, please QA the plugin over at https://github.com/akaalias/obsidian-extract-pdf-highlights and let me know what I can do to launch it!

Thank you so much, 

Alexis