### PR TITLE
Add obsidian-date-in-metadata plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4155,5 +4155,12 @@
         "author": "YISH",
         "description": "A enhancing export plugin base on pandoc for Obsidian. It allows to export to formats like Html, DOCX, ePub and PDF or Hugo.",
         "repo": "mokeyish/obsidian-enhancing-export"
-  }
+    },
+    {
+        "id": "obsidian-date-in-metadata",
+        "name": "Date in metadata",
+        "author": "Salmund",
+        "description": "Insert automatically the date in YAML frontmatter on file creation event.",
+        "repo": "salmund/obsidian-date-in-metadata"
+    }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin
 
 ## Repo URL

 Link to my plugin: https://github.com/salmund/obsidian-date-in-metadata
 
 ## Release Checklist

- [ ] I have tested the plugin on
  -  [ ] Windows
  -  [ ] macOS
  -  [x] Linux
  -  [ ] Android *(if applicable)*
  -  [ ] iOS *(if applicable)*

-  [x] My GitHub release contains all required files

-  [x] `main.js`

-  [x] `manifest.json`

-  [ ] `styles.css` *(optional)*

-  [x] GitHub release name matches the exact version number specified in my manifest.json (***Note:** Use the exact version number, don't include a prefix `v`*)

-  [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.

-  [x] My README.md describes the plugin's purpose and provides clear usage instructions.

-  [x] I have read the tips in <https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md> and have self-reviewed my plugin to avoid these common pitfalls.

-  [x] I have added a license in the LICENSE file.

- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.

- [x] I have given proper attribution to these other projects in my `README.md`.
