### PR TITLE
Adds obsidian-style-settings plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1155,7 +1155,7 @@
     {
         "id": "obsidian-style-settings",
         "name": "Style Settings",
-        "description": "Offers controls for adjusting theme, plugin, and CSS snippet styles",
+        "description": "Offers controls for adjusting theme, plugin, and snippet CSS variables",
         "author": "mgmeyers",
         "repo": "mgmeyers/obsidian-style-settings",
         "branch": "main"

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1125,7 +1125,7 @@
     },
     {
         "id": "obsidian-admonition",
-	      "name": "Admonition",
+        "name": "Admonition",
         "description": "Admonition block-styled content for Obsidian.md",
         "author": "Jeremy Valentine",
         "repo": "valentine195/obsidian-admonition"
@@ -1151,5 +1151,13 @@
         "description": "Add hotkeys to insert specific templates",
         "author": "Vinzent",
         "repo": "Vinzent03/obsidian-hotkeys-for-templates"
+    },
+    {
+        "id": "obsidian-style-settings",
+        "name": "Style Settings",
+        "description": "Offers controls for adjusting theme, plugin, and CSS snippet styles",
+        "author": "mgmeyers",
+        "repo": "mgmeyers/obsidian-style-settings",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# [x] I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->

https://github.com/mgmeyers/obsidian-style-settings

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->

- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] Github release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - `styles.css` _(optional)_
- [x] Github release name matches the exact version number specified in your manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
