### PR TITLE
add Sync Filename & Title to community-plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3714,5 +3714,13 @@
         "author": "Ganessh Kumar R P",
         "description": "An Obsidian plugin to provide an editor for Markdown tables. It can open CSV, Microsoft Excel/Google Sheets data as Markdown tables from Obsidian Markdown editor.",
         "repo": "ganesshkumar/obsidian-table-editor"
+    },
+    {
+        "id": "sync-filename-title",
+        "name": "Sync Filename & Title",
+        "description": "Keeps the filename and title of files in sync.",
+        "author": "Eric Rykwalder",
+        "repo": "erykwalder/sync-filename-title",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

https://github.com/erykwalder/sync-filename-title

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` (intentionally not included)
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
