### PR TITLE
Removes YAML front matter template plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -555,14 +555,6 @@
         "branch": "master"
     },
     {
-        "id": "obsidian-yfm-templater-plugin",
-        "name": "YAML front matter template plugin",
-        "author": "Miltiadis Orfanos",
-        "description": "Create templates using the Eta.js template engines and YAML front matter as data.",
-        "repo": "m-orfanos/obsidian-yfm-templater-plugin",
-        "branch": "main"
-    },
-    {
         "id": "discordian-plugin",
         "name": "Discordian Theme",
         "author": "@radekkozak",


### PR DESCRIPTION
The plugin isn't currently not working in the latest build (I can't even get it to run...). I don't have time right now to fix the issue, it will have to wait at least another 2-3 weeks. I'd rather remove it from the list until then so it doesn't affect anyone. Sorry for the trouble.