### PR TITLE
Add obsidian-downfile

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,4 +1,12 @@
-[{
+[       
+    {
+        "id": "obsidian-downfile",
+        "name": "资源库",
+        "author": "whghcyx",
+        "description": "down plugin,theme,css in china",
+        "repo": "WHG555/obsidian-downfile"
+    },
+        {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
         "author": "Argentina Ortega Sainz",


### PR DESCRIPTION
Repo URL
Link to my plugin: https://github.com/WHG555/obsidian-downfile

Release Checklist
 I have tested this on Window
 My GitHub release contains all required files
 main.js
 manifest.json
 styles.css
 GitHub release name matches the exact version number specified in my manifest.json (Note: Use the exact version number, don't include a prefix v)
 The id in my manifest.json matches the id in the community-plugins.json file.
 README clearly describes the plugins purpose and provides clear usage instructions.
 I have added a license in the LICENSE file.

这个插件是给在中国的ob使用人员来使用，方便我们下载插件、主题。同时添加了一个CSS样式的库，可以更方便的分享，下载CSS样式。
