### PR TITLE
add obsidian-pdf-annotation plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3722,5 +3722,12 @@
         "description": "Search multibyte characters by the first character of corresponding ASCII encoding of input method. For example, for Chinese, search by the first character of Pinyin.",
         "repo": "anselmwang/obsidian-vim-multibyte-char-search",
         "branch": "main"
+    },
+    {
+        "id": "obsidian-pdf-annotation",
+        "name": "Extract PDF Annotations",
+        "author": "Franz Achermann",
+        "description": "Extract PDF Annotations (Notes and Highlights) and sort them by topics",
+        "repo": "munach/obsidian-pdf-annotations"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3724,10 +3724,10 @@
         "branch": "main"
     },
     {
-        "id": "obsidian-pdf-annotation",
+        "id": "obsidian-extract-pdf-annotations",
         "name": "Extract PDF Annotations",
         "author": "Franz Achermann",
         "description": "Extract PDF Annotations (Notes and Highlights) and sort them by topics",
-        "repo": "munach/obsidian-pdf-annotations"
+        "repo": "munach/obsidian-extract-pdf-annotations"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/munach/obsidian-pdf-annotations

## Release Checklist
- [X] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [X]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
