### PR TITLE
Add Extended Multi Cursor plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2731,5 +2731,13 @@
         "description": "Use multiple cursors even more powerfully.",
         "author": "SkepticMystic",
         "repo": "SkepticMystic/advanced-cursors"
+    },
+    {
+        "id": "obsidian-multi-cursor",
+        "name": "Extended Multi Cursor",
+        "description": "This plugin enhances the default multi-cursor implementation with Sublime Text style keybindings. It also allows you to click on an existing selection to de-select it.",
+        "author": "Oliver Fawcett",
+        "repo": "ollyfg/obsidian-multi-cursor",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
Simpler than `advanced-cursors`, this plugin brings some sublime text keybindings and allows click-to-deselect on existing selections.

Related: https://forum.obsidian.md/t/ability-to-multi-cursor-select-with-keyboard/7665/11

Sorry I can't test on platforms other than MacOS I'm stuck at home due to covid. Isn't the point of Electron + JS to be platform agnostic unless you get into some really advanced stuff? Happy to wait until I've tested on all platforms though, but it'll be a few months.

# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/ollyfg/obsidian-multi-cursor

## Release Checklist

<!--- Confirm that you have done the following before submitting your plugin -->
- [ ] I have tested this on Windows, macOS, and Linux _(if applicable)_ (Nope! Only have macOS available...)
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [x] `styles.css` _(optional)_ (N/A)
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] README clearly describes the plugins purpose and provides clear usage instructions.
- [X] I have added a license in the LICENSE file.
