### PR TITLE
add Open vault in VSCode

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1751,6 +1751,13 @@
         "repo": "NomarCub/obsidian-copy-url-in-preview"
     },
     {
+        "id": "open-vscode",
+        "name": "Open vault in VSCode",
+        "author": "NomarCub",
+        "description": "Ribbon button and command to open vault as a Visual Studio Code workspace",
+        "repo": "NomarCub/obsidian-open-vscode"
+    },
+    {
         "id": "initiative-tracker",
         "name": "Initiative Tracker",
         "author": "Jeremy Valentine",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1751,13 +1751,6 @@
         "repo": "NomarCub/obsidian-copy-url-in-preview"
     },
     {
-        "id": "open-vscode",
-        "name": "Open vault in VSCode",
-        "author": "NomarCub",
-        "description": "Ribbon button and command to open vault as a Visual Studio Code workspace",
-        "repo": "NomarCub/obsidian-open-vscode"
-    },
-    {
         "id": "initiative-tracker",
         "name": "Initiative Tracker",
         "author": "Jeremy Valentine",
@@ -1770,5 +1763,12 @@
         "author": "Sean Slater",
         "description": "This displays the location of the cursor (character and line number).",
         "repo": "spslater/obsidian-cursor-location-plugin"
+    },
+    {
+        "id": "open-vscode",
+        "name": "Open vault in VSCode",
+        "author": "NomarCub",
+        "description": "Ribbon button and command to open vault as a Visual Studio Code workspace",
+        "repo": "NomarCub/obsidian-open-vscode"
     }
 ]


### PR DESCRIPTION
# [x ] I am submitting a new Community Plugin

## Repo URL

https://github.com/NomarCub/obsidian-open-vscode

## Release Checklist

- [ ]  I have tested this on Windows, macOS, and Linux (if applicable) - only Windows was available to me to test on
- [x] Github release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] Github release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file
