### PR TITLE
Add 'obsidian-magic-date-file' plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4543,5 +4543,12 @@
         "author": "Johnny✨ and phibr0",
         "description": "Customize your workspace by adding commands /everywhere/",
         "repo": "phibr0/obsidian-commander"
+    },
+    {
+        "id": "obsidian-magic-date-file",
+        "name": "Open File by Magic Date",
+        "author": "simplegy",
+        "description": "Define a hotkey and Moment.js pattern for the file that is most important to you (eg: your daily/weekly/monthly note).",
+        "repo": "simplegy/obsidian-magic-file-hotkey"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

https://github.com/SimplGy/obsidian-magic-file-hotkey

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
  - [x] I have given proper attribution to these other projects in my `README.md`.
