### PR TITLE
Adds obsidian-embedded-note-titles

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1159,5 +1159,13 @@
         "author": "mgmeyers",
         "repo": "mgmeyers/obsidian-style-settings",
         "branch": "main"
+    },
+    {
+        "id": "obsidian-embedded-note-titles",
+        "name": "Embedded Note Titles",
+        "author": "mgmeyers",
+        "description": "Inserts the note file name as an H1 heading above each note",
+        "repo": "mgmeyers/obsidian-embedded-note-titles",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

https://github.com/mgmeyers/obsidian-embedded-note-titles

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->

- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] Github release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - `styles.css` _(optional)_
- [x] Github release name matches the exact version number specified in your manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
