### PR TITLE
Make capitalisation of Quorafind match earlier lower-case uses.

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4877,7 +4877,7 @@
         "name": "Sakana Widget",
         "author": "Boninall",
         "description": "Add the Sakana! Widget to your own Obsidian!",
-        "repo": "Quorafind/obsidian-sakana-widget",
+        "repo": "quorafind/obsidian-sakana-widget",
         "branch": "master"
     },
     {


### PR DESCRIPTION
This is an edit to an existing line in `community-plugins.json`

The change is:

```diff
- "repo": "Quorafind/obsidian-sakana-widget",
+ "repo": "quorafind/obsidian-sakana-widget",
```

This is a workaround for a limitation in the Hub Python code. See https://github.com/obsidian-community/obsidian-hub/issues/308

It makes the capitalisation of `quorafind` consistent throughout the community release files.

/CC @Quorafind for info.

