### PR TITLE
Update metacopy & Github Publisher description

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2563,8 +2563,8 @@
     },
     {
         "id": "obsidian-metacopy",
-        "name": "Metacopy",
-        "description": "Copy the value of a frontmatter key.",
+        "name": "Metacopy & URL",
+        "description": "Copy the value of a frontmatter key and create a link from it!",
         "author": "Mara-Li",
         "repo": "Lisandra-dev/obsidian-metacopy"
     },
@@ -3783,8 +3783,8 @@
         "id": "obsidian-mkdocs-publisher",
         "name": "Github Publisher",
         "author": "Mara-Li",
-        "description": "Github Publisher is a plugin that help you to send file in a configured Github Repository, based on a frontmatter entry state.",
-        "repo": "obsidianMkdocs/obsidian-github-publisher"
+        "description": "Github Publisher helps you to publish your notes on a preconfigured GitHub repository, for free, and more!",
+        "repo": "ObsidianPublisher/obsidian-github-publisher"
     },
     {
         "id": "obsidian-notion-video",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2564,7 +2564,7 @@
     {
         "id": "obsidian-metacopy",
         "name": "Metacopy & URL",
-        "description": "Copy the value of a frontmatter key and create a link from it!",
+        "description": "Copy the value of a frontmatter key and allows to create link from it using various settings.",
         "author": "Mara-Li",
         "repo": "Lisandra-dev/obsidian-metacopy"
     },


### PR DESCRIPTION
I changed : 
- The name and description of [Metacopy](https://github.com/Lisandra-dev/obsidian-metacopy/)
- The author of [Obsidian Github Publisher](https://github.com/ObsidianPublisher/obsidian-github-publisher), and the description of the plugin.

Thank you :D!