### PR TITLE
Obsidian Git Mobile

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16,8 +16,8 @@
     {
         "id": "obsidian-git",
         "name": "Obsidian Git",
-        "author": "Denis Olehov",
-        "description": "Backup your vault with git.",
+        "author": "Vinzent, (Denis Olehov)",
+        "description": "Backup your vault with Git",
         "repo": "denolehov/obsidian-git"
     },
     {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4671,10 +4671,10 @@
     },
     {
         "id": "obsidian-git-isomorphic",
-        "name": "Obsidian Git Isomorphic",
+        "name": "Obsidian Git Mobile",
         "author": "Vinzent",
-        "description": "Backup your vault with Git on all devices.",
-        "repo": "Vinzent03/obsidian-git-isomorphic",
+        "description": "Backup your vault with Git on all devices",
+        "repo": "Vinzent03/obsidian-git-mobile",
         "branch": "main"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4668,5 +4668,13 @@
         "description": "Create folder of snippets to activate them in one click !",
         "repo": "Mara-Li/obsidian-group-snippets",
         "branch": "master"
+    },
+    {
+        "id": "obsidian-git-isomorphic",
+        "name": "Obsidian Git Isomorphic",
+        "author": "Vinzent",
+        "description": "Backup your vault with git on all devices.",
+        "repo": "Vinzent03/obsidian-git-isomorphic",
+        "branch": "main"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4668,13 +4668,5 @@
         "description": "Create folder of snippets to activate them in one click !",
         "repo": "Mara-Li/obsidian-group-snippets",
         "branch": "master"
-    },
-    {
-        "id": "obsidian-git-isomorphic",
-        "name": "Obsidian Git Mobile",
-        "author": "Vinzent",
-        "description": "Backup your vault with Git on all devices",
-        "repo": "Vinzent03/obsidian-git-mobile",
-        "branch": "main"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4673,7 +4673,7 @@
         "id": "obsidian-git-isomorphic",
         "name": "Obsidian Git Isomorphic",
         "author": "Vinzent",
-        "description": "Backup your vault with git on all devices.",
+        "description": "Backup your vault with Git on all devices.",
         "repo": "Vinzent03/obsidian-git-isomorphic",
         "branch": "main"
     }


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Vinzent03/obsidian-git-mobile

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.

The code of this plugin lies in [obsidian-git](https://github.com/denolehov/obsidian-git). Since 1,5 years I'm the maintainer of the plugin. So I'm updating the author field of Obsidian Git.
The codebase works with two different git implementations. I'm removing the native git dependency in the [build process](https://github.com/Vinzent03/obsidian-git-mobile/blob/main/.github/workflows/main.yml) of this plugin. I haven't found a way to package node dependencies in a mobile version, so I have to create a whole new plugin entry.