### PR TITLE
Remove legacy status from Dracula Official

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -742,11 +742,10 @@
     },
     {
         "name": "Dracula Official",
-        "author": "Zeno Rocha & Andy Byers",
+        "author": "Dracula",
         "repo": "dracula/obsidian",
         "screenshot": "screenshot.png",
-        "modes": ["dark"],
-        "legacy": true
+        "modes": ["dark"]
     },
     {
         "name": "Nebula",


### PR DESCRIPTION
# I am updating an existing Community Theme for 0.16 compatibility

## Repo URL

Link to my theme: 
https://github.com/dracula/obsidian

## Theme checklist

- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `obsidian.css` / `theme.css`
  - [x] The screenshot file.
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using.
      I have given proper attribution to these other themes in my `README.md`.
