### PR TITLE
Add Darkyan theme to community themes

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -461,5 +461,12 @@
         "screenshot": "Screenshot.png",
         "modes": ["dark", "light"],
         "branch": "main"
+    },
+    {
+        "name": "Darkyan",
+        "author": "johackim",
+        "repo": "johackim/darkyan",
+        "screenshot": "screenshot.png",
+        "modes": ["dark"]
     }
 ]


### PR DESCRIPTION
# [x] I am submitting a new Community Theme

## Repo URL

https://github.com/johackim/obsidian-darkyan

## Theme checklist

- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo)
  - [x] `obsidian.css`
  - [x] The screenshot file
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme
- [x] I have added a license in the LICENSE file
- [x] If my repo is not using the `master` branch (legacy), please indicate