### PR TITLE
Add Limelight to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2516,5 +2516,12 @@
         "description": "Local Images plugin finds all links to external images in your notes, then downloads and saves images locally, and finally adjusts the image links in your notes to point to the saved image files.",
         "author": "catalysm, aleksey-rezvov",
         "repo": "aleksey-rezvov/obsidian-local-images"
+    },
+    {
+        "id": "obsidian-limelight",
+        "name": "Limelight",
+        "description": "Spotlight your active pane",
+        "author": "Scott Mikula",
+        "repo": "smikula/obsidian-limelight"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/smikula/obsidian-limelight

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.
