### PR TITLE
Update community-css-themes.json

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -799,10 +799,9 @@
     {
         "name": "Catppuccin",
         "author": "Marshall Beckrich",
-        "repo": "mbeckrich/obsidian",
+        "repo": "catppuccin/obsidian",
         "screenshot": "assets/screenshot.png",
-        "modes": ["dark"],
-        "legacy": true
+        "modes": ["dark", "light"]
     },
     {
         "name": "Theme-That-Shall-Not-Be-Named",


### PR DESCRIPTION
Removing Catppuccin's legacy status with a 1.0.0 compatible update

<!--- Delete this section if submitting a plugin -->
# I am submitting a new Community Theme

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my theme: [https://github.com/catppuccin/obsidian](https://github.com/catppuccin/obsidian)


## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `obsidian.css`
  - [x] The screenshot file.
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using.
      I have given proper attribution to these other themes in my `README.md`.
