### PR TITLE
[Fix] Fixed Markdown shortcuts typo

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3562,7 +3562,7 @@
     },
     {
         "id": "markdown-shortcuts",
-        "name": "Marjdown shortcuts",
+        "name": "Markdown shortcuts",
         "author": "Jules Guesnon",
         "description": "Allows to write markdown from shortcuts",
         "repo": "JulesGuesnon/obsidian-markdown-shortcuts"


### PR DESCRIPTION
# Description

As stated in #795, I introduced a typo when I made a PR for my plugin markdown shortcuts, so here is the fix.