### PR TITLE
Add Deep Work Theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -508,5 +508,13 @@
         "screenshot": "screenshot.png",
         "modes": ["dark"],
         "branch": "main"
+    },
+    {
+        "name": "Deep Work",
+        "author": "nikbrunner",
+        "repo": "nikbrunner/obsidian-deep-work-theme",
+        "screenshot": "screenshot.png",
+        "modes": ["dark", "light"],
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Theme

## Repo URL
Link to my theme: [nikbrunner/obsidian-deep-work-theme](https://github.com/nikbrunner/obsidian-deep-work-theme)

## Theme checklist
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo)
  - [x] `obsidian.css`
  - [x] The screenshot file
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme
- [x] I have added a license in the LICENSE file
- [x] If my repo is not using the `master` branch, please indicate in `community-themes.json` with `"branch": "main"`.
- [x] Come up with a generic name which does not include "GitHub" directly
