### PR TITLE
add obsidian-paste-as-html plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5532,5 +5532,13 @@
         "description": "Numerals turns any code block into an advanced calculator. Evaluates math expressions on each line of a code block, including units, currency, and optional TeX rendering",
         "repo": "gtg922r/obsidian-numerals",
         "branch": "master"
+    },
+    {
+        "id": "obsidian-paste-as-html",
+        "name": "Paste As Html",
+        "author": "maotong06",
+        "description": "Paste As Html, Keep the original css style. Paste from web browser",
+        "repo": "maotong06/obsidian-paste-as-html-plugin",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
 # I am submitting a new Community Plugin
 ## Repo URL
 Link to my plugin: https://github.com/maotong06/obsidian-paste-as-html-plugin
 
 ## Release Checklist
 * [x]  I have tested the plugin on
   
   * [x]   Windows
   * [x]   macOS
   * [x]   Linux
 * [x]  My GitHub release contains all required files
   
   * [x]  `main.js`
   * [x]  `manifest.json`
 * [x]  GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
 * [x]  The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
 * [x]  My README.md describes the plugin's purpose and provides clear usage instructions.
 * [x]  I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
 * [x]  I have added a license in the LICENSE file.
 * [x]  My project respects and is compatible with the original license of any code from other plugins that I'm using.
   I have given proper attribution to these other projects in my `README.md`.

