### PR TITLE
Add link-to-obsidian

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3216,5 +3216,12 @@
         "author": "farling42",
         "description": "Imports your journal entries from your selected Foundry VTT world into a folder within your Obsidian Vault",
         "repo": "farling42/obsidian-import-foundry"
+    },
+    {
+        "id": "link-to-obsidian",
+        "name": "Link Server",
+        "author": "moelody",
+        "description": "This plugin will open a reverse proxy server at port 3333 to get wikiLink information Obsidian API.",
+        "repo": "moelody/link-to-obsidian"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/moelody/link-to-obsidian

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
