### PR TITLE
Update Link to Screenshot for SF

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -524,7 +524,7 @@
         "name": "Shimmering Focus",
         "author": "pseudometa",
         "repo": "chrisgrieser/shimmering-focus",
-        "screenshot": "docs/images/Promo%20Screenshot/promo-screenshot.png",
+        "screenshot": "assets/promo-screenshot.png",
         "modes": ["dark", "light"],
         "legacy": true
     },


### PR DESCRIPTION
(I had to re-organize the theme repo due to 0.16, breaking the promo screenshot link)