### PR TITLE
add obsidian-typora-hotkey-plugin to community-plugins.json

### DIFF
--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: 16.x
       - run: | 
-          git checkout plugin-stats-chores
+          git checkout -b plugin-stats-chores
           git pull origin HEAD:master
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -1,0 +1,29 @@
+name: Pull plugin stats
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  pull-stats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+        env:
+          gh_token: ${{ secrets.GH_TOKEN }}
+        run: |
+          node update-stats.js
+  commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create report file
+      - name: Commit report
+        run: |
+          git config --global user.name 'Obsidian Bot'
+          git config --global user.email 'admin@obsidian.md'
+          git commit -am "Update plugin stats"
+          git push

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -15,20 +15,16 @@ jobs:
   pull-stats:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-            ref: ${{ github.head_ref }}
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x
       - run: | 
-          git checkout -b plugin-stats-chores
-          git pull origin HEAD:master
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'
           touch foo.txt
           git add .
           git commit -m "chore: Update plugin stats"
-          git push origin HEAD:master
+          git push
         env:
           gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -1,15 +1,13 @@
 name: Pull plugin stats
 
-# on:
-#   schedule:
-#     - cron: "0 0 * * *"
-
-# node update-stats.js
+on:
+  schedule:
+    - cron: "*/10 * * * *"
 
 # run it on closing PR to test the workflow, will remove once it works
-on:
-  pull_request:
-    types: [opened, closed, synchronize]
+# on:
+#   pull_request:
+#     types: [opened, closed, synchronize]
 
 jobs:
   pull-stats:
@@ -20,12 +18,11 @@ jobs:
         with:
           node-version: 16.x
       - run: | 
-          git pull origin HEAD:master
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'
-          touch foo.txt
+          node update-stats.js
           git add .
           git commit -m "chore: Update plugin stats"
-          git push origin HEAD:master
+          git push
         env:
           gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: 16.x
       - run: | 
-          git checkout HEAD:master
+          git checkout origin HEAD:master
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'
           touch foo.txt

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 16.x
       - run: |
-          git branch
+          git checkout plugin-stats
           node update-stats.js
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 16.x
       - run: |
-          git checkout master
+          git branch
           node update-stats.js
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -1,8 +1,13 @@
 name: Pull plugin stats
 
+# on:
+#   schedule:
+#     - cron: "0 0 * * *"
+
+# run it on closing PR to test the workflow, will remove once it works
 on:
-  schedule:
-    - cron: "0 0 * * *"
+  pull_request:
+    types: [closed]
 
 jobs:
   pull-stats:
@@ -12,10 +17,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x
+      - run: |
+          node update-stats.js
         env:
           gh_token: ${{ secrets.GH_TOKEN }}
-        run: |
-          node update-stats.js
   commit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -19,15 +19,9 @@ jobs:
           node-version: 16.x
       - run: |
           node update-stats.js
-        env:
-          gh_token: ${{ secrets.GH_TOKEN }}
-  commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Commit updates
-        run: |
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'
           git commit -am "chore: Update plugin stats"
           git push
+        env:
+          gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -7,7 +7,7 @@ name: Pull plugin stats
 # run it on closing PR to test the workflow, will remove once it works
 on:
   pull_request:
-    types: [closed]
+    types: [opened, closed]
 
 jobs:
   pull-stats:

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -19,13 +19,12 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x
-      - run: |
-          git checkout -b update-plugin-stats
+      - run: | 
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'
           touch foo.txt
           git add .
           git commit -m "chore: Update plugin stats"
-          git push --set-upstream origin master
+          git push origin master
         env:
           gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -4,6 +4,8 @@ name: Pull plugin stats
 #   schedule:
 #     - cron: "0 0 * * *"
 
+# node update-stats.js
+
 # run it on closing PR to test the workflow, will remove once it works
 on:
   pull_request:
@@ -19,7 +21,7 @@ jobs:
           node-version: 16.x
       - run: |
           git checkout -b update-plugin-stats
-          node update-stats.js
+          echo 'Test new file' > foo.txt
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'
           git commit -am "chore: Update plugin stats"

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -20,10 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Create report file
-      - name: Commit report
+      - name: Commit updates
         run: |
-          git config --global user.name 'Obsidian Bot'
-          git config --global user.email 'admin@obsidian.md'
+          git config --local user.name 'Obsidian Bot'
+          git config --local user.email 'admin@obsidian.md'
           git commit -am "Update plugin stats"
           git push

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+            ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16.x
         env:
           gh_token: ${{ secrets.GH_TOKEN }}
         run: |

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -27,6 +27,6 @@ jobs:
           touch foo.txt
           git add .
           git commit -m "chore: Update plugin stats"
-          git push origin master
+          git push origin HEAD:master
         env:
           gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -25,6 +25,6 @@ jobs:
           touch foo.txt
           git add .
           git commit -m "chore: Update plugin stats"
-          git push
+          git push origin HEAD:master
         env:
           gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -21,10 +21,10 @@ jobs:
           node-version: 16.x
       - run: |
           git checkout -b update-plugin-stats
-          echo 'Test new file' > foo.txt
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'
+          touch foo.txt
           git commit -am "chore: Update plugin stats"
