### PR TITLE
changing repo owner of Github Publisher

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4024,7 +4024,7 @@
         "name": "Github Publisher",
         "author": "Mara-Li",
         "description": "Github Publisher is a plugin that help you to send file in a configured Github Repository, based on a frontmatter entry state.",
-        "repo": "Mara-Li/obsidian-github-publisher"
+        "repo": "obsidianMkdocs/obsidian-github-publisher"
     },
     {
         "id": "obsidian-notion-video",


### PR DESCRIPTION
Hi!
Because of the amount of repo linked to `Github Publisher` and my free publish alternative, `Obsidian Mkdocs Publisher`, I created an organization. So, I need, again to change the repo link in the release.

Sorry for inconveniance !