### PR TITLE
Renamed theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -887,9 +887,9 @@
         "modes": ["light"]
     },
     {
-        "name": "Red Solitude",
+        "name": "Solitude",
         "author": "MajorEnkidu",
-        "repo": "MajorEnkidu/red-solitude-obsidian-theme",
+        "repo": "MajorEnkidu/solitude-obsidian-theme",
         "screenshot": "promo_screenshot.png",
         "modes": ["dark"]
     },


### PR DESCRIPTION
I renamed the theme, in order to not confuse anyone. I somewhat recently gave the user the freedom to choose their own accent color, such that the theme isn't limited to the red accent color anymore.

<!--- Delete this section if submitting a plugin -->
# I am submitting a new Community Theme

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my theme: 
https://github.com/MajorEnkidu/solitude-obsidian-theme

## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `manifest.json`
  - [x] `theme.css`
  - [x] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.
