### PR TITLE
Remove old plugins 

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1816,13 +1816,6 @@
         "branch": "main"
     },
     {
-        "id": "plugin-changelogs",
-        "name": "Plugin Changelogs",
-        "author": "phibr0",
-        "description": "Read Plugin Changelogs inside Obsidian",
-        "repo": "phibr0/obsidian-plugin-changelogs"
-    },
-    {
         "id": "advanced-toolbar",
         "name": "Advanced Mobile Toolbar",
         "author": "phibr0",
@@ -1960,13 +1953,6 @@
         "description": "Add description, summary and more info to folders with folder notes.",
         "author": "AidenLx",
         "repo": "aidenlx/alx-folder-note"
-    },
-    {
-        "id": "macro-plugin",
-        "name": "Macros",
-        "author": "phibr0",
-        "description": "Group multiple Commands into one Macro and set delays.",
-        "repo": "phibr0/obsidian-macros"
     },
     {
         "id": "obsidian-hide-sidebars-when-narrow",


### PR DESCRIPTION
- Plugin changelogs is not functional anymore, and I don't have the time to maintain that many plugins anyway
- The Macros plugin has many bugs and a really small feature set, I plan to add a more powerful version of it to [Commander](https://github.com/phibr0/obsidian-commander) in the near future.