### PR TITLE
Add New-Note-Plus plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4541,5 +4541,13 @@
         "author": "Grzegorz Dominiczak",
         "description": "Calculates and displays diff in hours and minutes between two dates in `timediff` markdown block",
         "repo": "dominiczaq/obsidian-plugin-time-diff"
+    },
+    {
+        "id": "new-note-plus",
+        "name": "New Note Plus",
+        "author": "Lucas Lee",
+        "description": "A new URL Scheme to create new note using clipboard contents",
+        "repo": "ilucaslee/obsidian-new-note-plus",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:[obsidian-new-note-plus](https://github.com/ilucaslee/obsidian-new-note-plus)

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
