### PR TITLE
Add Quick Explorer plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2147,5 +2147,12 @@
         "description": "Hover on external links to see the destination URL.",
         "author": "Jamie Brynes",
         "repo": "jamiebrynes7/obsidian-hover-external-link"
+    },
+    {
+        "id": "quick-explorer",
+        "name": "Quick Explorer",
+        "description": "Perform file explorer operations (and see your current file path) from the title bar, using the mouse or keyboard",
+        "author": "PJ Eby",
+        "repo": "pjeby/quick-explorer"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/pjeby/quick-explorer/

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [ x My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
