### PR TITLE
Update Novel Word Count description

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3659,7 +3659,7 @@
         "id": "novel-word-count",
         "name": "Novel Word Count",
         "author": "Isaac Lyman",
-        "description": "Displays a word or page count for each file, folder and vault in the File Explorer pane.",
+        "description": "Displays a word count, page count, creation date, or other statistic for each file, folder and vault in the File Explorer pane.",
         "repo": "isaaclyman/novel-word-count-obsidian"
     },
     {


### PR DESCRIPTION
# I am updating the description of a Community Plugin

Link to my plugin: https://github.com/isaaclyman/novel-word-count-obsidian

I promise not to do this often. Following a number of community requests, the scope of my plugin has increased significantly and the old description doesn't summarize it well any more. I've updated the wording.