### PR TITLE
Fix plugin search fields in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To add your plugin to the list, make a pull request to the `community-plugins.js
 The order of this list is not kept, please add your plugin to the end of the list.
 
 - `id`: A unique ID for your plugin. Make sure this is the same one you have in your `manifest.json`.
-- `name`: The name of your plugin. This will be used to search for your plugin.
+- `name`: The name of your plugin.
 - `author`: The author's name.
 - `description`: A short description of what your plugin does.
 - `repo`: The GitHub repository identifier, in the form of `user-name/repo-name`, if your GitHub repo is located at `https://github.com/user-name/repo-name`.
@@ -29,7 +29,7 @@ The order of this list is not kept, please add your plugin to the end of the lis
 ### How community plugins are pulled
 
 - Obsidian will read the list of plugins in `community-plugins.json`.
-- The `name` field is used for searching.
+- The `name`, `author` and `description` fields are used for searching.
 - When the user opens the detail page of your plugin, Obsidian will pull the `manifest.json` and `README.md` from your GitHub repo using the specified branch (or `master`).
 - The `manifest.json` in your repo will only be used to figure out the latest version. Actual files are fetched from your GitHub releases.
 - If your `manifest.json` requires a version of Obsidian that's higher than the running app, your `versions.json` will be consulted to find the latest version of your plugin that is compatible.


### PR DESCRIPTION
The readme currently states that only the `name` field is used when
searching for plugins.

I noticed that the `author` and `description` fields are also used, so
am updating the readme here to reflect this.