### PR TITLE
Add Obsidian Trello plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2185,5 +2185,13 @@
         "description": "Switch input method with fcitx-remote when Vim keymap is enabled.",
         "author": "yuanotes",
         "repo": "yuanotes/obsidian-vim-im-switch-plugin"
+    },
+    {
+        "id": "obsidian-trello",
+        "name": "Obsidian Trello",
+        "description": "Connect Trello cards to Obsidian notes.",
+        "author": "OfficerHalf",
+        "repo": "OfficerHalf/obsidian-trello",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->
# I am submitting a new Community Plugin

This is a plugin to connect Trello cards to Obsidian notes. It uses the trello rest API along with a new view in Obsidian to retrieve data, display comments, add new comments. Plenty of future work ahead to expand what it can do.

Code review notes:

- It's a fairly large one. I used [rxjs](https://www.learnrxjs.io/) all over the place in it, but that's the only 3rd party library involved.
- Has a dependency on the [MetaEdit](https://github.com/chhoumann/MetaEdit) plugin, but it should fail gracefully.
- Uses rxjs ajax to make requests to the Trello API. Internally this uses standard XMLHttpRequest stuff, it just gets wrapped in some rxjs magic.
- Yes, there's an API key committed in the code. This is intentional - not sure why Trello calls it that, it's really an application ID.
- Things are fairly broken up and documented, styles should be isolated. I used built in colors/styling where possible.
- Trello has pretty strict rate limits not just for each token but also each app. I'll need to adjust these if people start seeing errors. I can investigate creating multiple apps if need be. Currently responses are cached per session with a timeout, but not stored if Obsidian is closed.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/OfficerHalf/obsidian-trello/

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
  - Works on mobile too, with a couple small styling issues. But it doesn't make much sense as a mobile plugin IMO anyway, so it's not a top priority.
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
