### PR TITLE
Remove stray space at end of theme URL - fix to existing theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -885,7 +885,7 @@
     {
         "name": "Sparkling Wisdom",
         "author": "Learner fvs",
-        "repo": "learnerfvs/Sparkling-Wisdom-obsidian-theme- ",
+        "repo": "learnerfvs/Sparkling-Wisdom-obsidian-theme-",
         "screenshot": "sparkling wisdom.png",
         "modes": ["dark", "light"],
         "branch": "master"


### PR DESCRIPTION
This is a correction to a GitHub URL in the theme 'Sparkling-Wisdom-obsidian-theme-'