### PR TITLE
Update plugin descriptions

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -846,7 +846,7 @@
     {
         "id": "obsidian-hotkeys-for-specific-files",
         "name": "Hotkeys for specific files",
-        "description": "Set hotkeys for specific files and open them just with your keyboard.",
+        "description": "Add commands for specific files and open them with a hotkey",
         "author": "Vinzent",
         "repo": "Vinzent03/obsidian-hotkeys-for-specific-files"
     },
@@ -1104,7 +1104,7 @@
     {
         "id": "obsidian-hotkeys-for-templates",
         "name": "Hotkeys for templates",
-        "description": "Add hotkeys to insert specific templates",
+        "description": "Add commands to insert specific templates with a hotkey",
         "author": "Vinzent",
         "repo": "Vinzent03/obsidian-hotkeys-for-templates"
     },
@@ -1126,8 +1126,8 @@
     },
     {
         "id": "obsidian-advanced-uri",
-        "name": "Advanced Obsidian URI",
-        "description": "Advanced modes for Obsidian URI",
+        "name": "Advanced URI",
+        "description": "Control everything in Obsidian with URI",
         "author": "Vinzent",
         "repo": "Vinzent03/obsidian-advanced-uri"
     },


### PR DESCRIPTION
I'm updating the description of 3 plugins and change the name of `Advanced Obsidian URI` to remove the unnecessary "Obsidian" phrase.