### PR TITLE
remove warmth theme from community themes

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -35,13 +35,6 @@
         "modes": ["dark"]
     },
     {
-        "name": "Warmth",
-        "author": "chad-bennett",
-        "repo": "chad-bennett/warmth-obsidian-theme",
-        "screenshot": "warmth.jpg",
-        "modes": ["light"]
-    },
-    {
         "name": "Gastown",
         "author": "lizardmenfromspace",
         "repo": "dogwaddle/obsidian-gastown-theme.md",


### PR DESCRIPTION
removing warmth theme from community themes because it needs far more work than i have time for these days.


## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my theme: https://github.com/chad-bennett/warmth-obsidian-theme