### PR TITLE
Add "Blockquote Levels" plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4831,5 +4831,13 @@
         "description": "Adds a button to the search view for copying the Obsidian search URL.",
         "repo": "czottmann/obsidian-copy-search-url",
         "branch": "main"
-    }
+     },
+     {
+        "id": "blockquote-levels",
+        "name": "Blockquote Levels",
+        "author": "Carlo Zottmann",
+        "description": "Adds commands for increasing/decreasing the blockquote level of the current line or selection(s).",
+        "repo": "czottmann/obsidian-blockquote-levels",
+        "branch": "master"
+     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/czottmann/obsidian-blockquote-levels

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
