### PR TITLE
Add "Obsidian Antidote Plugin"

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5881,6 +5881,13 @@
         "author": "dartungar",
         "description": "Improved Mermaid.js experience for Obsidian: visual toolbar with common elements & more",
         "repo": "dartungar/obsidian-mermaid"
+    },
+    {
+        "id": "obsidian-antidote-plugin",
+        "name": "Antidote Plugin",
+        "author": "Samuel Martineau",
+        "description": "This is a plugin that integrates Antidote with Obsidian",
+        "repo": "Samuel-Martineau/obsidian-antidote-plugin"
     }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [Samuel-Martineau/obsidian-antidote-plugin](https://github.com/Samuel-Martineau/obsidian-antidote-plugin) 

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
