### PR TITLE
Added Command URI Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1742,5 +1742,13 @@
         "author": "Greg Zuro",
         "description": "Render Kroki diagrams.",
         "repo": "gregzuro/obsidian-kroki"
+    },
+    {
+        "id": "command-uri-obsidian",
+        "name": "Command URIs",
+        "author": "death_au",
+        "description": "Trigger any command palette command via an obsidian:// URI.",
+        "repo": "deathau/command-uri-obsidian",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
I just wanted a system-wide hotkey to create a new Zettlekasten note from anywhere, inside or outside Obsidian. Triggering a URI scheme seemed to be the easiest way to do that. 

Simply use the URI `obsidian://command?<command>` where `<command>` can either be the command's name (i.e. the text that appears in the command palette itself), or the command id, if you know it (tip: bring up the developer console and use `app.commands.commands` to view a list of all the commands). Just remember to url-encode the commands (spaces => `%20`).

Also, you can run multiple commands via a single URI by separating them with `&`!

It also opens up other possibilities, like creating a link to your daily note on your web browser's speed dial, or creating a random note shortcut that opens on startup. Not to mention it opens up URI schemes to plugins that haven't necessarily defined them.