### PR TITLE
adding Obsidian HackerNews

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2185,5 +2185,13 @@
         "description": "Switch input method with fcitx-remote when Vim keymap is enabled.",
         "author": "yuanotes",
         "repo": "yuanotes/obsidian-vim-im-switch-plugin"
+    },
+    {
+        "id": "obsidian-hackernews",
+        "name": "HackerNews",
+        "author": "arpitbbhayani",
+        "description": "Periodically fetches and displays top stories from HackerNews.",
+        "repo": "arpitbbhayani/obsidian-hackernews",
+        "branch": "master"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2187,14 +2187,6 @@
         "repo": "yuanotes/obsidian-vim-im-switch-plugin"
     },
     {
-        "id": "obsidian-hackernews",
-        "name": "HackerNews",
-        "author": "arpitbbhayani",
-        "description": "Periodically fetches and displays top stories from HackerNews.",
-        "repo": "arpitbbhayani/obsidian-hackernews",
-        "branch": "master"
-    },
-    {
         "id": "luhman",
         "name": "Luhman",
         "author": "Dylan Elliott",
@@ -2250,5 +2242,12 @@
         "description": "Perform file explorer operations (and see your current file path) from the title bar, using the mouse or keyboard",
         "author": "PJ Eby",
         "repo": "pjeby/quick-explorer"
+    },
+    {
+        "id": "obsidian-hackernews",
+        "name": "HackerNews",
+        "author": "arpitbbhayani",
+        "description": "Periodically fetches and displays top stories from HackerNews.",
+        "repo": "arpitbbhayani/obsidian-hackernews"
     }
 ]


### PR DESCRIPTION
Periodically fetches and displays top stories from HackerNews.

<!--- Delete this section if submitting a theme -->
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/arpitbbhayani/obsidian-hackernews

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
