### PR TITLE
Added Snippet Commands plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2516,5 +2516,13 @@
         "author": "Robin Haupt",
         "repo": "Robin-Haupt-1/Obsidian-Map-of-Content",
         "branch": "main"
+    },
+    {
+        "id": "snippet-commands-obsidian",
+        "name": "Snippet Commands",
+        "author": "death_au",
+        "description": "Registers custom css snippets as commands (which you can bind hotkeys to)",
+        "repo": "deathau/snippet-commands-obsidian",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
Adds all your CSS snippets as commands, accessible from the command palette and even assignable to hotkeys!