### PR TITLE
Add dark mode option to Cardstock theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -642,7 +642,7 @@
         "author": "cassidoo",
         "repo": "cassidoo/cardstock",
         "screenshot": "screenshot.png",
-        "modes": ["light"],
+        "modes": ["dark", "light"],
         "branch": "main"
     },
     {


### PR DESCRIPTION
# I am updating an existing community theme

## Repo URL
Link to my theme: https://github.com/cassidoo/cardstock

## Theme checklist
- [ ] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [ ] `obsidian.css`
  - [ ] The screenshot file.
- [ ] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [ ] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other themes that I'm using.
      I have given proper attribution to these other themes in my `README.md`.
- [ ] If my repo is not using the `master` branch, please indicate in `community-themes.json` with `"branch": "main"`.
