### PR TITLE
Add Status Bar Pomo Timer plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1699,5 +1699,12 @@
         "description": "Quickly create notes in Obsidian from web pages.",
         "repo": "kevboh/obsidian-pluck",
         "branch": "main"
+    },
+    {
+    "id": "obsidian-statusbar-pomo",
+    "name": "Status Bar Pomodoro Timer",
+    "author": "kzhovn",
+    "description": "Adds a pomodoro timer to your status bar.",
+    "repo": "kzhovn/statusbar-pomo-obsidian"
     }
 ]


### PR DESCRIPTION
# [x] I am submitting a new Community Plugin

## Repo URL

https://github.com/kzhovn/statusbar-pomo-obsidian

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on ~~Windows, macOS,~~ and Linux _(if applicable)_
- [x] Github release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] Github release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file
