### PR TITLE
Remove Advanced Appearance

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -177,14 +177,6 @@
         "repo": "ryanjamurphy/review-obsidian"
     },
     {
-        "id": "obsidian-advanced-appearance",
-        "name": "Advanced Appearance",
-        "author": "@kepano",
-        "description": "Change colors, fonts and other cosmetic settings",
-        "repo": "kepano/obsidian-advanced-appearance",
-        "branch": "main"
-    },
-    {
         "id": "obsidian-hider",
         "name": "Hider",
         "author": "@kepano",


### PR DESCRIPTION
Removing Advance Appearance from plugins list

See more detail in Readme — the plugin has become obsolete, and I no longer have time to support it.
https://github.com/kepano/obsidian-advanced-appearance