### PR TITLE
Added obsidian-timestamper Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3098,5 +3098,12 @@
         "description": "Create markdown-based presentations in Obsidian",
         "repo": "MSzturc/obsidian-advanced-slides",
         "branch": "main" 
+    },
+    {
+        "id": "obsidian-timestamper",
+        "name": "TimeStamper",
+        "description": "Insert a customized or predefined time- or date-stamp at the current cursor position.",
+        "author": "Martin Eder",
+        "repo": "Gru80/obsidian-timestamper"
     }
 ]


### PR DESCRIPTION
Added obsidian-timestamper plugin, a plugin to insert customized or predefined time- and date-stamps at the current cursor position

# I am submitting a new Community Plugin

## Repo URL

Link to my plugin:
https://github.com/Gru80/obsidian-timestamper

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android
  - [x]  iOS 
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
