### PR TITLE
ADD Plugin obsidian-markdown-file-suffix

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4668,5 +4668,15 @@
         "description": "Create folder of snippets to activate them in one click !",
         "repo": "Mara-Li/obsidian-group-snippets",
         "branch": "master"
+    },
+    {
+        "id": "obsidian-markdown-file-suffix",
+        "name": "Addional Markdown suffix (.mdx/.svx).",
+        "version": "1.0.0",
+        "minAppVersion": "0.10.12",
+        "description": "Use additional files like .mdx / .svx as if they were markdown.",
+        "author": "swissmation",
+        "authorUrl": "https://github.com/swissmation",
+        "isDesktopOnly": false
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4671,12 +4671,10 @@
     },
     {
         "id": "obsidian-markdown-file-suffix",
-        "name": "Addional Markdown suffix (.mdx/.svx).",
-        "version": "1.0.0",
-        "minAppVersion": "0.10.12",
-        "description": "Use additional files like .mdx / .svx as if they were markdown.",
+        "name": "More Markdown file suffix (.mdx/.svx).",
         "author": "swissmation",
-        "authorUrl": "https://github.com/swissmation",
-        "isDesktopOnly": false
+        "description": "Use additional files like .mdx / .svx as if they were markdown.",
+        "repo": "swissmation/obsidian-markdown-file-suffix",
+        "branch": "master"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4672,9 +4672,9 @@
     {
         "id": "obsidian-markdown-file-suffix",
         "name": "More Markdown file suffix (.mdx/.svx).",
-        "author": "swissmation",
+        "author": "swissmation.com",
         "description": "Use additional files like .mdx / .svx as if they were markdown.",
-        "repo": "swissmation/obsidian-markdown-file-suffix",
+        "repo": "git-no/obsidian-markdown-file-suffix",
         "branch": "master"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/swissmation/obsidian-markdown-file-suffix

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
