### PR TITLE
add alx-folder-note-folderv

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3507,5 +3507,12 @@
         "description": "A patch for Obsidian's built-in CodeMirror Editor to support Japanese word splitting",
         "repo": "sonarAIT/cm-japanese-patch",
         "branch": "main"
+    },
+    {
+        "id": "alx-folder-note-folderv",
+        "name": "AidenLx's Folder Note - folderv Component",
+        "description": "Optional `folderv` Component for alx-folder-note",
+        "author": "AidenLx",
+        "repo": "aidenlx/alx-folder-note-folderv"
     }
 ]


### PR DESCRIPTION
# I am submitting a Community Plugin

## Repo URL

Link to my plugin: https://github.com/aidenlx/alx-folder-note-folderv

It's a part of existing [alx-folder-note](https://github.com/aidenlx/alx-folder-note) plugin that has been published for quite some time so there is no need to review this plugin in depth. 

The purpose of creating a dedicated plugin is to make the Folder Overview feature optional so that those only need basic feature of alx-folder-note won't have to [waste the loading time](https://github.com/aidenlx/alx-folder-note/issues/57) for all the resources for `folderv` code block

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
