### PR TITLE
Update description for Double colon conceal plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5886,7 +5886,7 @@
     {
         "id": "double-colon-conceal",
         "name": "Double Colon Conceal",
-        "description": "Display double colon (i.e. Dataview inline fields) as a single colon in reading view (preview mode) for more natural experience.",
+        "description": "Display double colon (i.e. Dataview inline fields) as a single colon for more natural reading experience.",
         "author": "Michal Srch",
         "repo": "msrch/obsidian-double-colon-conceal"
     },


### PR DESCRIPTION
I am updating plugin description for "Double colon conceal" plugin due to latest changes - conceal works in editing view as well now.

Plugin: https://github.com/msrch/obsidian-double-colon-conceal