### PR TITLE
Adds Backslash LaTeX Macro Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5796,5 +5796,12 @@
         "author": "Michael Hansen",
         "description": "Render NPC and adversary statblocks for The One Ring 2E roleplaying game.",
         "repo": "modality/obsidian-the-one-ring-2e-statblocks"
+    },
+    {
+        "id": "backslash-latex-macro",
+        "name": "Backslash LaTeX Macro",
+        "author": "Bjarno Oeyen",
+        "description": "Replace LaTeX macros with (Unicode) characters. Inspired by DrRacket.",
+        "repo": "Bjarno/obsidian-backslash-latex",
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5802,6 +5802,6 @@
         "name": "Backslash LaTeX Macro",
         "author": "Bjarno Oeyen",
         "description": "Replace LaTeX macros with (Unicode) characters. Inspired by DrRacket.",
-        "repo": "Bjarno/obsidian-backslash-latex",
+        "repo": "Bjarno/obsidian-backslash-latex"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/Bjarno/obsidian-backslash-latex

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux -- will test later
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_ -- no `styles.css` present
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`. -- This plugin does not depend on any other plugin: only on Obsidian itself.