### PR TITLE
Add folder-note-core

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2155,5 +2155,12 @@
         "description": "Configure various CodeMirror options such as text selection behavior and syntax highlighting",
         "repo": "nothingislost/obsidian-codemirror-options",
         "branch": "main"
+    },
+    {
+        "id": "folder-note-core",
+        "name": "Folder Note Core",
+        "description": "Provide core features and API for folder notes",
+        "author": "AidenLx",
+        "repo": "aidenlx/folder-note-core"
     }
 ]


### PR DESCRIPTION

# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/aidenlx/folder-note-core

The core of [alx-folder-note v0.11.0+](https://github.com/aidenlx/alx-folder-note/tree/core), derived from [alx-folder-note](https://github.com/aidenlx/alx-folder-note/), providing API and basic folder note features without ux patches and folder overview

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
