### PR TITLE
Add obsidian-koreader-sync to community plugins list

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3223,5 +3223,13 @@
         "description": "Formatting attachments name (filename attachmentType indexNumber.xxx)",
         "author": "JYC333",
         "repo": "JYC333/obsidian-attachment-name-formatting"
+    },
+    {
+        "id": "obsidian-koreader-plugin",
+        "name": "KOReader Sync",
+        "description": "Sync highlights/notes from KOReader",
+        "author": "Federico \"Edo\" Granata",
+        "repo": "Edo78/obsidian-koreader-sync"
     }
+ 
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3231,5 +3231,4 @@
         "author": "Federico \"Edo\" Granata",
         "repo": "Edo78/obsidian-koreader-sync"
     }
- 
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Edo78/obsidian-koreader-sync

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [X]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
