### PR TITLE
Updating Red Graphite

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -111,9 +111,8 @@
         "name": "Red Graphite",
         "author": "SeanWcom",
         "repo": "seanwcom/Red-Graphite-for-Obsidian",
-        "screenshot": "screenshot01.png",
-        "modes": ["dark", "light"],
-        "legacy": true
+        "screenshot": "thumbnail.png",
+        "modes": ["dark", "light"]
     },
     {
         "name": "Subtlegold",


### PR DESCRIPTION
Red Graphite has been updated to work with Obsidian 1.0.

https://github.com/seanwcom/Red-Graphite-for-Obsidian