### PR TITLE
Added obsidian-to-notion plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4207,5 +4207,12 @@
         "author": "Snezhig",
         "description": "Lets you define a title in frontmatter to be displayed as the filename",
         "repo": "Snezhig/obsidian-front-matter-title"
+    },
+    {
+        "id": "obsidian-to-notion",
+        "name": "Obsidian shared to Notion",
+        "author": "Easychris",
+        "description": "This is a  plugin for Obsidian. This plugin share obsidian md file to notion with notion api",
+        "repo": "Easychris/obsidian-to-notion"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin:[GitHub - EasyChris/obsidian-to-notion: share obsidian md file to notion](https://github.com/EasyChris/obsidian-to-notion)

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
