### PR TITLE
Rename Zotero Desktop Connector plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3832,11 +3832,11 @@
         "repo": "Johnson0907/obsidian-daily-notes-viewer"
     },
     {
-        "id": "obsidian-zotero-desktop-connector",
-        "name": "Zotero Desktop Connector",
+        "id": "obsidian-zotero-integration",
+        "name": "Zotero Integration",
         "author": "mgmeyers",
-        "description": "Insert citations, bibliographies, and notes directly from Zotero desktop.",
-        "repo": "mgmeyers/obsidian-zotero-desktop-connector",
+        "description": "Insert and import citations, bibliographies, notes, and PDF annotations from Zotero.",
+        "repo": "mgmeyers/obsidian-zotero-integration",
         "branch": "main"
     },
     {


### PR DESCRIPTION
Per the request of Zotero's devs, I'm renaming my plugin to create less confusion between my plugin and Zotero's native "Zotero Connector"
