### PR TITLE
Fix typo in obsidian-structured-plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2848,7 +2848,7 @@
         "name": "Structured Plugin",
         "description": "Structured plugin. Create hierarchy in notes using \".\"",
         "author": "dobrovolsky",
-        "repo": "dobrovolsky/obsidain-structure"
+        "repo": "dobrovolsky/obsidian-structure"
     },
     {
         "id": "cooklang-obsidian",


### PR DESCRIPTION
Fix typo in repo name
