### PR TITLE
Add number-headings-obsidian to community plugins list

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1997,5 +1997,12 @@
         "author": "phibr0",
         "description": "Group multiple Commands into one Macro and set delays.",
         "repo": "phibr0/obsidian-macros"
+    },
+    {
+        "id": "number-headings-obsidian",
+        "name": "Number Headings",
+        "description": "Automatically number or re-number headings in an Obsidian document.",
+        "author": "Kevin Albrecht",
+        "repo": "onlyafly/number-headings-obsidian"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/onlyafly/number-headings-obsidian

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
