### PR TITLE
changing the root repo

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -931,8 +931,7 @@
         "name": "Footnote Shortcut",
         "description": "Makes creating footnotes in Obsidian more fun!",
         "author": "Alexis Rondeau, Micha Brugger",
-        "repo": "MichaBrugger/obsidian-footnotes",
-        "branch": "master"
+        "repo": "MichaBrugger/obsidian-footnotes"
     },
     {
         "id": "obsidian-gallery",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -930,8 +930,9 @@
         "id": "obsidian-footnotes",
         "name": "Footnote Shortcut",
         "description": "Makes creating footnotes in Obsidian more fun!",
-        "author": "Alexis Rondeau",
-        "repo": "akaalias/obsidian-footnotes"
+        "author": "Alexis Rondeau, Micha Brugger",
+        "repo": "MichaBrugger/obsidian-footnotes",
+        "branch": "master"
     },
     {
         "id": "obsidian-gallery",


### PR DESCRIPTION
As discussed on Discord: the original owner does not maintain the plugin anymore (didn't react to any kind of outreach either), so we need to change the repo to the functioning fork I created.
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/MichaBrugger/obsidian-footnotes

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
