### PR TITLE
Add Dayspring to community themes

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -949,5 +949,12 @@
         "repo": "luke-rmaki/silence-obsidian",
         "screenshot": "Screenshot.png",
         "modes": ["dark"]
+    },
+    {
+        "name": "Dayspring",
+        "author": "Eric Rykwalder",
+        "repo": "erykwalder/dayspring-theme",
+        "screenshot": "screenshots/thumbnail.png",
+        "modes": ["light"]
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Theme

## Repo URL

Link to my theme:  https://github.com/erykwalder/dayspring-theme

## Theme checklist

- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `theme.css`
  - [x] The screenshot file: `screenshots/thumbnail.png`
  - [x] `manifest.json`
- [x] I have indicated which modes (dark, **light**, or both) are compatible with my theme.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using.
      I have given proper attribution to these other themes in my `README.md`.
