### PR TITLE
Add Code Block Enhancer Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2054,5 +2054,12 @@
         "description": "This Plugin enables the use of Markdown Emoji Shortcodes :smile:, just like in Slack or Discord",
         "author": "phibr0",
         "repo": "phibr0/obsidian-emoji-shortcodes"
+    },
+    {
+        "id": "obsidian-code-block-enhancer",
+        "name": "Code Block Enhancer",
+        "description": "Enhance obsidian markdown code block,provides copy button,linenumber,language name tip and so on.",
+        "author": "hafuhafu",
+        "repo": "nyable/obsidian-code-block-enhancer"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin
This plugin provides copy button,linenumber,language name for the markdown code block in preview.
## Repo URL
Link to my plugin: [https://github.com/nyable/obsidian-code-block-enhancer](https://github.com/nyable/obsidian-code-block-enhancer)

## Release Checklist
 

- [x] I have tested this on Windows
- [x]  My GitHub release contains all required files
  - [x]  main.js
  - [x] manifest.json
  - [x] styles.css (optional)
- [x] GitHub release name matches the exact version number specified in my manifest.json (Note: Use the exact version number, don't include a prefix v)
- [x] The id in my manifest.json matches the id in the community-plugins.json file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.