### PR TITLE
add plugin obsidian-disable-plugin-temporarily

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5556,5 +5556,13 @@
         "author": "MAKE.md",
         "repo": "Make-md/makemd",
         "branch": "main"
+    },
+    {
+        "id": "obsidian-disable-plugin-temporarily",
+        "name": "Disable Plugin Temporarily",
+        "description": "Disable all plugin temporarily",
+        "author": "DuocNV",
+        "repo": "nguyenvanduocit/obsidian-disable-plugin-temporarily",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: [repo](https://github.com/nguyenvanduocit/obsidian-disable-plugin-temporarily)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.