### PR TITLE
Add Random To-Do Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1806,5 +1806,12 @@
         "author": "kurakart",
         "description": "Garbling text in Obsidian turns all content in the entire app (notes, sidebar, etc) into lines so you can take screenshots without exposing sensitive data.",
         "repo": "kurakart/garble-text"
+    },
+    {
+        "id": "obsidian-random-todo",
+        "name": "Random To-Do",
+        "author": "NatiAris",
+        "description": "Open a random file containing your custom to-do marker, or a random marker at its position.",
+        "repo": "NatiAris/obsidian-random-todo"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/NatiAris/obsidian-random-todo

## Release Checklist

- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
  - I don't have access to a Windows machine
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
