### PR TITLE
Fix tag-wrangler description

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -742,7 +742,7 @@
         "id": "tag-wrangler",
         "name": "Tag Wrangler",
         "author": "PJ Eby",
-        "description": "Rename, delete, toggle, and search tags from the tag pane",
+        "description": "Rename, merge, toggle, and search tags from the tag pane",
         "repo": "pjeby/tag-wrangler"
     },
     {


### PR DESCRIPTION
The description should say "merge" instead of "delete"
