### PR TITLE
Correct Obsidian tabs plugin entry

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1246,9 +1246,9 @@
     },
     {
         "id": "obsidian-tabs",
-        "name": "Tabbed View",
+        "name": "Obsidian Tabs",
         "author": "foreveryone",
-        "description": "New panes are opened",
+        "description": "New panes are opened in a tabbed view.",
         "repo": "gitobsidiantutorial/obsidian-tabs"
     },
     {


### PR DESCRIPTION
The original pull request still used the outdated 'Tabbed View' title, rather than the current 'Obsidian Tabs' title, also, the description was incomplete.
