### PR TITLE
added git-sync to plugin list

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5862,7 +5862,7 @@
          "repo": "jvsteiner/s3-image-uploader"
     },
     {
-         "id": "git-sync-plugin",
+         "id": "git-sync",
          "name": "Git Sync",
          "description": "Sync your vault with Github.",
          "author": "oscarspalk",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5860,5 +5860,12 @@
          "description": "An image uploader for Obsidian that allows you to self host images on AWS S3.",
          "author": "jvsteiner",
          "repo": "jvsteiner/s3-image-uploader"
+    },
+    {
+         "id": "git-sync-plugin",
+         "name": "Git Sync",
+         "description": "Sync your vault with Github.",
+         "author": "oscarspalk",
+         "repo": "oscarspalk/obsidian-git-sync"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [git-sync](https://github.com/oscarspalk/obsidian-git-sync)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
