### PR TITLE
Add Obsidian Date in Metadata plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4484,5 +4484,11 @@
         "author": "Salmund",
         "description": "Allow to use the selected word as an alias in link suggestion",
         "repo": "salmund/obsidian-better-link-inserter"
+    },
+        "id": "obsidian-date-in-metadata",
+        "name": "Obsidian Date in Metadata",
+        "author": "Salmund",
+        "description": "Insert the current date and time in YAML frontmatter on file creation",
+        "repo": "salmund/obsidian_date_in_metadata"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
