### PR TITLE
Rename `State Switcher` to `Yaml Manager`

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4222,9 +4222,9 @@
     },
     {
         "id": "obsidian-state-switcher",
-        "name": "State Switcher",
+        "name": "Yaml Manager",
         "author": "Lijyze",
-        "description": "Allow you switch value of specific field within custom value set, so you won't make mistake.",
+        "description": "Keep you away from directly operating yaml front matter.",
         "repo": "lijyze/obsidian-state-switcher"
     },
     {


### PR DESCRIPTION
Functionalities of this plugin has been enhanced considerable, so I'm renaming it to make its name more suitable.