### PR TITLE
Use main branch for California Coast theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -319,7 +319,8 @@
         "author": "mgmeyers",
         "repo": "mgmeyers/obsidian-california-coast-theme",
         "screenshot": "screenshots/04.png",
-        "modes": ["dark", "light"]
+        "modes": ["dark", "light"],
+        "branch": "main"
     },
     {
         "name": "Discordian",


### PR DESCRIPTION
This is a minor update. I noticed that the thumbnail for my theme isn't loading. Seems like it was pointing to the wrong branch!