### PR TITLE
[Fixed] Add Obsidian-Flashread Speed Reading Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2614,4 +2614,10 @@
         "author": "weichenw",
         "repo": "weichenw/obsidian-hypothesis-plugin"
     }
+    {
+        "id": "obsidian-flashread",
+        "name": "Obsidian Flashread Speed Reading",
+        "author": "AlexAndHisScripts",
+        "AlexAndHisScripts/obsidian-flashread"
+    }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2618,6 +2618,6 @@
         "id": "obsidian-flashread",
         "name": "Obsidian Flashread Speed Reading",
         "author": "AlexAndHisScripts",
-        "AlexAndHisScripts/obsidian-flashread"
+        "repo": "AlexAndHisScripts/obsidian-flashread"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->
# I am submitting a new Community Plugin

This PR has fixed the issue where I didn't put the ``repo`` key in. See #556 

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:
https://github.com/AlexAndHisScripts/obsidian-flashread

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [x] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] README clearly describes the plugins purpose and provides clear usage instructions.
- [x] I have added a license in the LICENSE file.