### PR TITLE
Add information that `manifest.json` is required for themes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/theme.md
+++ b/.github/PULL_REQUEST_TEMPLATE/theme.md
@@ -13,6 +13,7 @@ Link to my theme:
 - [ ] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
   - [ ] `theme.css`
   - [ ] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
+  - [ ] `manifest.json`
 - [ ] I have indicated which modes (dark, light, or both) are compatible with my theme.
 - [ ] I have added a license in the LICENSE file.
 - [ ] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.

--- a/.github/PULL_REQUEST_TEMPLATE/theme.md
+++ b/.github/PULL_REQUEST_TEMPLATE/theme.md
@@ -11,9 +11,9 @@ Link to my theme:
 
 <!--- Confirm that you have done the following before submitting your theme -->
 - [ ] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
+  - [ ] `manifest.json`
   - [ ] `theme.css`
   - [ ] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
-  - [ ] `manifest.json`
 - [ ] I have indicated which modes (dark, light, or both) are compatible with my theme.
 - [ ] I have added a license in the LICENSE file.
 - [ ] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.


### PR DESCRIPTION
Apparently, the `manifest.json` is required for themes to work, but it isn't listed as such here. see: https://discord.com/channels/686053708261228577/931552763467411487/1069862338162855986