### PR TITLE
Add Hover External Link plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2018,5 +2018,12 @@
         "description": "Automatically number or re-number headings in an Obsidian document.",
         "author": "Kevin Albrecht",
         "repo": "onlyafly/number-headings-obsidian"
+    },
+    {
+        "id": "hover-external-link",
+        "name": "Hover External Link",
+        "description": "Hover on external links to see the destination URL.",
+        "author": "Jamie Brynes",
+        "repo": "jamiebrynes7/obsidian-hover-external-link"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

This plugin adds tooltips on hover for external links. These tooltips display the destination URL.

## Repo URL

Link to my plugin: https://github.com/jamiebrynes7/obsidian-hover-external-link

## Release Checklist

- [x] I have tested this on Windows
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
