### PR TITLE
Add 'obsidian-reveal-file-in-navigation' plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4909,5 +4909,13 @@
         "author": "Akos Balasko",
         "repo": "akosbalasko/Onyx-Boox-Annotation-Highlight-Extractor",
 		    "branch": "master"
+    },
+    {
+        "id": "obsidian-reveal-file-in-navigation",
+        "name": "obsidian plugin for reveal file in navigation",
+        "author": "mistj",
+        "description": "This plugin provides a button to locate the currently active file in the side navigation.",
+        "repo": "tyrad/obsidian-reveal-file-in-navigation",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/tyrad/obsidian-reveal-file-in-navigation

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
