### PR TITLE
Add page heading from links plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -653,5 +653,6 @@
         "author": "Mark Beattie",
         "description": "Inserts a heading into blank pages from the filename",
         "repo": "beet/page-headings-obsidian-plugin",
+        "branch": "main"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -646,5 +646,12 @@
         "author": "Michal Bureš",
         "description": "Convert file path to uri for easier use of links to local files outside of Obsidian",
         "repo": "MichalBures/obsidian-file-path-to-uri"
+    },
+    {
+        "id": "page-heading-from-links",
+        "name": "Page Heading From Links",
+        "author": "Mark Beattie",
+        "description": "Inserts a heading into blank pages from the filename",
+        "repo": "beet/page-headings-obsidian-plugin",
     }
 ]


### PR DESCRIPTION
Adds https://github.com/beet/page-headings-obsidian-plugin

I like to create new pages by first inserting a link into the parent page like `[[My child page]]`, and then clicking on the link to create it. I then have to manually insert a heading matching the filename like `# My child page`.

With this plugin enabled, a `file-open` callback constructs a heading any time a blank file is opened, either from having just created it from a link, or it already existing, and inserts it into the page so it's one less thing to do.
