### PR TITLE
Add obsidian-file-link plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2132,5 +2132,12 @@
         "description": "When you click an image, it will be displayed in a popup layer and you can view, drag, zoom, rotate the image.",
         "author": "sissilab",
         "repo": "sissilab/obsidian-image-toolkit"
+    },
+    {
+        "id": "obsidian-file-link",
+        "name": "Obsidian File Link",
+        "description": "This plugin lets you create simple file links in your notes.",
+        "author": "Marc Julian Schwarz",
+        "repo": "marcjulianschwarz/obsidian-file-link"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/marcjulianschwarz/obsidian-file-link

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
