### PR TITLE
Add Import Foundry and Import JSON plug-ins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3106,5 +3106,19 @@
         "author": "Feng Peng",
         "repo": "QAMichaelPeng/obsidian-graphviz",
         "branch": "main"
+    },
+    {
+        "id": "obsidian-import-json"
+        "name": "JSON Importer",
+        "author": "farling42",
+        "description": "Import a JSON file containing an array of data, creating notes from a Handlebars template file",
+        "repo": "farling42/obsidian-import-json"
+    },
+    {
+        "id": "import-foundry"
+        "name": "Foundry world Importer",
+        "author": "farling42",
+        "description": "Imports your journal entries from your selected Foundry VTT world into a folder within your Obsidian Vault",
+        "repo": "farling42/obsidian-import-foundry"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3204,14 +3204,14 @@
         "repo": "Gru80/obsidian-timestamper"
     },
     {
-        "id": "obsidian-import-json"
+        "id": "obsidian-import-json",
         "name": "JSON Importer",
         "author": "farling42",
         "description": "Import a JSON file containing an array of data, creating notes from a Handlebars template file",
         "repo": "farling42/obsidian-import-json"
     },
     {
-        "id": "import-foundry"
+        "id": "import-foundry",
         "name": "Foundry world Importer",
         "author": "farling42",
         "description": "Imports your journal entries from your selected Foundry VTT world into a folder within your Obsidian Vault",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugins:
https://github.com/farling42/obsidian-import-foundry
https://github.com/farling42/obsidian-import-json

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
