### PR TITLE
Update community-plugins.json for Obsidian-equationAutoTagAndReference

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5355,5 +5355,13 @@
         "author": "Sean Quinlan",
         "description": "This is a plugin for Obsidian that adds support for handlebars template blocks in notes.",
         "repo": "sbquinlan/obsidian-handlebars"
+    },
+    {
+        "id": "obsidian-equationAutoTagAndReference"
+        "name": "auto-Tag & Ref",
+        "author": "Luessiaw",
+        "description": "This is a plugin for auto eqution numbering and reference"
+        "repo": "Luessiaw/obsidian-equationAutoTagAndReference",
+        "branch": "master"
     }
 ]


### PR DESCRIPTION
Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
