### PR TITLE
Add obsidian-orthography plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -719,5 +719,12 @@
         "description": "Obsidian plugin for keeping the filename with the first heading of a file in sync",
         "author": "dvcrn",
         "repo": "dvcrn/obsidian-filename-heading-sync"
+    },
+    {
+        "id": "obsidian-orthography",
+        "name": "Obsidian Orthography",
+        "author": "denisoed",
+        "description": "Obsidian plugin to check & fix orthography errors in text",
+        "repo": "denisoed/obsidian-orthography"
     }
 ]


### PR DESCRIPTION
# Obsidian plugin to check & fix orthography errors in text

https://github.com/denisoed/obsidian-orthography

* Search for spelling errors in the text
* Displaying options for correcting word mistakes
* Correct a word mistake in one click