### PR TITLE
Add Obsidian Dev Tools Plugin (view console on Mobile)

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1917,5 +1917,12 @@
         "author": "OwnJoke",
         "repo": "OwnJoke/obsidian-budget-wysiwyg",
         "branch": "main"
+    },
+    {
+    	"id": "obsidian-dev-tools",
+    	"name": "Obsidian Dev Tools Plugin",
+    	"description": "This plugin is initially used to view the console on mobile devices, though it may have other plugin tools added in the future.",
+    	"author": "Kjell Connelly",
+    	"repo": "KjellConnelly/obsidian-dev-tools"
     }
 ]


### PR DESCRIPTION
I am submitting a new plugin: `Obsidian Dev Tools Plugin` (currently only **1**: displays a console, **2**: log and eval to console, and **3** display available obsidian icons. Meant for plugin development, often filling the gap for mobile devices)

## Repo URL
https://github.com/KjellConnelly/obsidian-dev-tools

## Release Checklist
- [x] I have tested this on macOS and iOS
- [x] Github release contains all required files
    - [x] `main.js`
    - [x] `manifest.json`
    - [x] `styles.css` (optional)
- [x] Github release name matches the exact version number specified in my manifest.json (**Note**: Use the exact version number, don't include a prefix v)
- [x] The `id` in my `manifest.json` matches the id in the `community-plugins.json` file.
- [x] `README` clearly describes the plugin's purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file