### PR TITLE
updating the plugin description and location

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -328,10 +328,10 @@
     },
     {
         "id": "music-code-blocks",
-        "name": "Music Sheet Code Blocks",
+        "name": "ABC Music Sheet Code Blocks",
         "author": "Til Blechschmidt",
-        "description": "Render music sheets directly from code blocks",
-        "repo": "TilBlechschmidt/obsidian-plugin-abcjs"
+        "description": "Render music sheets directly from code blocks using ABC music notation via abcjs",
+        "repo": "abcjs-music/obsidian-plugin-abcjs"
     },
     {
         "id": "cm-typewriter-scroll-obsidian",


### PR DESCRIPTION
# I am submitting an update to a Community Plugin

## Repo URL

Link to my plugin: https://github.com/abcjs-music/obsidian-plugin-abcjs
The plugin has been transferred to abcjs-music organization. The original location https://github.com/TilBlechschmidt/obsidian-plugin-abcjs redirects to the new URL.

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [ ] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [ ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ ] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
