### PR TITLE
Add obsidian-notion-video to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3895,5 +3895,12 @@
         "author": "Aditya Majethia",
         "description": "Chat View lets you quickly and easily create elegant Chat UIs in your Markdown Files.",
         "repo": "adifyr/obsidian-chat-view"
+    },
+    {
+        "id": "obsidian-notion-plugin",
+        "name": "Notion API",
+        "author": "lastknightcoder",
+        "description": "Using Notion API in Obsidian",
+        "repo": "LastKnightCoder/obsidian-notion"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3897,10 +3897,10 @@
         "repo": "adifyr/obsidian-chat-view"
     },
     {
-        "id": "obsidian-notion-plugin",
-        "name": "Notion API",
+        "id": "obsidian-notion-video",
+        "name": "Notion Video Embed",
         "author": "lastknightcoder",
-        "description": "Using Notion API in Obsidian",
+        "description": "embed your notion video in obsidian",
         "repo": "LastKnightCoder/obsidian-notion"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/LastKnightCoder/obsidian-notion

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
