### PR TITLE
Enable Solarized theme for v1.0.0

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -73,11 +73,10 @@
     },
     {
         "name": "Solarized",
-        "author": "Slowbad",
+        "author": "harmtemolder",
         "repo": "Slowbad/obsidian-solarized",
         "screenshot": "screenshot.png",
-        "modes": ["dark", "light"],
-        "legacy": true
+        "modes": ["dark", "light"]
     },
     {
         "name": "Comfort color dark",

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -74,7 +74,7 @@
     {
         "name": "Solarized",
         "author": "harmtemolder",
-        "repo": "Slowbad/obsidian-solarized",
+        "repo": "harmtemolder/obsidian-solarized",
         "screenshot": "screenshot.png",
         "modes": ["dark", "light"]
     },


### PR DESCRIPTION
I am submitting an update to my theme, enabling it for v1.0.0 according to [1.0 Theme Migration Guide](https://forum.obsidian.md/t/1-0-theme-migration-guide/42537).

Link to my theme: https://github.com/Slowbad/obsidian-solarized
