### PR TITLE
Re-add obsidian-filename-heading-sync

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -695,6 +695,13 @@
         "repo": "Vinzent03/obsidian-shortcuts-for-starred-files"
     },
     {
+        "id": "obsidian-filename-heading-sync",
+        "name": "Filename Heading Sync",
+        "description": "Obsidian plugin for keeping the filename with the first heading of a file in sync",
+        "author": "dvcrn",
+        "repo": "dvcrn/obsidian-filename-heading-sync"
+    },
+    {
         "id": "obsidian-orthography",
         "name": "Obsidian Orthography",
         "author": "denisoed",


### PR DESCRIPTION
The plugin got disabled due to a reported data loss issue. The plugin got hardened and a few bugs fixed so I'd like to re-submit it - https://github.com/dvcrn/obsidian-filename-heading-sync/issues/18