### PR TITLE
remove `legacy` from Shimmering Focus

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -525,8 +525,7 @@
         "author": "pseudometa",
         "repo": "chrisgrieser/shimmering-focus",
         "screenshot": "assets/promo-screenshot.png",
-        "modes": ["dark", "light"],
-        "legacy": true
+        "modes": ["dark", "light"]
     },
     {
         "name": "Firefly",


### PR DESCRIPTION
Shimmering Focus is now usable in Insider 0.16. 
(For those coming from Discord: A lot of Style Settings are still missing though)

- Screenshot is updated to the new requested format
- `manifest.json` added
- docs consolidated into the README.md for new theme browser