### PR TITLE
add "Shortcuts for starred files" plugin.

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -705,5 +705,12 @@
         "description": "Sync your Things logbook with your daily notes",
         "repo": "liamcain/obsidian-things-logbook",
         "branch": "main"
+    },
+    {
+        "id": "obsidian-shortcuts-for-starred-files",
+        "name": "Shortcuts for starred files",
+        "description": "Set an individual hotkey for the first 9 starred files and open them just with your keyboard.",
+        "author": "Vinzent",
+        "repo": "Vinzent03/obsidian-shortcuts-for-starred-files"
     }
 ]


### PR DESCRIPTION
I don't know it it is the best way to acces the starred files, but it works.
(https://github.com/Vinzent03/obsidian-shortcuts-for-starred-files)