### PR TITLE
Add obsidian-day-and-night to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4660,5 +4660,13 @@
         "description": "Create folder of snippets to activate them in one click !",
         "repo": "Mara-Li/obsidian-group-snippets",
         "branch": "master"
+    },
+    {
+        "id": "obsidian-day-and-night",
+        "name": "Day and Night",
+        "author": "Kevin Patel",
+        "description": "An Obsidian plugin to automatically toggle themes between day theme and night theme on a set time schedule.",
+        "repo": "CyberT17/obsidian-day-and-night",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/CyberT17/obsidian-day-and-night

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
