### PR TITLE
update copy-url-in-preview

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1745,9 +1745,9 @@
     },
     {
         "id": "copy-url-in-preview",
-        "name": "Copy URL in preview",
+        "name": "Copy Image and URL in Preview",
         "author": "NomarCub",
-        "description": "Copy URL context menu in preview mode",
+        "description": "Copy Image and Copy URL context menu in preview mode",
         "repo": "NomarCub/obsidian-copy-url-in-preview"
     },
     {


### PR DESCRIPTION
Update copy-url-in-preview name and description with features in [new release](https://github.com/NomarCub/obsidian-copy-url-in-preview/releases/tag/1.1.0).

---

I clicked on `[Community Plugin](?template=plugin.md)` ([Community Plugin](?template=plugin.md)) in preview but don't know what happened.
