### PR TITLE
added note-encryption-plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3082,5 +3082,13 @@
         "description": "Insert emoji and custom icons with shortcodes",
         "author": "AidenLx",
         "repo": "aidenlx/obsidian-icon-shortcodes"
+    },
+    {
+        "id": "note-encryption-plugin"
+        "name": "Note Encryption",
+        "author": "Likely Lee",
+        "description": "Encrypt / decrypt the active note with your password.",
+        "repo": "LikelyLee/NoteEncryption",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
added the note-encryption-plugin to community-plugins.json

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/LikelyLee/NoteEncryption

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
