### PR TITLE
add Hide Sidebars on Window Resize plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1949,10 +1949,10 @@
     },
     {
         "id": "obsidian-hide-sidebars-when-narrow",
-        "name": "Hide Sidebars When Narrow",
-        "author": "Michael Hanson",
-        "description": "Automatically hides the sidebars when your window is narrow.",
-        "repo": "mybuddymichael/obsidian-hide-sidebars-when-narrow"
+        "name": "Hide Sidebars on Window Resize",
+        "author": "NomarCub, Michael Hanson",
+        "description": "Automatically hides the sidebars when your window is narrow on window resize",
+        "repo": "NomarCub/obsidian-hide-sidebars-on-window-resize"
     },
     {
         "id": "obsidian-linter",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/NomarCub/obsidian-hide-sidebars-on-window-resize

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
