### PR TITLE
Add File path to URI plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -639,5 +639,12 @@
         "author": "Emile",
         "description": "Add context menu items to search the internet based on the title of your note",
         "repo": "HEmile/obsidian-search-on-internet"
+    },
+    {
+        "id": "obsidian-file-path-to-uri",
+        "name": "File path to URI",
+        "author": "Michal Bureš",
+        "description": "Convert file path to uri for easier use of links to local files outside of Obsidian",
+        "repo": "MichalBures/obsidian-file-path-to-uri"
     }
 ]


### PR DESCRIPTION
Adds https://github.com/MichalBures/obsidian-file-path-to-uri plugin.