### PR TITLE
Remove legacy status from Dark Moss

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -429,8 +429,7 @@
         "author": "sergey",
         "repo": "sergey900553/obsidian_githublike_theme",
         "screenshot": "screenshot.png",
-        "modes": ["dark"],
-        "legacy": true
+        "modes": ["dark"]
     },
     {
         "name": "Mammoth",


### PR DESCRIPTION
# Repo URL
https://github.com/sergey900553/obsidian_githublike_theme
# Theme checklist
- Screenshot is updated 
- `manifest.json` added
- updated readme
- added `theme.css`
- added LICENSE file
