### PR TITLE
Add Generic Initiative Tracker for TTRPGs to the Plugin List

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2928,5 +2928,13 @@
         "description": "Structured plugin. Create hierarchy in notes using \".\"",
         "author": "dobrovolsky",
         "repo": "dobrovolsky/obsidain-structure"
+    },
+    {
+      "id": "generic-initiative-tracker",
+      "name": "Generic Initiative Tracker",
+      "description": "TTRPG Generic Initiative Tracker",
+      "author": "Beau Shinkle",
+      "repo": "beaushinkle/obsidian-generic-initiative-tracker",
+      "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/beaushinkle/obsidian-generic-initiative-tracker

## Release Checklist
- [ ] I have tested the plugin on
  - [X]  Windows
  - [X]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
