### PR TITLE
update name of existing plugin `cm-chs-patch`

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1134,7 +1134,7 @@
     },
     {
         "id": "cm-chs-patch",
-        "name": "Word Splitting for Simplified Chinese in Edit Mode",
+        "name": "Word Splitting for Simplified Chinese in Edit Mode and Vim Mode",
         "author": "AidenLx",
         "description": "A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting",
         "repo": "aidenlx/cm-chs-patch",


### PR DESCRIPTION
rename plugin with id `cm-chs-patch` from `Word Splitting for Simplified Chinese in Edit Mode` to `Word Splitting for Simplified Chinese in Edit Mode and Vim Mode`