### PR TITLE
Add Matter to community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3030,5 +3030,12 @@
         "description": "See the favicon for a linked website.",
         "author": "Johannes Theiner",
         "repo": "joethei/obsidian-link-favicon"
+    },
+    {
+        "id": "matter",
+        "name": "Matter",
+        "author": "Matter",
+        "description": "Official Matter Obsidian integration.",
+        "repo": "getmatterapp/obsidian-matter"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

Hi all! I'm with the [Matter](https://hq.getmatter.app) team. We've received dozens of requests for an Obsidian integration. We can't wait to get this to all of our users. Let me know if there is anything else you need from us.

## Repo URL
Link to my plugin: [obsidian-matter](https://github.com/getmatterapp/obsidian-matter)

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
