### PR TITLE
add Split Pane View Helper plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5333,5 +5333,13 @@
         "author": "mvdkwast",
         "repo": "mvdkwast/obsidian-copy-as-html",
         "branch": "master"
+    },
+    {
+        "id": "obsidian-split-pane-view",
+        "name": "Split Pane View Helper",
+        "description": "Quickly open a split source/preview view via hotkey or toolbar",
+        "author": "luckman212",
+        "repo": "luckman212/obsidian-split-pane-view",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/luckman212/obsidian-split-pane-view

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android
  - [ ]  iOS
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css`
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
- [x] I have given proper attribution to these other projects in my `README.md`.
