### PR TITLE
remove linked data vocabularies

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2503,13 +2503,6 @@
         "branch": "main"
     },
     {
-        "id": "linked-data-vocabularies",
-        "name": "Linked Data Vocabularies (SKOS)",
-        "description": "Use structured linked data as metadata in your notes.",
-        "author": "kometenstaub",
-        "repo": "kometenstaub/obsidian-linked-data-vocabularies"
-    },
-    {
         "id": "map-of-content",
         "name": "Map of Content",
         "description": "Automatically generate a Map of Content for your vault",


### PR DESCRIPTION
I have noticed today that one website the plugin makes requests to has a per minute request limit. 

With default settings and normal usage it shouldn't cause problems. However, I have decided to change the implementation, because restricting it effectively so that users cannot go over that limit would limit the plugins' user experience.

I currently don't have the time to make these changes, which is why I'm pulling the plugin for now.
