### PR TITLE
Add zk-new-pane (Open Zettelkasten in New Pane)

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2132,5 +2132,12 @@
         "description": "When you click an image, it will be displayed in a popup layer and you can view, drag, zoom, rotate the image.",
         "author": "sissilab",
         "repo": "sissilab/obsidian-image-toolkit"
+    },
+    {
+        "id": "zk-new-pane",
+        "name": "Open Zettelkasten in New Pane",
+        "description": "Adds a command to open a new Zettel in a new pane (or Ctrl/Cmd-click the ribbon button)",
+        "author": "pjeby",
+        "repo": "pjeby/zk-new-pane"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin
...but this is such a trivial feature that you might want to just add the same functionality to the core plugin for a future release, and it might actually be less work than reviewing this plugin.  :wink:

(Especially since it can just be done by adding a new-pane flag to `onCreateNote()` and passing it through to `getLeaf()`, then adding a second command with an extra bind parameter of true, and making the button handler set the flag based on `Keymap.isModifier(event, "Mod")`.)

So yeah, if you want to implement the functionality in the next insider release, feel free to just close this PR.

## Repo URL
Link to my plugin: [zk-new-pane](/pjeby/zk-new-pane)

## Release Checklist
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.

