### PR TITLE
Add Things logbook plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -692,10 +692,18 @@
         "repo": "d-sauer/Obsidian-Min3ditorHotkeys-plugin"
     },
     {
-       "id":"obsidian-jsonifier",
-       "name":"JSONifier",
-       "author":"Kjell Connelly",
-       "description":"JSON.stringify() or JSON.parse() highlighted text and copy to clipboard.",
-       "repo":"KjellConnelly/obsidian-jsonifier"
+        "id":"obsidian-jsonifier",
+        "name":"JSONifier",
+        "author":"Kjell Connelly",
+        "description":"JSON.stringify() or JSON.parse() highlighted text and copy to clipboard.",
+        "repo":"KjellConnelly/obsidian-jsonifier"
+    },
+    {
+        "id": "things-logbook",
+        "name": "Things Logbook",
+        "author": "liamcain",
+        "description": "Sync your Things logbook with your daily notes",
+        "repo": "liamcain/obsidian-things-logbook",
+        "branch": "main"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -692,11 +692,11 @@
         "repo": "d-sauer/Obsidian-Min3ditorHotkeys-plugin"
     },
     {
-        "id":"obsidian-jsonifier",
-        "name":"JSONifier",
-        "author":"Kjell Connelly",
-        "description":"JSON.stringify() or JSON.parse() highlighted text and copy to clipboard.",
-        "repo":"KjellConnelly/obsidian-jsonifier"
+        "id": "obsidian-jsonifier",
+        "name": "JSONifier",
+        "author": "Kjell Connelly",
+        "description": "JSON.stringify() or JSON.parse() highlighted text and copy to clipboard.",
+        "repo": "KjellConnelly/obsidian-jsonifier"
     },
     {
         "id": "things-logbook",


### PR DESCRIPTION
https://github.com/liamcain/obsidian-things-logbook

This plugin will periodically fetch tasks from the [Things 3](https://culturedcode.com/things/) SQLite DB and insert them into their own section within your daily notes.

Note: The plugin is macOS-only (and requires Things to be installed) so I do an initial upfront check in `onload` for the platform.