### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -232,7 +232,7 @@
         "name": "Copy button for code blocks",
         "author": "Daniel Brandenburg",
         "description": "Copy button for code blocks",
-        "repo": "natpalmer-e4o4/obsidian-code-block-copy"
+        "repo": "jdbrice/obsidian-code-block-copy"
     },
     {
         "id": "searchpp",


### PR DESCRIPTION
Fix code-block-copy plugin repo reference from link found within current plugin manifest information.

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
