### PR TITLE
update link to screenshot

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -554,7 +554,7 @@
         "name": "Shimmering Focus",
         "author": "pseudometa",
         "repo": "chrisgrieser/shimmering-focus",
-        "screenshot": "dual-theme-screenshot.png",
+        "screenshot": "docs/images/Promo%20Screenshot/promo-screenshot.png",
         "modes": ["dark", "light"],
         "branch": "main"
     },


### PR DESCRIPTION
I am re-organizing the repo, therefore a change of the location of the promo screenshot. That's it.