### PR TITLE
Update Fantasy Calendar repository

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2626,7 +2626,7 @@
         "name": "Fantasy Calendar",
         "description": "Fantasy calendars in Obsidian!",
         "author": "Jeremy Valentine",
-        "repo": "valentine195/obsidian-fantasy-calendar"
+        "repo": "fantasycalendar/obsidian-fantasy-calendar"
     },
     {
         "id": "obsidian-pikt",


### PR DESCRIPTION
The Fantasy Calendar plugin is now officially part of the [Fantasy Calendar](https://fantasy-calendar.com/) family.