### PR TITLE
Remove California Coast settings plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -513,14 +513,6 @@
         "repo": "cristianvasquez/obsidian-snippets-plugin"
     },
     {
-        "id": "obsidian-california-coast-settings",
-        "name": "California Coast Theme",
-        "author": "mgmeyers",
-        "description": "Settings plugin for the California Coast theme.",
-        "repo": "mgmeyers/obsidian-california-coast-settings",
-        "branch": "main"
-    },
-    {
         "id": "obsidian-temple",
         "name": "Temple",
         "author": "garyng",


### PR DESCRIPTION
With the release of the [Style Settings](https://github.com/mgmeyers/obsidian-style-settings) plugin, the California Coast settings plugin is now deprecated. This PR removes it from the community-plugin list.