### PR TITLE
Update Plugin Description of Obsidian Charts

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -540,7 +540,7 @@
         "id": "obsidian-charts",
         "name": "Obsidian Charts",
         "author": "phibr0",
-        "description": "This Plugin lets you create Charts with Chartist as its backend!",
+        "description": "This Plugin lets you easily create Charts within Obsidian!",
         "repo": "phibr0/obsidian-charts"
     },
     {


### PR DESCRIPTION
The Plugin is using Chart.js instead of chartist now (well, like for the last 6 months)