### PR TITLE
add obsidian-image-toolkit plugin.

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1997,5 +1997,12 @@
         "author": "phibr0",
         "description": "Group multiple Commands into one Macro and set delays.",
         "repo": "phibr0/obsidian-macros"
+    },
+    {
+        "id": "obsidian-image-toolkit",
+        "name": "Obsidian Image Toolkit",
+        "author": "sissilab",
+        "description": "When you click an image, it will be displayed in a popup layer and you can view, drag, zoom, rotate the image.",
+        "repo": "sissilab/obsidian-image-toolkit"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [ ] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [ ] My GitHub release contains all required files
  - [ ] `main.js`
  - [ ] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ ] README clearly describes the plugins purpose and provides clear usage instructions.
- [ ] I have added a license in the LICENSE file.
