### PR TITLE
Add Zenburn theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -946,5 +946,13 @@
       "screenshot": "screenshot.png",
       "modes": ["dark"],
       "branch": "main"
-  }
+    },
+    {
+      "name": "Zenburn",
+      "author": "danyim",
+      "repo": "danyim/obsidian-zenburn",
+      "screenshot": "screen.png",
+      "modes": ["dark"],
+      "branch": "main"
+    }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a plugin -->
# I am submitting a new Community Theme
Hello, I'm submitting a new theme called Zenburn. It's a low-contrast "dark mode" theme from vim that I've used for all my tools over the years. I just wanted to see it on Obsidian :)

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my theme: https://github.com/danyim/obsidian-zenburn


## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `obsidian.css`
  - [x] The screenshot file.
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using.
      I have given proper attribution to these other themes in my `README.md`.
- [x] If my repo is not using the `master` branch, please indicate in `community-themes.json` with `"branch": "main"`.
