### PR TITLE
Add obsidian-relativenumber plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3348,5 +3348,12 @@
         "description": "Trigger shortcuts in Apple's Shortcuts app from Obsidian with custom commands.",
         "repo": "macstories/obsidian-shortcut-launcher",
         "branch": "main"
+    },
+    {
+        "id": "obsidian-relativenumber",
+        "name": "Relativenumber (relative line numbers)",
+        "author": "Rob Stevenson",
+        "description": "Displays relative line numbers in the editor's gutter.",
+        "repo": "thisdotrob/obsidian-relativenumber-plugin"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3419,5 +3419,5 @@
         "author": "Rob Stevenson",
         "description": "Displays relative line numbers in the editor's gutter.",
         "repo": "thisdotrob/obsidian-relativenumber-plugin"
-   }
+    }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3414,6 +3414,7 @@
         "description": "A command palette that does all of the things you want it to do.",
         "repo": "AlexBieg/obsidian-better-command-palette"
     },
+    {
         "id": "obsidian-relativenumber",
         "name": "Relativenumber (relative line numbers)",
         "author": "Rob Stevenson",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

[Link to my plugin](https://github.com/thisdotrob/obsidian-relativenumber-plugin)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
