### PR TITLE
Update name of plugin from "Paste to Current Indentation" to "Paste Mode"

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1772,10 +1772,10 @@
     },
     {
         "id": "obsidian-paste-to-current-indentation",
-        "name": "Paste to Current Indentation",
+        "name": "Paste to Mode",
         "author": "Jacob Levernier",
-        "description": "This plugin allows pasting and marking text as block-quotes at any level of indentation.",
-        "repo": "jglev/obsidian-paste-to-current-indentation"
+        "description": "Paste content and mark block quotes at any level of indentation.",
+        "repo": "jglev/obsidian-paste-mode"
     },
     {
         "id": "obsimian-exporter",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1772,7 +1772,7 @@
     },
     {
         "id": "obsidian-paste-to-current-indentation",
-        "name": "Paste to Mode",
+        "name": "Paste Mode",
         "author": "Jacob Levernier",
         "description": "Paste content and mark block quotes at any level of indentation.",
         "repo": "jglev/obsidian-paste-mode"


### PR DESCRIPTION
# I am updating an existing Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/jglev/obsidian-paste-mode

The "Paste to Current Indentation" has been listed as a community plugin for some time, but has grown in functionality over several releases. With this in mind, I would like to rename the plugin to "Paste Mode."