### PR TITLE
changed description of my plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3832,7 +3832,7 @@
         "id": "obsidian-doubleshift",
         "name": "Doubleshift",
         "author": "Qwyntex",
-        "description": "Open the command palette by pressing Double Shift like in IntelliJ",
+        "description": "Open the command palette by pressing Shift (or any other key) twice like in IntelliJ and create your own shortcuts",
         "repo": "qwyntex/doubleshift"
     },
     {


### PR DESCRIPTION
# changing description of my Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:
[Doubleshift](https://github.com/Qwyntex/doubleshift)
## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
