### PR TITLE
Change repo (link) of Tressel Sync for Obsidian plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2966,7 +2966,7 @@
         "name": "Tressel Sync for Obsidian",
         "description": "Official Tressel plugin to sync/export your tweets and threads into Obsidian",
         "author": "Tressel",
-        "repo": "aseem-thakar/obsidian-tressel"
+        "repo": "tresselteam/obsidian-tressel"
     },
     {
         "id": "image-window",


### PR DESCRIPTION
I changed the repo of my existing plugin (under this account) to the new team account (@tresselteam)