### PR TITLE
Add Banners plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2068,5 +2068,12 @@
         "author": "phibr0",
         "description": "This Plugin provides a go to Line Command",
         "repo": "phibr0/obsidian-go-to-line"
+    },
+    {
+        "id": "obsidian-banners",
+        "name": "Banners",
+        "author": "Danny Hernandez",
+        "description": "Add banner images to your notes!",
+        "repo": "noatpad/obsidian-banners"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin
This plugin adds the ability to add banners to your notes, through either an image URL or a local image file.

## Repo URL
Link to my plugin: https://github.com/noatpad/obsidian-banners

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
