### PR TITLE
update Royal Velvet theme (add light mode)

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -820,7 +820,7 @@
         "author": "caro401",
         "repo": "caro401/royal-velvet",
         "screenshot": "royal-velvet.png",
-        "modes": ["dark"]
+        "modes": ["dark", "light"]
     },
     {
         "name": "Aqua",


### PR DESCRIPTION
<!--- Delete this section if submitting a plugin -->
# Royal Velvet theme now supports light mode.

## Repo URL

Link to my theme: https://github.com/caro401/royal-velvet


## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `manifest.json`
  - [x] `theme.css`
  - [x] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.
