### PR TITLE
Add SearchR plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4312,5 +4312,12 @@
         "author": "mnowotnik",
         "description": "Use js files or snippets to code your own quick and dirty plugins",
         "repo": "mnowotnik/obsidian-user-plugins"
+    },
+    {
+        "id": "obsidian-searchr-plugin",
+        "name": "SearchR",
+        "author": "Matthias Gruber",
+        "description": "The official plugin for SearchR",
+        "repo": "MatthiasGruba/obsidian-searchr"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/MatthiasGruba/obsidian-searchr

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
