### PR TITLE
Infos for publicly announcing plugin/themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,10 @@ To add your plugin to the list, make a pull request to the `community-plugins.js
 - If your `manifest.json` requires a version of Obsidian that's higher than the running app, your `versions.json` will be consulted to find the latest version of your plugin that is compatible.
 - When the user chooses to install your plugin, Obsidian will look for your GitHub releases tagged identically to the version inside `manifest.json`.
 - Obsidian will download `manifest.json`, `main.js`, and `styles.css` (if available), and store them in the proper location inside the vault.
+
+### Announcing the First Public Release of your Plugin/Theme
+
+- Once admitted to the plugin/theme browser, you can announce the public availability of your plugin/theme:
+  - [in the forums](https://forum.obsidian.md/c/share-showcase/9) as a showcase, and
+  - [on the Discord Server](https://discord.gg/veuWUTm) in the channel `#updates`. (You need the `developer` role to be able to post in that channel; [you can get that role here](https://discord.com/channels/686053708261228577/702717892533157999/830492034807758859).)
+- You can also announce the first working version of your plugin as a public beta before "officially" submitting it to the plugin/theme browser. That way, you can acquire some beta testers for feedback. It's recommended to use the [BRAT Plugin](https://obsidian.md/plugins?id=obsidian42-brat) to make the installation as easy as possible for interested beta testers.


### PR DESCRIPTION
while not strictly necessary, it's probably useful to give plugin/theme devs some infos on how/where to announce their contribution. 

Questions how to post in `#updates` come up regularly in Discord, for example, and can be centrally answered by this addition to the readme.