### PR TITLE
Fix mode named compatibleModes which prevents parsing themes list

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -770,7 +770,7 @@
         "author": "Hung-Su Nguyen",
         "repo": "hungsu/typomagical-obsidian",
         "screenshot": "Typomagical-split.jpg",
-        "compatibleModes": ["light","dark"],
+        "modes": ["light","dark"],
         "branch": "main"
     },
     {

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -770,7 +770,7 @@
         "author": "Hung-Su Nguyen",
         "repo": "hungsu/typomagical-obsidian",
         "screenshot": "Typomagical-split.jpg",
-        "modes": ["light","dark"],
+        "modes": ["light", "dark"],
         "branch": "main"
     },
     {


### PR DESCRIPTION
<!--- Delete this section if submitting a plugin -->
# I am submitting a correction to an existing Community Theme

## Repo URL

Not applicable

## Fix

A recently-added theme currently has its mode list called `compatibleModes` - I've fixed it to `modes`, for consistency with the rest of the file...

Found by running a Python script to parse the themes, which tripped up saying no "modes" value was available.