### PR TITLE
Add Plugin Link Master

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2569,5 +2569,13 @@
         "author": "Dmitriy Shulha",
         "description": "With this plugin you can embed Plotly charts in your notes.",
         "repo": "Dmitriy-Shulha/obsidian-plotly"
-    }
+    },
+    {
+        "id": "obsidian-Link-Master",
+        "name": "Link Master",
+        "author": "fukun",
+        "description": "Link Master helps you find potential links.",
+        "repo": "fukunee/obsidian-link-master"
+    },
+        
 ]


### PR DESCRIPTION

# I am submitting a new Community Plugin
![image](https://user-images.githubusercontent.com/21358831/137640789-ebdcbd54-8468-48af-a3d4-0ab12e4dbc31.png)

Link Master search global file cached contents. Then list the unlinked files logically-related to **active file's filename** sorted by the possibilities to link them up; 
When the possibility is really high. **Add link Feature** will show a button that helps you replace the keywords to links automatically;


## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/fukunee/obsidian-link-master

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.