### PR TITLE
Add "Obsidian-Account-Linker" Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4580,5 +4580,12 @@
         "description": "A plugin for Obsidian that will highlight and focus on the currently selected heading",
         "repo": "nagi1999a/obsidian-focus-plugin",
         "branch": "master"
-    }
+    },
+    {
+        "id": "obsidian-account-linker",
+        "name": "Account Linker",
+        "author": "qwegat",
+        "description": "Plugin for describing external service accounts in the front matter",
+        "repo": "qwegat/Obsidian-Account-Linker",
+        "branch": "master"
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4588,4 +4588,5 @@
         "description": "Plugin for describing external service accounts in the front matter",
         "repo": "qwegat/Obsidian-Account-Linker",
         "branch": "master"
+    }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:https://github.com/qwegat/Obsidian-Account-Linker

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x]  The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
