### PR TITLE
Remove "Extra Markdown Commands" from Plugin List

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2849,13 +2849,6 @@
         "repo": "twentytwokhz/language-translator"
     },
     {
-        "id": "obsidian-extra-md-commands",
-        "name": "Extra Markdown Commands",
-        "description": "Adds various commands, e.g. for __bold__ or <cite>.",
-        "author": "pseudometa",
-        "repo": "chrisgrieser/obsidian-extra-md-commands"
-    },
-    {
         "id": "customizable-page-header-buttons",
         "name": "Customizable Page Header",
         "description": "Add buttons for executing commands to the page header.",


### PR DESCRIPTION
I'd like to deprecate the plugin, since I have made a much better plugin that includes most of this plugin's functionality: [Smarter Markdown Hotkeys](https://github.com/chrisgrieser/obsidian-smarter-md-hotkeys). For HTML tags, there is now the much more customizable [Wrap with Shortcuts Plugin](https://github.com/manic/obsidian-wrap-with-shortcuts). All in all, there isn't really any reason to keep this plugin in the community store.

([Discord Reference](https://discord.com/channels/686053708261228577/716028884885307432/953006639475220490))