### PR TITLE
Add PlantUML Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1035,5 +1035,12 @@
         "description": "Move note attachments and update links automatically",
         "author": "Dmitry Savosh",
         "repo": "derwish-pro/obsidian-consistent-attachments-and-links"
+    },
+    {
+        "id": "obsidian-plantuml",
+        "name": "PlantUML"
+        "description": "Generate PlantUML diagrams",
+        "author": "Johannes Theiner",
+        "repo": "joethei/obsidian-plantuml"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1038,7 +1038,7 @@
     },
     {
         "id": "obsidian-plantuml",
-        "name": "PlantUML"
+        "name": "PlantUML",
         "description": "Generate PlantUML diagrams",
         "author": "Johannes Theiner",
         "repo": "joethei/obsidian-plantuml"


### PR DESCRIPTION
# [ ] I am submitting a new Community Theme

## Repo URL

<!--- Paste a link to your repo here for easy access -->

# [X] I am submitting a new Community Plugin

## Repo URL

[https://github.com/joethei/obsidian-plantuml/](https://github.com/joethei/obsidian-plantuml/)

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->

- [ ] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [X] Github release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] Github release name matches the exact version number specified in your manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] README clearly describes the plugins purpose and provides clear usage instructions.
