### PR TITLE
Add TODO plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -864,5 +864,13 @@
         "description": "Status bar item with vault statistics such as number of notes, files, attachments, and links",
         "author": "Bryan Kyle",
         "repo": "bkyle/obsidian-vault-statistics-plugin"
+    },
+    {
+        "id": "obsidian-plugin-todo",
+        "name": "Obsidian TODO",
+        "description": "Text-based GTD in Obsidian. Collects all outstanding TODOs from your vault and presents them in lists Today, Scheduled, Inbox and Someday/Maybe.",
+        "author": "Lars Lockefeer",
+        "repo": "larslockefeer/obsidian-plugin-todo",
+        "branch": "main"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -867,7 +867,7 @@
     },
     {
         "id": "obsidian-plugin-todo",
-        "name": "Obsidian TODO",
+        "name": "Obsidian TODO | Text-based GTD",
         "description": "Text-based GTD in Obsidian. Collects all outstanding TODOs from your vault and presents them in lists Today, Scheduled, Inbox and Someday/Maybe.",
         "author": "Lars Lockefeer",
         "repo": "larslockefeer/obsidian-plugin-todo",


### PR DESCRIPTION
A plugin for text-based GTD in Obsidian.

Features in this initial release:
- Aggregates all outstanding TODOs in your vault and lists them in a single view
- Split out TODOs by type ("Today", "Scheduled", "Inbox" and "Someday/Maybe")
- Schedule a TODO for a specific date by adding a tag #YYYY-DD-MM
- Mark a TODO as Someday/Maybe by adding a tag #someday
- Complete TODOs from the list view
- Quickly jump to the file in which a TODO is found from the list view