### PR TITLE
Add Obsidian Keep plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3728,6 +3728,6 @@
         "name": "Obsidian Keep",
         "author": "Ellpeck",
         "description": "An Obsidian plugin that displays Google Keep in the app"
-        "repo": "Ellpeck/https://github.com/Ellpeck/ObsidianKeep"
+        "repo": "Ellpeck/ObsidianKeep"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3722,5 +3722,12 @@
         "author": "Johnson0907",
         "description": "Help you to clean empty files and unused attachments in the vault.",
         "repo": "Johnson0907/obsidian-file-cleaner"
+    },
+    {
+        "id": "obsidian-keep"
+        "name": "Obsidian Keep",
+        "author": "Ellpeck",
+        "description": "An Obsidian plugin that displays Google Keep in the app"
+        "repo": "Ellpeck/https://github.com/Ellpeck/ObsidianKeep"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/Ellpeck/ObsidianKeep

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_ 
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.

## A Note
I'd like to point out here that the way I am making this plugin happen is extremely [cursed](https://github.com/Ellpeck/ObsidianKeep/blob/master/main.ts#L105-L117) in [places](https://github.com/Ellpeck/ObsidianKeep/blob/master/main.ts#L132-L140), so I fully understand if it can't be added to the community plugin list right now. There's a short explanation as to why all of this is being done in [the README](https://github.com/Ellpeck/ObsidianKeep/blob/master/README.md) as well.

As stated in the README, I plan on improving this compatibility beyond just displaying Google Keep directly once the [official Google Keep API](https://developers.google.com/keep) is farther along and if/once it exits Enterprise-only mode. Though, since I don't know when that is happening, and since I find this plugin extremely useful for personal use, I thought I'd still try to submit it officially!