### PR TITLE
add local plantuml provider

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3060,5 +3060,12 @@
         "author": "kometenstaub",
         "repo": "kometenstaub/obsidian-linked-data-vocabularies",
         "branch": "main"
+    },
+     {
+        "id": "local-plantuml",
+        "name": "Local PlantUML Provider",
+        "description": "Render your PlantUML diagrams locally. ",
+        "author": "Johannes Theiner",
+        "repo": "joethei/obsidian-local-plantuml"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/joethei/obsidian-local-plantuml

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
