### PR TITLE
Add Nomnoml Diagram plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2412,5 +2412,13 @@
         "author": "TfTHacker",
         "repo": "TfTHacker/obsidian42-text-transporter",
         "branch": "main"
+    },
+    {
+        "id": "obsidian-nomnoml-diagram",
+        "name": "Nomnoml Diagram",
+        "description": "Draw nomnoml diagrams in Obsidian notes",
+        "author": "Daeik Kim",
+        "repo": "Daeik/obsidian-nomnoml-diagram",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Daeik/obsidian-nomnoml-diagram

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, ~~macOS~~, and ~~Linux~~ _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
