### PR TITLE
Remove obsidian-deep-work-theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -475,14 +475,6 @@
         "modes": ["dark"]
     },
     {
-        "name": "Deep Work",
-        "author": "nikbrunner",
-        "repo": "nikbrunner/obsidian-deep-work-theme",
-        "screenshot": "screenshot.png",
-        "modes": ["dark", "light"],
-        "legacy": true
-    },
-    {
         "name": "Blackbird",
         "author": "Ivan Chernov",
         "repo": "vanadium23/obsidian-blackbird-theme",


### PR DESCRIPTION
# I am ~~submitting~~ removing a Community Theme

## Repo URL

Link to my theme: [Obsidian Deep Work Theme](https://github.com/nikbrunner/obsidian-deep-work-theme)

## Explanation

Due to the new changes introduced for 0.16.0, I want to remove my Theme from the Community Themes List for the time being.
The new changes are very good, but I rather want to use my limited time for my [new original project](https://github.com/terra-theme), which will also include an Obsidian Theme, based on the new system.

I'd rather make a clean break and not let the project sit around untended.

