### PR TITLE
Added Visually Numbered Headings plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5563,5 +5563,13 @@
         "description": "This is a markdown export plugin for Obsidian.",
         "author": "bingryan",
         "repo": "bingryan/obsidian-markdown-export-plugin"
+    },
+    {
+        "id": "obsidian-visually-numbered-headings",
+        "name": "Visually Numbered Headings",
+        "description": "Heading numbering without modifying your files.",
+        "author": "Platon Ivanov",
+        "repo": "platon-ivanov/obsidian-visually-numbered-headings",
+	"branch": "master"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: [https://github.com/platon-ivanov/obsidian-releases-visually-numbered-headings](https://github.com/platon-ivanov/obsidian-releases-visually-numbered-headings)

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
