### PR TITLE
Add filename-heading-sync plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -712,5 +712,12 @@
         "description": "Set an individual hotkey for the first 9 starred files and open them just with your keyboard.",
         "author": "Vinzent",
         "repo": "Vinzent03/obsidian-shortcuts-for-starred-files"
+    },
+    {
+        "id": "obsidian-filename-heading-sync",
+        "name": "Filename Heading Sync",
+        "description": "Obsidian plugin for keeping the filename with the first heading of a file in sync",
+        "author": "dvcrn",
+        "repo": "dvcrn/obsidian-filename-heading-sync"
     }
 ]


### PR DESCRIPTION
Plugin for keeping the filename and first heading of a file in sync https://github.com/dvcrn/obsidian-filename-heading-sync