### PR TITLE
Add "Boost Link Suggestions" plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5881,6 +5881,13 @@
         "author": "dartungar",
         "description": "Improved Mermaid.js experience for Obsidian: visual toolbar with common elements & more",
         "repo": "dartungar/obsidian-mermaid"
+    },
+    {
+        "id": "boost-link-suggestions",
+        "name": "Boost Link Suggestions",
+        "author": "Jacob Levernier",
+        "description": "Alternative inline link suggester that orders results by link count and manual boosts.",
+        "repo": "jglev/obsidian-boost-link-suggestions"
     }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/jglev/obsidian-boost-link-suggestions

_(This plugin follows [this thread](https://discord.com/channels/686053708261228577/716028884885307432/1053860523646656563) in Discord.)_

## Release Checklist
- [X] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [X]  Linux
  - [X]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
