### PR TITLE
Fix: Add modes to Creature theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -625,6 +625,7 @@
         "author": "Marcus Olsson",
         "repo": "marcusolsson/obsidian-creature-theme",
         "screenshot": "screenshot.png",
+        "modes": ["dark"],
         "branch": "main"
     }
 ]


### PR DESCRIPTION
Forgot to add `modes`. It only supports dark.