### PR TITLE
Update Full Calendar description

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3602,7 +3602,7 @@
         "id": "obsidian-full-calendar",
         "name": "Full Calendar",
         "author": "Davis Haupt (@davish)",
-        "description": "Obsidian integration with Full Calendar (fullcalendar.io) to keep, manage, and visualize events alongside your other notes in your Vault.",
+        "description": "Keep events and manage your calendar alongside all your other notes in your Obsidian Vault.",
         "repo": "davish/obsidian-full-calendar",
         "branch": "main"
     },


### PR DESCRIPTION
This PR updates the description for the Full Calendar plugin, since the old wording made it seem like fullcalendar.io was a third-party service you needed to use rather than a UI library that the plugin was built on top of.