### PR TITLE
Add alx-folder-note

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1917,5 +1917,12 @@
         "author": "OwnJoke",
         "repo": "OwnJoke/obsidian-budget-wysiwyg",
         "branch": "main"
+    },
+    {
+      "id": "alx-folder-note",
+      "name": "AidenLx's Folder Note",
+      "description": "Add description, summary and more info to folders with folder notes.",
+      "author": "AidenLx",
+      "repo": "aidenlx/alx-folder-note"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: <https://github.com/alx-plugins/alx-folder-note>

## Release Checklist

- [x] I have tested this on macOS
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css`
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
