### PR TITLE
Remove extended-context-menu + Update my Plugin Info

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -329,7 +329,7 @@
     {
         "id": "cycle-through-panes",
         "name": "Cycle through Panes",
-        "author": "Vinadon & Rythm",
+        "author": "Vinadon & phibr0",
         "description": "Cycle through your open Panes with `ctrl + Tab`, just like with Tabs in your Browser!",
         "repo": "phibr0/cycle-through-panes"
     },
@@ -539,7 +539,7 @@
     {
         "id": "obsidian-charts",
         "name": "Obsidian Charts",
-        "author": "phibr0 / Rythm",
+        "author": "phibr0",
         "description": "This Plugin lets you create Charts with Chartist as its backend!",
         "repo": "phibr0/obsidian-charts"
     },
@@ -1521,8 +1521,8 @@
     },
     {
         "id": "obsidian-dictionary-plugin",
-        "name": "Obsidian Dictionary",
-        "description": "This is a simple dictionary for the Obsidian Note-Taking Tool.",
+        "name": "Dictionary",
+        "description": "This is a multilingual Dictionary for the Obsidian Note-Taking Tool.",
         "author": "phibr0",
         "repo": "phibr0/obsidian-dictionary"
     },
@@ -1662,13 +1662,6 @@
         "description": "This is a plugin to create notes in chosen folder.",
         "author": "Ivan Chernov",
         "repo": "vanadium23/obsidian-advanced-new-file"
-    },
-    {
-        "id": "extended-context-menu",
-        "name": "Extended Context Menu",
-        "description": "This Plugin adds a API for other Plugins to create better Custom Context Menus in Obsidians Editor.",
-        "author": "phibr0",
-        "repo": "phibr0/obsidian-extended-context-menu"
     },
     {
         "id": "file-explorer-note-count",


### PR DESCRIPTION
- I removed mentions of my old discord name (rythm)
- I removed the extended-context-menu Plugin since its not needed anymore, for my knowledge no Plugin relies on it
- On Discord I was told that using "Obsidian" in a Plugin Name is more or less bad, since of course its for Obsidian and it messes with the sorting