### PR TITLE
remove page header button plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2806,14 +2806,6 @@
         "repo": "twentytwokhz/language-translator"
     },
     {
-        "id": "customizable-page-header-buttons",
-        "name": "Customizable Page Header and Title Bar",
-        "description": "Add buttons for executing commands to the page header and the title bar (on desktop).",
-        "author": "kometenstaub",
-        "repo": "kometenstaub/customizable-page-header-buttons",
-        "branch": "main"
-    },
-    {
         "id": "auto-class",
         "name": "Auto Class",
         "description": "Automatically apply CSS classes to markdown views based on a note's path.",


### PR DESCRIPTION
Most of the functionality is implemented by the Commander plugin.

And @pjeby has implemented history counts with the native tab title bar buttons in Pane Relief. Since Obsidian version 0.16 isn’t public yet, I think it makes sense to merge this commit once 0.16 goes public.