### PR TITLE
Add b0o/obsidian-embedded-note-paths

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4683,5 +4683,13 @@
         "description": "Enables dashing cursor that follows the page scroll",
         "repo": "9r0x/obsidian-dashing-cursor",
         "branch": "master"
+    },
+    {
+        "id": "obsidian-embedded-note-paths",
+        "name": "Embedded Note Paths",
+        "author": "b0o",
+        "description": "Inserts the note file path above each note.",
+        "repo": "b0o/obsidian-embedded-note-paths",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/b0o/obsidian-embedded-note-paths/

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
