### PR TITLE
Page Count Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2900,4 +2900,13 @@
         "author": "Nico Jeske",
         "repo": "nicojeske/mousewheel-image-zoom"
     }
+ 
+     {
+        "id": "obsidian-Page-Count",
+        "name": "Page Count",
+        "description": "Adds the current note's page count (with one decimal place) to Obsidian's status bar.",
+        "author": "Ash Cull",
+        "repo": "ReaderGuy42/Obsidian-Page-Count"
+    }
+ 
 ]


### PR DESCRIPTION
Shows page count to one decimal place in status bar.
https://github.com/ReaderGuy42/Obsidian-Page-Count

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/ReaderGuy42/Obsidian-Page-Count

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
