### PR TITLE
Make capitalisation of quorafind match earlier lower-case uses.

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5499,7 +5499,7 @@
         "name": "Double Click Tab",
         "author": "Boninall",
         "description": "A plugin to modify the default behavior when you double click on the tab title, like close tab.",
-        "repo": "Quorafind/Obsidian-Double-Click-Tab",
+        "repo": "quorafind/Obsidian-Double-Click-Tab",
         "branch": "master"
     },
     {


### PR DESCRIPTION
This is an edit to an existing plugin. It is needed to work around a limitation of the Obsidian Hub Python code.

See earlier https://github.com/obsidianmd/obsidian-releases/pull/1328 for more information.