### PR TITLE
Remove Sidebar Toggler from the Community Store

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4327,13 +4327,6 @@
         "repo": "Oliver-Akins/file-hider"
     },
     {
-        "id": "obsidian-sidebar-toggler",
-        "name": "Sidebar Toggler",
-        "author": "pseudometa",
-        "description": "Finer control of the Obsidian sidebars. To be used with an external window manager.",
-        "repo": "chrisgrieser/obsidian-sidebar-toggler"
-    },
-    {
         "id": "obsidian-path-finder",
         "name": "Path Finder",
         "author": "jerrywcy",


### PR DESCRIPTION
With the new `eval` URI scheme from the Advanced URI plugin, this plugin's functionality can be achieved in a much more efficient and customizable manner, making this plugin pretty much obsolete: https://github.com/Vinzent03/obsidian-advanced-uri/issues/114