-          git push
+          git push --set-upstream origin master
         env:
           gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: 16.x
       - run: | 
+          git checkout HEAD:master
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'
           touch foo.txt

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -24,7 +24,8 @@ jobs:
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'
           touch foo.txt
-          git commit -am "chore: Update plugin stats"
+          git add .
+          git commit -m "chore: Update plugin stats"
           git push --set-upstream origin master
         env:
           gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: 16.x
       - run: |
+          git checkout master
           node update-stats.js
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -7,7 +7,7 @@ name: Pull plugin stats
 # run it on closing PR to test the workflow, will remove once it works
 on:
   pull_request:
-    types: [opened, closed]
+    types: [opened, closed, synchronize]
 
 jobs:
   pull-stats:

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: 16.x
       - run: | 
+          git pull origin HEAD:master
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'
           touch foo.txt

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 16.x
       - run: |
-          git checkout plugin-stats
+          git checkout -b update-plugin-stats
           node update-stats.js
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -24,5 +24,5 @@ jobs:
         run: |
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'
-          git commit -am "Update plugin stats"
+          git commit -am "chore: Update plugin stats"
           git push

--- a/.github/workflows/plugin-stat.yml
+++ b/.github/workflows/plugin-stat.yml
@@ -22,7 +22,8 @@ jobs:
         with:
           node-version: 16.x
       - run: | 
-          git checkout origin HEAD:master
+          git checkout plugin-stats-chores
+          git pull origin HEAD:master
           git config --local user.name 'Obsidian Bot'
           git config --local user.email 'admin@obsidian.md'
           touch foo.txt

--- a/update-stats.js
+++ b/update-stats.js
@@ -1,0 +1,103 @@
+let fs = require('fs');
+let https = require('https');
+
+let plugins = JSON.parse(fs.readFileSync('./community-plugins.json', 'utf8'));
+let stats = JSON.parse(fs.readFileSync('./community-plugin-stats.json', 'utf8'));
+
+let githubToken = process.env.gh_token;
+
+console.log(`Updating stats for ${Object.keys(plugins).length} plugins`);
+let newStats = {};
+for (let plugin of plugins) {
+	let key = plugin.id;
+	if (stats.hasOwnProperty(key)) {
+		newStats[key] = stats[key];
+	}
+}
+
+let saveStats = () => fs.writeFileSync('./community-plugin-stats.json', JSON.stringify(newStats, null, 2), 'utf8');
+
+saveStats();
+
+(async() => {
+	for (let key in plugins) {
+		if (!plugins.hasOwnProperty(key)) {
+			continue;
+		}
+
+		for (let attempt = 0; attempt < 5; attempt++) {
+			try {
+				let plugin = plugins[key];
+				let id = plugin.id;
+
+				console.log(`Downloading stats for ${id}`);
+				let stats = newStats[id] = newStats[id] || {};
+				let repo = plugin.repo;
+				let data = await download(repo);
+				let releases = JSON.parse(data);
+				// stats is Array<{tag_name: string, assets: Array<{name: string, download_count}>}>
+
+				console.log(`Received ${releases.length} releases`);
+				for (let release of releases) {
+					let version = release.tag_name;
+					let assets = release.assets;
+					let downloads = 0;
+					for (let asset of assets) {
+						if (asset.name === 'manifest.json') {
+							downloads = asset.download_count;
+						}
+					}
+					if (downloads) {
+						stats[version] = downloads;
+					}
+				}
+
+				let total = 0;
+				for (let version in stats) {
+					if (stats.hasOwnProperty(version) && version !== 'downloads') {
+						total += stats[version];
+					}
+				}
+
+				console.log(`Total downloads: ${total}`);
+				stats['downloads'] = total;
+
+				saveStats();
+				break;
+			} catch (e) {
+				console.log('Failed', e.message);
+				await new Promise(resolve => setTimeout(resolve, 1000));
+			}
+		}
+
+		await new Promise(resolve => setTimeout(resolve, 200));
+	}
+
+	console.log('All done!');
+})();
+
+function download(repo) {
+	return new Promise((resolve, reject) => {
+		let req = https.get(
+			{
+				host: 'api.github.com',
+				port: 443,
+				path: '/repos/' + repo + '/releases',
+				headers: {
+					'User-Agent': 'Obsidian-Script',
+					// Generate a permission-less token here https://github.com/settings/tokens
+					// This raises the API rate limit from 60/hr to 5000/hr
+					'Authorization': 'Basic ' + Buffer.from(githubToken).toString('base64')
+				}
+			}, 
+			function (res) {
+				let body = [];
+				res.on('data', (data) => body.push(data));
+				res.on('end', () => resolve(body.join('')));
+			}
+		);
+		req.on('error', reject);
+	});
+}
+
+

--- a/update-stats.js
+++ b/update-stats.js
@@ -69,8 +69,6 @@ saveStats();
 				await new Promise(resolve => setTimeout(resolve, 1000));
 			}
 		}
-
-		await new Promise(resolve => setTimeout(resolve, 200));
 	}
 
 	console.log('All done!');


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/Wingsky6/obsidian-typora-hotkey-plugin

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
  - [ ] Android _(if applicable)_
  - [ ] iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in [https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md](https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md) and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.  
  I have given proper attribution to these other projects in my `README.md`.
