### PR TITLE
added Note Timer plugin to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2679,5 +2679,13 @@
         "description": "Inserts random quotes in the editor",
         "author": "Florin Bobis",
         "repo": "twentytwokhz/quote-of-the-day"
+    },
+    {
+        "id": "obsidian-note-timer",
+        "name": "Note Timer",
+        "author": "davidvdev",
+        "description": "Use codeblocks to add a timer and optional log to your notes.",
+        "repo": "davidvdev/obsidian-note-timer",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a theme -->
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: davidvdev/obsidian-note-timer

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [ x ] I have tested this on Windows, macOS, and Linux _(if applicable)_
- [ x ] My GitHub release contains all required files
  - [ x ] `main.js`
  - [ x ] `manifest.json`
  - [ x ] `styles.css` _(optional)_
- [ x ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ x ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ x ] README clearly describes the plugins purpose and provides clear usage instructions.
- [ x ] I have added a license in the LICENSE file.
