### PR TITLE
Add "folder-notes" plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5881,6 +5881,14 @@
         "author": "dartungar",
         "description": "Improved Mermaid.js experience for Obsidian: visual toolbar with common elements & more",
         "repo": "dartungar/obsidian-mermaid"
+    },
+    {
+        "id": "folder-notes",
+        "name": "Folder Notes",
+        "author": "Alan Grainger",
+        "description": "Adds Folder Notes to the default Obsidian file tree.",
+        "repo": "alangrainger/obsidian-folder-notes",
+        "branch": "main"
     }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/alangrainger/obsidian-folder-notes

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
- [x] I have given proper attribution to these other projects in my `README.md`.
