### PR TITLE
Fix inconsistency in case of username

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3484,7 +3484,7 @@
         "name": "Insert Heading Link",
         "author": "Signynt",
         "description": "Add a command to create a Link to a Heading.",
-        "repo": "signynt/insert-heading-link"
+        "repo": "Signynt/insert-heading-link"
     },
     {
         "id": "settings-search",


### PR DESCRIPTION
There are now two plugins by user @Signynt 

![image](https://user-images.githubusercontent.com/4840096/155412151-ee20a095-7c95-49e8-8e0e-c6b777560969.png)

![image](https://user-images.githubusercontent.com/4840096/155412168-59127b1d-0029-40ee-9068-cea88fa18da3.png)

Note the difference in capitalisation of the user name in the two `repo` values...

The Obsidian Hub code wasn't written to detect inconsistencies in the case used for the same user name, and even though the code here isn't wrong, unfortunately we've ended up with two differently-cased author files created in the Hub vault, which has tripped up Mac Hub Contributors (me!) and will also trip up Windows Hub contributors.

See https://github.com/obsidian-community/obsidian-hub/issues/308
> "Prevent files being created that differ only in case of name - and deal with signynt.md/Signynt.md"

This PR tweaks the newer `signynt`  Url to make it consistent with the original `Signynt`, until we can come up with a way to guard against this happening again in the Hub vault.