### PR TITLE
Add hotkey-helper plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1013,5 +1013,12 @@
         "description": "Open or reveal the current note in DEVONthink.",
         "author": "ryanjamurphy",
         "repo": "ryanjamurphy/DEVONlink-obsidian"
+    },
+    {
+        "id": "hotkey-helper",
+        "name": "Hotkey Helper",
+        "author": "PJ Eby",
+        "description": "Easily see and access any plugin's settings or hotkey assignments (and conflicts) from the Community Plugins tab",
+        "repo": "pjeby/hotkey-helper"
     }
 ]


### PR DESCRIPTION
# [x] I am submitting a new Community Plugin

## Repo URL
https://github.com/pjeby/hotkey-helper

## Release Checklist
- [x] I have tested this on Windows ~~macOS, and Linux~~
- [x] Github release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css`
- [x] Github release name matches the exact version number specified in your manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
