### PR TITLE
Add Kindle Export Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3552,5 +3552,13 @@
         "description": "Command palette without unwanted commands",
         "repo": "qawatake/obsidian-command-palette-minus-plugin",
         "branch": "main"
-    }
+    },
+    {
+	"id": "obsidian-kindle-export"
+    "name": "Kindle Export",
+    "author": "Simeon Stanek",
+	"description": "Export your Notes to your Kindle. Includes embedded Notes and Images ![[]]"
+    "repo": "SimeonLukas/obsidian-kindle-export",
+	"branch": "main"
+}
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/SimeonLukas/obsidian-kindle-export

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
