### PR TITLE
Added the obsidian-success-plan plugin (REDO)

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2928,5 +2928,13 @@
         "description": "Structured plugin. Create hierarchy in notes using \".\"",
         "author": "dobrovolsky",
         "repo": "dobrovolsky/obsidain-structure"
+    },
+    {
+      "id": "obsidian-success-plan",
+      "name": "Success Plan",
+      "author": "Joshwin Greene",
+      "description": "Manage your tasks, projects, key results, and goals within Obsidian. This plugin follows #theGamificationProject's Success Plan Framework.",
+      "repo": "thex3family/obsidian-success-plan",
+      "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/thex3family/obsidian-success-plan

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
