### PR TITLE
Add obsidian-advanced-selection plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3507,5 +3507,12 @@
         "description": "A patch for Obsidian's built-in CodeMirror Editor to support Japanese word splitting",
         "repo": "sonarAIT/cm-japanese-patch",
         "branch": "main"
+    },
+    {
+        "id": "obsidian-advanced-selection",
+        "name": "Advanced Selection",
+        "author": "Yu Wang",
+	    "description": "More flexible ways to select texts in Obsidian Editor",
+        "repo": "anselmwang/obsidian-advanced-selection"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/anselmwang/obsidian-advanced-selection

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [ ] `main.js`
  - [ ] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ ] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
