### PR TITLE
Add Heatmap Calendar plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3552,5 +3552,13 @@
         "description": "Command palette without unwanted commands",
         "repo": "qawatake/obsidian-command-palette-minus-plugin",
         "branch": "main"
+    },
+    {
+        "id": "heatmap-calendar",
+        "name": "Heatmap Calendar",
+        "author": "Richard Slettevoll",
+        "description": "Activity Year Overview for DataviewJS, Github style – Track Goals, Progress, Habits, Tasks, Exercise, Finances, \"Dont Break the Chain\" etc.",
+        "repo": "Richardsl/heatmap-calendar-obsidian",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
I am submitting a new Community Plugin called Heatmap Calendar

### Link to my plugin:

https://github.com/Richardsl/heatmap-calendar-obsidian/#readme

### Release Checklist

I have tested the plugin on:
- [x] Windows
- [ ] macOS
- [ ] Linux
- [ ] Android (if applicable)
- [ ] iOS (if applicable)

My GitHub release contains all required files
- [x] main.js
- [x] manifest.json
- [x] styles.css (optional)

### I have tested the plugin on

- [x] GitHub release name matches the exact version number specified in my manifest.json (Note: Use the exact version number, don't include a prefix v)
- [x] The id in my manifest.json matches the id in the community-plugins.json file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
- [x] I have given proper attribution to these other projects in my README.md.
