### PR TITLE
add mx-bili-plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1806,5 +1806,13 @@
         "author": "kurakart",
         "description": "Garbling text in Obsidian turns all content in the entire app (notes, sidebar, etc) into lines so you can take screenshots without exposing sensitive data.",
         "repo": "kurakart/garble-text"
+    },
+    {
+        "id": "mx-bili-plugin",
+        "name": "Media Extended BiliBili Plugin",
+        "description": "Add advanced bilibili videos support for Media Extended plugin",
+        "author": "AidenLx",
+        "id": "mx-bili-plugin",
+        "repo": "aidenlx/mx-bili-plugin"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1810,9 +1810,8 @@
     {
         "id": "mx-bili-plugin",
         "name": "Media Extended BiliBili Plugin",
-        "description": "Add advanced bilibili videos support for Media Extended plugin",
         "author": "AidenLx",
-        "id": "mx-bili-plugin",
+        "description": "Add advanced bilibili videos support for Media Extended plugin",
         "repo": "aidenlx/mx-bili-plugin"
     }
 ]


### PR DESCRIPTION

## Repo URL

https://github.com/aidenlx/mx-bili-plugin

A plugin that opens a reverse proxy server for [Media Extended](https://github.com/aidenlx/media-extended) to play bilibili video in Obsidian

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on macOS
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - ~~`styles.css`~~
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
