### PR TITLE
Add insert-heading-link plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3420,5 +3420,12 @@
         "author": "Rob Stevenson",
         "description": "Displays relative line numbers in the editor's gutter.",
         "repo": "thisdotrob/obsidian-relativenumber-plugin"
+    },
+    {
+        "id": "insert-heading-link",
+        "name": "Insert Heading Link",
+        "author": "Signynt",
+        "description": "Add a Link to a Heading.",
+        "repo": "signynt/insert-heading-link"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/signynt/insert-heading-link

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
