### PR TITLE
Vault name in status bar (desktop only)

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6127,5 +6127,12 @@
         "author": "Mixa Team",
         "description": "Publish your notes and blog posts with Mixa directly from Obsidian",
         "repo": "mixasite/obsidian-mixa"
+    },
+    {
+        "id": "vault-name-status-bar",
+        "name": "Vault name in status bar",
+        "author": "1C0D",
+        "description": "See your vault name in the status bar.",
+        "repo": "1C0D/Obsidian-Vault-Name-in-Status-Bar"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [ x] I have tested the plugin on
  - [ x]  Windows
  - [x ]  macOS
  - [ x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x ] My GitHub release contains all required files
  - [x ] `main.js`
  - [ x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x ] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x ] I have added a license in the LICENSE file.
- [x ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
