### PR TITLE
Change display name for the readwise community plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1246,7 +1246,7 @@
     },
     {
         "id": "obsidian-readwise",
-        "name": "Readwise",
+        "name": "Readwise Community",
         "description": "Sync Readwise highlights into your notes",
         "author": "renehernandez",
         "repo": "renehernandez/obsidian-readwise",


### PR DESCRIPTION
# [ ] I am changing the display name for the Readwise Community plugin

A while ago I had changed the name of the plugin to **Readwise Community** as per request by the Readwise folks. I misseed updating the name here, so that it shows with the proper name in the `Browse` plugin list in Obsidian

## Repo URL

https://github.com/renehernandez/obsidian-readwise