### PR TITLE
Deprecate "Add Codemirror matchbrackets.js"

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -371,13 +371,6 @@
         "branch": "main"
     },
     {
-        "id": "mrj-add-codemirror-matchbrackets",
-        "name": "Add Codemirror's matchbrackets.js",
-        "description": "This plugins adds matchbrackets.js which allows to use `di[` or `ya(` commands in Vim mode",
-        "author": "MrJackphil",
-        "repo": "mrjackphil/obsidian-add-codemirror-matchbrackets"
-    },
-    {
         "id": "obsidian-juliandate",
         "name": "Julian Date Quick Insert",
         "author": "thek3nger",


### PR DESCRIPTION
Would like to deprecate the plugin because it was implemented in Obsidian 0.13.8.