### PR TITLE
Fix id for visini/obsidian-icons-plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -655,7 +655,7 @@
         "branch": "main"
     },
     {
-        "id": "page-heading-from-links",
+        "id": "obsidian-icons-plugin",
         "name": "Icons Plugin",
         "author": "Camillo Visini",
         "description": "Add icons to your notes",


### PR DESCRIPTION
I forgot to adjust the id for the plugin. I apologize for the oversight. 

See https://github.com/obsidianmd/obsidian-releases/pull/122

Thank you in advance!