### PR TITLE
Rename Dropbox Backups plugin.

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1542,7 +1542,7 @@
     },
     {
         "id": "obsidian-dropbox-backups",
-        "name": "Dropbox Backups",
+        "name": "Aut-O-Backups",
         "description": "Automated Dropbox backups of your entire vault.",
         "author": "ryanpcmcquen",
         "repo": "ryanpcmcquen/obsidian-dropbox-backups"


### PR DESCRIPTION
I have to rename the plugin to meet Dropbox's branding guidelines, and the app has already surpassed the limit of users for a development app.

https://github.com/ryanpcmcquen/obsidian-dropbox-backups