### PR TITLE
Rename "Daily notes new tab" to "Daily notes opener"

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3599,11 +3599,11 @@
         "repo": "Richardsl/heatmap-calendar-obsidian"
     },
     {
-        "id": "obsidian-daily-notes-new-tab",
-        "name": "Daily notes new tab",
+        "id": "obsidian-daily-notes-opener",
+        "name": "Daily notes opener",
         "author": "Reorx",
-        "description": "Add command and sidebar button to open daily notes in new tab",
-        "repo": "reorx/obsidian-daily-notes-new-tab"
+        "description": "Easily open daily notes and periodic notes in new pane; customize periodic notes background; quick append new line to daily notes.",
+        "repo": "reorx/obsidian-daily-notes-opener"
     },
     {
         "id": "obsidian-advanced-new-folder",


### PR DESCRIPTION
# I am submitting a Community Plugin rename

Previously the plugin is called [Daily notes new tab](https://github.com/reorx/obsidian-daily-notes-new-tab), I just realized that I should use the word [Pane](https://help.obsidian.md/User+interface/Workspace/Panes/Pane+layout) not "Tab", and this plugin has added a lot of new features so I think "opener" could be a better name for it.

The new repo's release starts from [2.0.0](https://github.com/reorx/obsidian-daily-notes-opener/releases/tag/2.0.0).

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/reorx/obsidian-daily-notes-opener

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
