### PR TITLE
remove obsidian-todo-txt from community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1110,13 +1110,6 @@
         "branch": "main"
     },
     {
-        "id": "todo-txt",
-        "name": "Todo.txt support",
-        "description": "Native support for todo.txt files",
-        "author": "Stephen Solka",
-        "repo": "trashhalo/obsidian-todo-txt"
-    },
-    {
         "id": "obsidian-admonition",
         "name": "Admonition",
         "description": "Admonition block-styled content for Obsidian.md",


### PR DESCRIPTION
There isn't a good way in the obsidian api right now to implement a new text format that has similar behavior to MarkdownSourceView respecting the various editor settings. Lots of custom logic for token parsing is baked into hypermd codemirror mode. example [[foo]] printing to be clickable internal link. As an implementation I originally extended from that view and modify the parts I needed for todo-txt but its constantly breaking as changes go out.

I give up.
![](https://media.giphy.com/media/3o7bucatGMMLf8WBVe/giphy.gif)