### PR TITLE
Remove legacy status from Typewriter

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -722,8 +722,7 @@
         "author": "crashmoney",
         "repo": "crashmoney/obsidian-typewriter",
         "screenshot": "cover.jpg",
-        "modes": ["dark", "light"],
-        "legacy": true
+        "modes": ["dark", "light"]
     },
     {
         "name": "WilcoxOne",


### PR DESCRIPTION
<!--- Delete this section if submitting a plugin -->
# I am submitting a new Community Theme

## Repo URL


Link to my theme: https://github.com/crashmoney/obsidian-typewriter


## Theme checklist

- [x] Add `manifest.json`
- [x] Add `theme.css`
- [x] Add `LICENSE` file