### PR TITLE
Add Obsidianotion theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1261,13 +1261,12 @@
         "repo": "Bluemoondragon07/obsidian-big-and-bold",
         "screenshot": "cover.png",
         "modes": ["dark", "light"]
-    }
+    },
     {
         "name": "Obsidianotion",
         "author": "Diego Eis",
         "repo": "diegoeis/obsidianotion",
         "screenshot": "cover.png",
-        "modes": ["dark", "light"],
-        "branch": "master"
+        "modes": ["dark", "light"]
     }
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1262,4 +1262,12 @@
         "screenshot": "cover.png",
         "modes": ["dark", "light"]
     }
+    {
+        "name": "Obsidianotion",
+        "author": "Diego Eis",
+        "repo": "diegoeis/obsidianotion",
+        "screenshot": "cover.png",
+        "modes": ["dark", "light"],
+        "branch": "master"
+    }
 ]


### PR DESCRIPTION
A theme to help people who are migrating from Notion. Could be used together with Make.md plugin or using other plugins like Banner.

* [Community Theme](?template=theme.md)

[Link to my theme](https://github.com/diegoeis/obsidianotion)
