### PR TITLE
Shortening obsidian-pocket name

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1920,9 +1920,9 @@
     },
     {
         "id": "obsidian-pocket",
-        "name": "Pocket reading list integration",
+        "name": "Pocket integration",
         "author": "Nimalan Mahendran",
-        "description": "Access your Pocket list entries and create notes for them easily",
+        "description": "Access your Pocket reading list entries and create notes for them easily",
         "repo": "nybbles/obsidian-pocket"
     },
     {


### PR DESCRIPTION
I would like to change the human-readable name of the `obsidian-pocket` plugin, based on user feedback from https://github.com/nybbles/obsidian-pocket/issues/49.
