### PR TITLE
add koncham-undefault-hotkeys plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1072,5 +1072,15 @@
           "description": "Inline dice rolling for Obsidian.md",
           "author": "Jeremy Valentine",
           "repo": "valentine195/obsidian-dice-roller"
+    },
+    {
+
+          "id": "obsidian-koncham-undefault-hotkeys",
+          "name": "koncham undefault hotkeys",
+          "description": "unset some default CodeMirror hotkeys",
+          "author": "mano",
+          "repo": "manogna4/obsidian-koncham-undefault-hotkeys",
+          "branch": "main"
+            
     }
 ]


### PR DESCRIPTION
# [x] I am submitting a new Community Plugin

## Repo URL

https://github.com/manogna4/obsidian-koncham-undefault-hotkeys

## Release Checklist

- [ ] I have tested this on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] Github release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] Github release name matches the exact version number specified in your manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
