### PR TITLE
Add URL Namer plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4987,5 +4987,13 @@
         "description": "This is a plugin for synchornizing Obsidian notes to other note-based softwares like Anki, following more strictly the principles of Zettelkasten and treating each Obsidian file as a note.",
         "repo": "tansongchen/obsidian-note-synchronizer",
         "branch": "master"
+    },
+    {
+        "id": "obsidian-url-namer",
+        "name": "URL Namer",
+        "author": "zfei",
+        "description": "This plugin retrieves the HTML titles to name the raw URL links.",
+        "repo": "https://github.com/zfei/obsidian-url-namer",
+        "branch": "master"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4993,7 +4993,7 @@
         "name": "URL Namer",
         "author": "zfei",
         "description": "This plugin retrieves the HTML titles to name the raw URL links.",
-        "repo": "https://github.com/zfei/obsidian-url-namer",
+        "repo": "zfei/obsidian-url-namer",
         "branch": "master"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4989,7 +4989,7 @@
         "branch": "master"
     },
     {
-        "id": "obsidian-url-namer",
+        "id": "url-namer",
         "name": "URL Namer",
         "author": "zfei",
         "description": "This plugin retrieves the HTML titles to name the raw URL links.",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/zfei/obsidian-url-namer

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
