### PR TITLE
Add Tag Page Preview plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1997,5 +1997,12 @@
         "author": "phibr0",
         "description": "Group multiple Commands into one Macro and set delays.",
         "repo": "phibr0/obsidian-macros"
+    },
+    {
+        "id": "tag-page-preview",
+        "name": "Tag Page Preview",
+        "author": "aidurber",
+        "description": "Clicking a tag opens a dialog listing pages that use that tag",
+        "repo": "aidurber/tag-page-preview"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Aidurber/tag-page-preview

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [X] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] README clearly describes the plugins purpose and provides clear usage instructions.
- [X] I have added a license in the LICENSE file.
