### PR TITLE
Update community-plugins.json to include "Blurry Edit Mode" plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1129,5 +1129,12 @@
         "description": "Admonition block-styled content for Obsidian.md",
         "author": "Jeremy Valentine",
         "repo": "valentine195/obsidian-admonition"
+    },
+    {
+        "id": "obsidian-blurry-edit-mode",
+	"name": "Blurry Edit Mode",
+        "description": "Provides a button and command to toggle blurred text for better privacy in Edit mode. No more 'shoulder surfing!'",
+        "author": "Jill Alberts",
+        "repo": "jillalberts/obsidian-blurry-edit-mode"
     }
 ]


### PR DESCRIPTION
I followed the instructions carefully, but this is my first time trying anything like this! Any/all suggestions welcome.

# [X] I am submitting a new Community Plugin

## Repo URL

https://github.com/jillalberts/obsidian-blurry-edit-mode

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->

- [X] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [X] Github release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] Github release name matches the exact version number specified in your manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] README clearly describes the plugins purpose and provides clear usage instructions.
