### PR TITLE
Add Request

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1741,6 +1741,6 @@
         "name": "Request",
         "author": "Ulysses Popple",
         "description": "Makes fetch requests to configurable URLs",
-        "repo": "https://gitlab.com/ulysses.codes/obsidian-request-plugin"
+        "repo": "ulyssesdotcodes/obsidian-request-plugin"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1735,5 +1735,12 @@
         "author": "Greg Zuro",
         "description": "Render Kroki diagrams.",
         "repo": "gregzuro/obsidian-kroki"
+    },
+    {
+        "id": "obsidian-request",
+        "name": "Request",
+        "author": "Ulysses Popple",
+        "description": "Makes fetch requests to configurable URLs",
+        "repo": "https://gitlab.com/ulysses.codes/obsidian-request-plugin"
     }
 ]


### PR DESCRIPTION
A plugin that lets you perform fetch requests from obsidian. It appends the selected text to one of a list of configured urls and replaces the selected text with the response.

The full URL is included for the repo becuase it is hosted on gitlab. I made the personal decision to switch to gitlab after they non-consentually scraped public github repos for a machine learning tool (1). If it's an issue, I can create a github mirror, but considering Obsidian has a tech-savvy dev team and git itself is universal, maybe it should be possible to include other git hosts as well.

1. https://www.theverge.com/2021/7/7/22561180/github-copilot-legal-copyright-fair-use-public-code

<!--- Delete this section if submitting a theme -->
# [x] I am submitting a new Community Plugin

## Repo URL

https://gitlab.com/ulysses.codes/obsidian-request-plugin

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] Github release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] Github release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file
