### PR TITLE
Fix typo in plugin name: Sugest -> Suggest

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3380,7 +3380,7 @@
     },
     {
         "id": "obsidian-frontmatter-tag-suggest",
-        "name": "Frontmatter Tag Sugest",
+        "name": "Frontmatter Tag Suggest",
         "description": "Autocompletes tags in the frontmatter tags field",
         "author": "Jonathan Miller",
         "repo": "jmilldotdev/obsidian-frontmatter-tag-suggest"


### PR DESCRIPTION
Just a typo in a plugin name...

/CC @jmilldotdev