### PR TITLE
Add Typomagical to community themes

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -766,6 +766,14 @@
         "branch": "main"
     },
     {
+        "name": "Typomagical",
+        "author": "Hung-Su Nguyen",
+        "repo": "hungsu/typomagical-obsidian",
+        "screenshot": "Typomagical-split.jpg",
+        "compatibleModes": ["light","dark"],
+        "branch": "main"
+    },
+    {
         "name": "Wyrd",
         "author": "Curio Heart",
         "repo": "curio-heart/obsidian-wyrd",


### PR DESCRIPTION
# I am submitting a new Community Theme

## Repo URL

Link to my theme: https://github.com/hungsu/typomagical-obsidian


## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo)
  - [x] `obsidian.css`
  - [x] The screenshot file
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme
- [x] I have added a license in the LICENSE file
- [x] If my repo is not using the `master` branch, please indicate in `community-themes.json` with `"branch": "main"`.
