### PR TITLE
Add Old Note Admonitor plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4901,5 +4901,13 @@
         "author": "Akos Balasko",
         "repo": "akosbalasko/Onyx-Boox-Annotation-Highlight-Extractor",
 		    "branch": "master"
+    },
+    {
+        "id": "obsidian-old-note-admonitor",
+        "name": "Old Note Admonitor",
+        "description": "This Obsidian plugin shows warnings if the note has not been updated for over specific days",
+        "author": "tadashi-aikawa",
+        "repo": "tadashi-aikawa/obsidian-old-note-admonitor",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

https://github.com/tadashi-aikawa/obsidian-old-note-admonitor

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
