### PR TITLE
update name and description of copy-publish-url

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2820,8 +2820,8 @@
     },
     {
         "id": "copy-publish-url",
-        "name": "Copy Publish URL",
-        "description": "Copies the URL of the corresponding note on your Publish site to the clipboard.",
+        "name": "Publish and GitHub URL",
+        "description": "Copy or open the URL of the corresponding note on your Publish site. You can also open its Git commit history on GitHub.",
         "author": "kometenstaub",
         "repo": "kometenstaub/copy-publish-url",
         "branch": "main"


### PR DESCRIPTION
The scope of the plugin is bigger now, hence the changes.

I didn't touch the ID, so current users should not be affected. Once it is merged, I will make a patch release and update the plugin name.