### PR TITLE
Add obsidian-capitalize-my-titles

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4854,5 +4854,13 @@
         "description": "Plugin to automatically update to system theme.",
         "repo": "jgauth/obsidian-system-theme",
         "branch": "master"
+    },
+    {
+        "id": "obsidian-capitalize-my-titles",
+        "name": "Capitalize My Titles",
+        "author": "Josselin ENET",
+        "description": "Automatically capitalizes titles in Markdown files.",
+        "repo": "joss-enet/obsidian-capitalize-my-titles",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/joss-enet/obsidian-capitalize-my-titles

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
