### PR TITLE
Add obsidian-image-auto-upload-plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1409,5 +1409,12 @@
         "author": "Tokuhiro Matsuno",
         "description": "This plugin will display the page linked 2hop ahead.",
         "repo": "tokuhirom/obsidian-2hop-links-plugin"
+    },
+    {
+        "id": "obsidian-image-auto-upload-plugin",
+        "name": "Image auto upload Plugin",
+        "description": "This plugin uploads images from your clipboard by PicGo",
+        "author": "renmu123",
+        "repo": "renmu123/obsidian-image-auto-upload-plugin"
     }
 ]


### PR DESCRIPTION
# [x] I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
https://github.com/renmu123/obsidian-image-auto-upload-plugin
## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->

- [ ] I have tested this on macOS, and Linux _(if applicable)_
- [x] I have tested this on Windows
- [x] Github release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - `styles.css` _(optional)_
- [x] Github release name matches the exact version number specified in your manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
