### PR TITLE
Add "dark" as a mode for Wikipedia Theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1098,7 +1098,7 @@
         "author": "Ha'ani Whitlock",
         "repo": "Bluemoondragon07/Wikipedia-Theme",
         "screenshot": "example.png",
-        "modes": ["light"],
+        "modes": ["dark", "light"],
         "branch": "main" 
     },
     {


### PR DESCRIPTION
I updated the theme a few days ago to support dark mode, so I added "dark" as a mode for it.
