### PR TITLE
Add obsidian-redirect to list of community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4312,5 +4312,12 @@
         "author": "mnowotnik",
         "description": "Use js files or snippets to code your own quick and dirty plugins",
         "repo": "mnowotnik/obsidian-user-plugins"
-    }
+    },
+    {
+        "id": "obsidian-redirect",
+        "name": "Redirect",
+        "author": "Jacob Levernier",
+        "description": "Facilitate management of especially non-markdown files, by allowing aliases to be set on any file.",
+        "repo": "jglev/obsidian-redirect"
+    },
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4318,6 +4318,7 @@
         "name": "Redirect",
         "author": "Jacob Levernier",
         "description": "Facilitate management of especially non-markdown files, by allowing aliases to be set on any file.",
-        "repo": "jglev/obsidian-redirect"
+        "repo": "jglev/obsidian-redirect",
+        "branch": "main"
     },
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/jglev/obsidian-redirect/

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [X]  Linux
  - [X]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.

**Thank you in advance for your code review! I appreciate your work!**
