### PR TITLE
Name changed, and add description.

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2556,9 +2556,9 @@
     },
     {
         "id": "obsidian-livesync",
-        "name": "Obsidian Live sync",
+        "name": "Self-hosted LiveSync",
         "author": "vorotamoroz",
-        "description": "Reflect your vault changes to some other devices immediately. Please make sure to disable other synchronize solutions to avoid content corruption or duplication.",
+        "description": "Community implementation of self-hosted livesync. Reflect your vault changes to some other devices immediately. Please make sure to disable other synchronize solutions to avoid content corruption or duplication.",
         "repo": "vrtmrz/obsidian-livesync",
         "branch": "main"
     },


### PR DESCRIPTION
Changed from "obsidian-livesync" to "Self-hosted LiveSync"
And add the note "Community implementation" to description.