### PR TITLE
add `Open PDF externally` to copy-url-in-preview plugin descripton

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1724,7 +1724,7 @@
         "id": "copy-url-in-preview",
         "name": "Copy Image and URL in Preview",
         "author": "NomarCub",
-        "description": "Copy Image and Copy URL context menu in preview mode",
+        "description": "Copy Image, Copy URL and Open PDF externally context menu in preview mode",
         "repo": "NomarCub/obsidian-copy-url-in-preview"
     },
     {


### PR DESCRIPTION
I am updating the description of my plugin to reflect a new feature. I tried following the link that the workflow wanted me to, but it thought this is a new plugin and the workflow failed. - https://github.com/obsidianmd/obsidian-releases/pull/985

Here's the repo: https://github.com/NomarCub/obsidian-copy-url-in-preview
