### PR TITLE
Add obsidian-spelling-check-ru plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1742,5 +1742,12 @@
         "author": "Greg Zuro",
         "description": "Render Kroki diagrams.",
         "repo": "gregzuro/obsidian-kroki"
+    },
+    {
+        "id": "obsidian-spelling-check-ru",
+        "name": "Spelling Checker (Russian)",
+        "author": "Vseslav Dorofeev",
+        "description": "A sample plugin for Obsidian. This plugin checks Russian spelling",
+        "repo": "vdor/obsidian-check-ru-spelling-plugin"
     }
 ]


### PR DESCRIPTION
This plugin checks russian spelling

# [х] I am submitting a new Community Plugin

## Repo URL

https://github.com/vdor/obsidian-check-ru-spelling-plugin

## Release Checklist

- [x] I have tested this on macOS
- [x] Github release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css`
- [x] Github release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file
