### PR TITLE
add obsidian external embed

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4119,5 +4119,13 @@
         "author": "musug",
         "description": "Screenshot png to jpeg and compress and rename.",
         "repo": "musug/obsidian-paste-png-to-jpeg"
+    },
+    {
+        "id": "obsidian-iframes",
+        "name": "Obsidian Iframes",
+        "author": "Trevor Nichols",
+        "description": "Allows you to create relative iframes and MD iframes in Obsidian",
+        "repo": "tnichols217/obsidian-iframes",
+        "branch": "main"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4121,11 +4121,11 @@
         "repo": "musug/obsidian-paste-png-to-jpeg"
     },
     {
-        "id": "obsidian-dynamic-import",
-        "name": "Obsidian Dynamic Import",
+        "id": "obsidian-external-embed",
+        "name": "Obsidian External Embed",
         "author": "Trevor Nichols",
         "description": "Allows you to Import other MD files into your notes, and improves iframes",
-        "repo": "tnichols217/obsidian-dynamic-import",
+        "repo": "tnichols217/obsidian-external-embed",
         "branch": "main"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4121,11 +4121,11 @@
         "repo": "musug/obsidian-paste-png-to-jpeg"
     },
     {
-        "id": "obsidian-iframes",
-        "name": "Obsidian Iframes",
+        "id": "obsidian-dynamic-import",
+        "name": "Obsidian Dynamic Import",
         "author": "Trevor Nichols",
-        "description": "Allows you to create relative iframes and MD iframes in Obsidian",
-        "repo": "tnichols217/obsidian-iframes",
+        "description": "Allows you to Import other MD files into your notes, and improves iframes",
+        "repo": "tnichols217/obsidian-dynamic-import",
         "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin:

https://github.com/tnichols217/obsidian-dynamic-import

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
