### PR TITLE
Plugin name changed - "Text Expander JS" to "Inline Scripts"

### DIFF
--- a/community-plugin-stats.json
+++ b/community-plugin-stats.json
@@ -10400,7 +10400,7 @@
     "1.0.4": 478,
     "1.0.5": 422
   },
-  "obsidian-inline-scripts": {
+  "obsidian-text-expander-js": {
     "0.18.0": 19,
     "0.16.2": 1,
     "0.15.1": 1,

--- a/community-plugin-stats.json
+++ b/community-plugin-stats.json
@@ -10400,7 +10400,7 @@
     "1.0.4": 478,
     "1.0.5": 422
   },
-  "obsidian-text-expander-js": {
+  "obsidian-inline-scripts": {
     "0.18.0": 19,
     "0.16.2": 1,
     "0.15.1": 1,

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4501,11 +4501,11 @@
         "branch": "main"
     },
     {
-        "id": "obsidian-text-expander-js",
-        "name": "Text Expander JS",
+        "id": "obsidian-inline-scripts",
+        "name": "Inline Scripts",
         "author": "Jonathan Heard",
-        "description": "Type text shortcuts that expand into javascript generated text.",
-        "repo": "jon-heard/obsidian-text-expander-js"
+        "description": "Type text shortcuts which are then replaced with JavaScript generated text.",
+        "repo": "jon-heard/obsidian-inline-scripts"
     },
     {
         "id": "metadata-menu",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4501,7 +4501,7 @@
         "branch": "main"
     },
     {
-        "id": "obsidian-inline-scripts",
+        "id": "obsidian-text-expander-js",
         "name": "Inline Scripts",
         "author": "Jonathan Heard",
         "description": "Type text shortcuts which are then replaced with JavaScript generated text.",


### PR DESCRIPTION
# I am submitting a rename of an existing Community Plugin

## Repo URL

Link to my plugin:
https://github.com/jon-heard/obsidian-inline-scripts

Link to the old plugin:
https://github.com/jon-heard/obsidian-text-expander-js