### PR TITLE
Add "Word Splitting for Japanese in Edit Mode" Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3456,5 +3456,12 @@
         "author": "Aviral Batra",
         "description": "Searches notes based on current line",
         "repo": "aviral-batra/obsidian-power-search"
+    },
+    {
+        "id": "cm-japanese-patch",
+        "name": "Word Splitting for Japanese in Edit Mode",
+        "author": "sonarAIT",
+        "description": "A patch for Obsidian's built-in CodeMirror Editor to support Japanese word splitting",
+        "repo": "sonarAIT/cm-japanese-patch"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3458,7 +3458,7 @@
         "repo": "aviral-batra/obsidian-power-search"
     },
     {
-        "id": "cm-japanese-patch",
+        "id": "japanese-word-splitter",
         "name": "Word Splitting for Japanese in Edit Mode",
         "author": "sonarAIT",
         "description": "A patch for Obsidian's built-in CodeMirror Editor to support Japanese word splitting",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [cm-japanese-patch](https://github.com/sonarAIT/cm-japanese-patch)

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
