### PR TITLE
Add Obsidian-Reset-Checkboxes Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3997,5 +3997,12 @@
         "author": "twibiral",
         "description": "Allows to execute code snippets within a note.",
         "repo": "twibiral/obsidian-execute-code"
-    }
+    },
+    {
+        "id": "obsidian-reset-checkboxes",
+        "name": "Reset Checkboxes",
+        "author": "Branwall",
+        "description": "Adds commands to check or reset all checkboxes in the open file.  Useful for checklists.",
+        "repo": "branwall/obsidian-reset-checkboxes"
+    }  
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

[Link to my plugin](https://github.com/branwall/obsidian-reset-checkboxes)

## Release Checklist
- [X] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
