### PR TITLE
Fix plugin mismatch

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1815,7 +1815,7 @@
         "repo": "publicus/obsidian-paste-to-current-indentation"
     },
     {
-        "id": "obsimian",
+        "id": "obsimian-exporter",
         "name": "Obsimian",
         "author": "Oliver Lade",
         "description": "Obsidian simulation framework for testing Obsidian plugins.",


### PR DESCRIPTION
I updated the source plugin ID per feedback in https://github.com/motif-software/obsimian/pull/3, but did not also update the ID here to match. This PR makes them consistent.