### PR TITLE
Require licenses

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@
   - [ ] `obsidian.css`
   - [ ] The screenshot file you pointed to
 - [ ] You have indicated which modes (dark, light, or both) are compatible with your theme
+- [ ] You have added a license in the LICENSE file
 - [ ] If you're not using the `master` branch (legacy), please indicate
 
 
@@ -31,3 +32,4 @@
 - [ ] Github release name matches the exact version number specified in your manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
 - [ ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
 - [ ] README clearly describes the plugins purpose and provides clear usage instructions.
+- [ ] You have added a license in the LICENSE file


### PR DESCRIPTION
Require plugins to have a license in the LICENSE file to avoid any legal snags / too many abandoned projects being lost to the litigious ether down the line.

Typically the MIT license will be a good choice for most projects who want to be very permissive (which might often be the case for plugins that are unlikely to ever be monetized or independent of Obsidian - I am not a lawyer).

Perhaps a comment containing a link to https://choosealicense.com/ could be added to the template, though I didn't want to add 'noise'.

Per discussion in #plugin-dev channel: https://discord.com/channels/686053708261228577/840286264964022302/854099720505786409

Feel free to close/discard this if this isn't how you want it - I just wanted to make sure it wasn't forgotten!

