### PR TITLE
change plugin name for Copy Image & URL plugin, use reading view terminology

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1722,9 +1722,9 @@
     },
     {
         "id": "copy-url-in-preview",
-        "name": "Copy Image and URL in Preview",
+        "name": "Copy Image and URL context menu",
         "author": "NomarCub",
-        "description": "Copy Image, Copy URL and Open PDF externally context menu in preview mode",
+        "description": "Copy Image, Copy URL and Open PDF externally context menu in reading view (formerly preview mode)",
         "repo": "NomarCub/obsidian-copy-url-in-preview"
     },
     {


### PR DESCRIPTION
This is a plugin update, not a new submission. The automatic PR navigation thing failed last time, so I'd rather do it in this plain way.
