### PR TITLE
Added Link Archiver to the community plugins list

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1887,5 +1887,13 @@
         "description": "Prepare Daf Yomi notes",
         "repo": "lyonsquark/obsidian-daf-yomi",
         "branch": "main"
+    },
+    {
+        "id": "link-archiver",
+        "name": "Link Archiver",
+        "author": "Michael Pedersen",
+        "description": "This plugin scans the opened note for links and submits them all to the Internet Archive's Wayback Machine (https://web.archive.org/).",
+        "repo": "baocin/obsidian-link-archiver",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [https://github.com/baocin/obsidian-link-archiver](https://github.com/baocin/obsidian-link-archiver)

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [X] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] README clearly describes the plugins purpose and provides clear usage instructions.
- [X] I have added a license in the LICENSE file.
