### PR TITLE
Add link heading range

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5057,5 +5057,13 @@
         "author": "Marcus Olsson",
         "repo": "marcusolsson/obsidian-projects",
         "branch": "main"
-    }
+    },
+    {
+        "id": "link-heaeding-range",
+        "name": "Link Heading Range",
+        "description": "Link to heading range using the extended wikilink syntax [[Page#HeaderA#HeaderB]].",
+        "author": "Limezy, for Anthropologie Biblique",
+        "repo": "AnthropologieBiblique/link-heading-range",
+        "branch": "main"
+    }   
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5062,7 +5062,7 @@
         "id": "link-heading-range",
         "name": "Link Heading Range",
         "description": "Link to heading range using the extended wikilink syntax [[Page#HeaderA#HeaderB]].",
-        "author": "Limezy",
+        "author": "AnthropologieBiblique",
         "repo": "AnthropologieBiblique/link-heading-range",
         "branch": "main"
     }   

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5062,7 +5062,7 @@
         "id": "link-heading-range",
         "name": "Link Heading Range",
         "description": "Link to heading range using the extended wikilink syntax [[Page#HeaderA#HeaderB]].",
-        "author": "Limezy, for Anthropologie Biblique",
+        "author": "Limezy",
         "repo": "AnthropologieBiblique/link-heading-range",
         "branch": "main"
     }   

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5059,7 +5059,7 @@
         "branch": "main"
     },
     {
-        "id": "link-heaeding-range",
+        "id": "link-heading-range",
         "name": "Link Heading Range",
         "description": "Link to heading range using the extended wikilink syntax [[Page#HeaderA#HeaderB]].",
         "author": "Limezy, for Anthropologie Biblique",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/AnthropologieBiblique/link-heading-range

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
