### PR TITLE
Add cm-chs-patch

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1183,5 +1183,12 @@
         "author": "darakah",
         "repo": "Darakah/obsidian-fountain",
         "branch": "main"
+    },
+    {
+        "id": "cm-chs-patch",
+        "name": "Word Splitting for Simplified Chinese in Edit Mode",
+        "author": "AidenLx",
+        "description": "A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting",
+        "repo": "alx-plugins/cm-chs-patch"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1189,6 +1189,7 @@
         "name": "Word Splitting for Simplified Chinese in Edit Mode",
         "author": "AidenLx",
         "description": "A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting",
-        "repo": "alx-plugins/cm-chs-patch"
+        "repo": "alx-plugins/cm-chs-patch",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION

## Repo URL

[alx-plugins/cm-chs-patch](https://github.com/alx-plugins/cm-chs-patch)

## Release Checklist

- [x] I have tested this on Windows, macOS
- [x] Github release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - `styles.css` _(optional)_
- [x] Github release name matches the exact version number specified in your manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.

Related Feature Request: <https://forum.obsidian.md/t/editor-cm5-doesnt-support-word-splitting-in-cjk-languages/15773>
