### PR TITLE
Added obsidian-paste-into-codeblock

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4341,5 +4341,12 @@
         "author": "XSPGMike",
         "description": "Create braincache flashcards from Obsidian",
         "repo": "XSPGMike/braincache_obsidian"
+    },
+    {
+        "id": "obsidian-paste-into-codeblock",
+        "name": "Paste into codeblock",
+        "author": "inode",
+        "description": "Allow paste into codeblock",
+        "repo": "inode-/obsidian-paste-into-codeblock"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/inode-/obsidian-paste-into-codeblock

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [ ]  macOS
  - [X]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
