### PR TITLE
Add indentation guides plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3106,5 +3106,13 @@
         "author": "Feng Peng",
         "repo": "QAMichaelPeng/obsidian-graphviz",
         "branch": "main"
+    },
+    {
+        "id": "obsidian-indentation-guides",
+        "name": "Indentation Guides",
+        "author": "mgmeyers",
+        "description": "Adds vertical lines to the editor denoting indentation level of lists and other content.",
+        "repo": "mgmeyers/obsidian-indentation-guides",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

https://github.com/mgmeyers/obsidian-indentation-guides

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
