### PR TITLE
Changed name of Google Tasks plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3890,7 +3890,7 @@
     },
     {
         "id": "obsidian-google-tasks",
-        "name": "Obsidian Google Tasks",
+        "name": "Google Tasks",
         "author": "YukiGasai",
         "description": "Interact with your Google Tasks from inside Obsidian",
         "repo": "YukiGasai/obsidian-google-tasks"


### PR DESCRIPTION
# I changed the name of my plugin

I want to change the name of my plugin to remove useless text and make it more visible when searching.

