### PR TITLE
Add Beeminder Word Count Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1349,5 +1349,13 @@
         "author": "Charlie Chao",
         "repo": "charliecm/obsidian-tidy-footnotes",
         "branch": "main"
+    },
+    {
+        "id": "beeminder-word-count-plugin",
+        "name": "Beeminder Word Count Plugin",
+        "description": "Post word counts directly from obsidian md file to Beeminder",
+        "author": "Yuta Miyama",
+        "repo": "kenzan100/beeminder-obsidian-word-count",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
I really enjoyed working with https://github.com/obsidianmd/obsidian-sample-plugin and Obsidian ecosystem in general. Thank you.

# [x] I am submitting a new Community Plugin

## Repo URL

https://github.com/kenzan100/beeminder-obsidian-word-count

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->

- [ ] I have tested this on ~Windows~, macOS, and ~Linux~ _(if applicable)_
- [x] Github release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - `styles.css` _(optional)_
- [x] Github release name matches the exact version number specified in your manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
