### PR TITLE
Add Zotero Bridge and Zotero Link to the list of community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4312,5 +4312,19 @@
         "author": "mnowotnik",
         "description": "Use js files or snippets to code your own quick and dirty plugins",
         "repo": "mnowotnik/obsidian-user-plugins"
+    },
+    {
+        "id": "zotero-bridge",
+        "name": "Zotero Bridge",
+        "author": "Shmavon Gazanchyan",
+        "description": "Obsidian plugin to integrate with Zotero through ZotServer",
+        "repo": "vanakat/zotero-bridge"
+    },
+    {
+        "id": "zotero-link",
+        "name": "Zotero Link",
+        "author": "Shmavon Gazanchyan",
+        "description": "Obsidian plugin to insert link to Zotero item ",
+        "repo": "vanakat/zotero-link"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:
- Zotero Bridge: https://github.com/vanakat/zotero-bridge
- Zotero Link: https://github.com/vanakat/zotero-link

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
