### PR TITLE
Add BetterLatexForObsidian plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2613,5 +2613,12 @@
         "description": "Sync your Hypothesis highlights",
         "author": "weichenw",
         "repo": "weichenw/obsidian-hypothesis-plugin"
+    },
+    {
+	"id": "better-latex-for-obsidian",
+	"name": "Better Latex For Obsidian",
+	"description": "This plugin offers LaTex autocomplete functionality",
+	"author": "GreasyCat",
+    "repo": "https://github.com/echaos/BetterLatexForObsidian"
     }
 ]


### PR DESCRIPTION
Repo URL:https://github.com/echaos/BetterLatexForObsidian

---

- [x]  I have tested this on Windows
- [x]  My GitHub release contains all required files
  - [x]  main.js
  - [x] manifest.json
  - [x] styles.css (optional)
- [x]  GitHub release name matches the exact version number specified in my manifest.json (Note: Use the exact version number, don't include a prefix v)
- [x] The id in my manifest.json matches the id in the community-plugins.json file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x]  I have added a license in the LICENSE file.