### PR TITLE
Add new "Share as Gist" plugin to `community-plugins.json`

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4312,5 +4312,12 @@
         "author": "mnowotnik",
         "description": "Use js files or snippets to code your own quick and dirty plugins",
         "repo": "mnowotnik/obsidian-user-plugins"
+    },
+    {
+        "id": "obsidian-share-as-gist",
+        "name": "Share as Gist",
+        "author": "timrogers",
+        "description": "Shares an Obsidian note as a GitHub.com gist",
+        "repo": "timrogers/obsidian-share-as-gist"
     }
 ]


### PR DESCRIPTION
This adds my new [`obsidian-share-as-gist`](https://github.com/timrogers/obsidian-share-as-gist) plugin to the plugin list in `community-plugins.json`.

The plugin allows you to share your notes as GitHub Gists, both publicly and privately, and then sync changes to your notes to gists on demand.
