### PR TITLE
Add obsidian-command-alias-plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2018,5 +2018,12 @@
         "description": "Automatically number or re-number headings in an Obsidian document.",
         "author": "Kevin Albrecht",
         "repo": "onlyafly/number-headings-obsidian"
+    },
+    {
+        "id": "obsidian-commard-alias-plugin",
+        "name": "Command Alias",
+        "description": "This plugin gives aliases to Obsidian commands.",
+        "author": "@Yajamon",
+        "repo": "yajamon/obsidian-command-alias-plugin"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/yajamon/obsidian-command-alias-plugin

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows and macOS
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
