### PR TITLE
Add WeeklyNote to community plugin list

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1997,5 +1997,12 @@
         "author": "phibr0",
         "description": "Group multiple Commands into one Macro and set delays.",
         "repo": "phibr0/obsidian-macros"
+    },
+    {
+        "id": "weekly-note",
+        "name": "WeeklyNote",
+        "author": "maloneya",
+        "description": "This plugin generates a templated weekly note, with shared todos.",
+        "repo": "maloneya/ObsidianWeekly"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->

Link to my plugin: https://github.com/maloneya/ObsidianWeekly

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [ ] I have tested this on Windows, macOS, and Linux _(if applicable)_
  - [x] macOS
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
