### PR TITLE
Add Typewriter to community themes

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -779,5 +779,13 @@
         "repo": "curio-heart/obsidian-wyrd",
         "screenshot": "img/Wyrd.png",
         "modes": ["dark", "light"]
+    },
+    {
+        "name": "Typewriter",
+        "author": "crashmoney",
+        "repo": "crashmoney/obsidian-typewriter",
+        "screenshot": "cover.jpg",
+        "modes": ["dark", "light"],
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Theme

## Repo URL

Link to my theme: https://github.com/crashmoney/obsidian-typewriter

## Theme checklist

- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo)
  - [x] `obsidian.css`
  - [x] The screenshot file
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme
- [x] I have added a license in the LICENSE file
- [x] If my repo is not using the `master` branch, please indicate in `community-themes.json` with `"branch": "main"`.
