### PR TITLE
Added Obsidian Dotenv to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1997,5 +1997,12 @@
         "author": "phibr0",
         "description": "Group multiple Commands into one Macro and set delays.",
         "repo": "phibr0/obsidian-macros"
+    },
+    {
+        "id": "obsidian-dotenv",
+        "name": "Dotenv",
+        "author": "metruzanca",
+        "description": "Easily manage custom variables accessible by other plugins e.g. templater (and it's templates)",
+        "repo": "metruzanca/obsidian-dotenv"
     }
 ]


### PR DESCRIPTION
I am submitting a new plugin: `Obsidian Dotenv` which allows setting custom variables on `app.env` (via plugin settings) to facilitate configuring global constants usable by other plugins e.g. templater or dataview. This should also facilitate distributing templates and vaults with custom & easily editable configurations. 

## Repo URL

Link to my plugin: https://github.com/metruzanca/obsidian-dotenv

## Release Checklist

(Don't own a mac :/ should all work as the plugin is just javascript.)

- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.

---

This is my working MVP version. Tomorrow/this weekend I'll be fleshing out this plugin further and hopefully presenting it to the rest of the community 