### PR TITLE
Remove Footnote indicator

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3241,13 +3241,6 @@
         "repo": "valentine195/obsidian-settings-search"
     },
     {
-        "id": "obsidian-footnote-indicator",
-        "name": "Footnote & Citation Indicator",
-        "author": "pseudometa",
-        "description": "Indicates the presence of footnotes in the gutter. Displays footnote and citation counts in the status bar.",
-        "repo": "chrisgrieser/obsidian-footnote-indicator"
-    },
-    {
         "id": "japanese-word-splitter",
         "name": "Word Splitting for Japanese in Edit Mode",
         "author": "sonarAIT",


### PR DESCRIPTION
[I added the functionality to the BetterWordCount plugin](url), since it offers much more customizability. As a result, the footnote indicator plugin has been essentially sherlocked by the plugin, so that it can be removed from the community store.

Plugin repo is also already archived.
