### PR TITLE
Add `"publish": true` to the Willemstad theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -888,7 +888,8 @@
         "repo": "tingmelvin/willemstad-x",
         "screenshot": "img/Willemstad-X.png",
         "modes": ["dark", "light"],
-        "branch": "main"
+        "branch": "main",
+        "publish": true
     },
     {
         "name": "Royal Velvet",


### PR DESCRIPTION
<!--- Delete this section if submitting a plugin -->
I am editing my Community Theme (Willemstad) to include an indication it has a `publish.css` file for Obsidian Publish

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my theme: https://github.com/tingmelvin/willemstad-x/
Publish file: https://github.com/tingmelvin/willemstad-x/blob/main/publish.css