### PR TITLE
fix two plugins linking the wrong repository

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4061,7 +4061,7 @@
         "name": "Obsidian Link",
         "author": "dennisseidel",
         "description": "Create Todoist tasks and projects including bidirectional links from Obsidian",
-        "repo": "dennisseidel/obsidian-releases"
+        "repo": "dennisseidel/obsidian-todoist-link"
     },
     {
         "id": "obsidian-rewarder",
@@ -4082,7 +4082,7 @@
         "name": "Omnisearch",
         "author": "Simon Cambier",
         "description": "A search engine that just works",
-        "repo": "scambier/obsidian-releases"
+        "repo": "scambier/obsidian-omnisearch"
     },
     {
         "id": "plugins-galore",


### PR DESCRIPTION
The entries for
both the [Todoist Link](https://github.com/dennisseidel/obsidian-todoist-link)
and the [Omnisearch](https://github.com/scambier/obsidian-omnisearch) plugins
are pointing to the authors forked version of this repo.
The plugins cannot be viewed in Obsidian as a result.

(I also think that the name for the Todoist plugin as it is in the list currently is missing the most important part cc @dennisseidel)