### PR TITLE
Add Graph Search Hotkey plugin to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,13 @@
 [
     {
+        "id": "obsidian-graph-search-hotkey",
+        "name": "Graph Search Hotkey",
+        "author": "Johannes Geisler",
+        "description": "This is a simple plugin so you can set a hotkey to switch to the search bar in the Graph view. It is Alt+f as a default.",
+        "repo": "AstralTomate/obsidian-graph-search-hotkey",
+        "branch": "main"
+    },
+    {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
         "author": "Argentina Ortega Sainz",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,13 +1,5 @@
 [
     {
-        "id": "obsidian-graph-search-hotkey",
-        "name": "Graph Search Hotkey",
-        "author": "Johannes Geisler",
-        "description": "This is a simple plugin so you can set a hotkey to switch to the search bar in the Graph view. It is Alt+f as a default.",
-        "repo": "AstralTomate/obsidian-graph-search-hotkey",
-        "branch": "main"
-    },
-    {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
         "author": "Argentina Ortega Sainz",
@@ -6033,6 +6025,14 @@
         "description": "Enables justified text and hyphenation",
         "author": "7596ff",
         "repo": "7596ff/obsidian-hyphenation",
+        "branch": "main"
+    },
+    {
+        "id": "obsidian-graph-search-hotkey",
+        "name": "Graph Search Hotkey",
+        "author": "Johannes Geisler",
+        "description": "This is a simple plugin so you can set a hotkey to switch to the search bar in the Graph view. It is Alt+f as a default.",
+        "repo": "AstralTomate/obsidian-graph-search-hotkey",
         "branch": "main"
     }
 ]


### PR DESCRIPTION
Add a plugin to set a hotkey for the search field in the graph view.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/AstralTomate/obsidian-graph-search-hotkey

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
