### PR TITLE
Update Code Editor Shortcuts description

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2438,7 +2438,7 @@
         "id": "obsidian-editor-shortcuts",
         "name": "Code Editor Shortcuts",
         "author": "Tim Hor",
-        "description": "Add keyboard shortcuts (hotkeys) commonly found in code editors such as Visual Studio Code or Sublime Text",
+        "description": "Add keyboard shortcuts (hotkeys) commonly found in code editors such as Visual Studio Code (vscode) or Sublime Text",
         "repo": "timhor/obsidian-editor-shortcuts"
     },
     {


### PR DESCRIPTION
Adds the 'vscode' keyword to the description of Code Editor Shortcuts to improve discoverability, as suggested in https://github.com/timhor/obsidian-editor-shortcuts/issues/4