### PR TITLE
Remove obsidian-pikt plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2608,14 +2608,6 @@
         "repo": "fantasycalendar/obsidian-fantasy-calendar"
     },
     {
-        "id": "obsidian-pikt",
-        "name": "Pikt",
-        "description": "An obsidian plugin to render pikchr codeblocks ",
-        "author": "Arnau Siches",
-        "repo": "arnau/obsidian-pikt",
-        "branch": "main"
-    },
-    {
         "id": "improved-vimcursor",
         "name": "Improved VimCursor",
         "author": "hhhapz",


### PR DESCRIPTION
The Pikt plugin is no longer maintained.

Please switch to **Preview** and select one of the following links:

* [x] [Community Plugin](?template=plugin.md)
* [ ] [Community Theme](?template=theme.md)
