### PR TITLE
Change repo of Neo4j Graph View

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -503,7 +503,7 @@
         "name": "Neo4j Graph View",
         "author": "Emile van Krieken",
         "description": "A plugin for advanced graph visualization and querying using Neo4j.",
-        "repo": "HEmile/semantic-markdown-converter",
+        "repo": "HEmile/obsidian-neo4j-graph-view",
         "branch": "main"
     },
     {


### PR DESCRIPTION
I'd like to change the name of the repo of Neo4j Graph View from `semantic-markdown-converter` to `obsidian-neo4j-graph-view`. 
The old name isn't representative of the contents of the repo anymore (the Python library called semantic-markdown-converter will be deprecated in the next version). 

Will everything keep working if the repo is changed like this? (Ie, all installations and stats are kept, just the link changes?)
The repo will be renamed when/if the PR is accepted, so people can still install it until that happens.