### PR TITLE
Add Vault Chat plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6203,8 +6203,7 @@
         "name": "Vault Chat",
         "author": "Exo Ascension",
         "description": "A ChatGPT bot trained on your vault notes. Ask your AI questions about your own thoughts and ideas!",
-        "repo": "kristenbrann/vault-chat",
-        "branch": "main"
+        "repo": "kristenbrann/vault-chat"
     }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6203,7 +6203,7 @@
         "name": "Vault Chat",
         "author": "Exo Ascension",
         "description": "A ChatGPT bot trained on your vault notes. Ask your AI questions about your own thoughts and ideas!",
-        "repo": "exoascension/vault-chat",
+        "repo": "kristenbrann/vault-chat",
         "branch": "main"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6197,6 +6197,14 @@
         "description": "This plugin is emoji titler to easily insert an emoji in the title using a keyboard shortcut.",
         "author": "Hyeonseo Nam",
         "repo": "HyeonseoNam/obsidian-emoji-titler"
+    },
+    {
+        "id": "vault-chat",
+        "name": "Vault Chat",
+        "author": "Exo Ascension",
+        "description": "A ChatGPT bot trained on your vault notes. Ask your AI questions about your own thoughts and ideas!",
+        "repo": "exoascension/vault-chat",
+        "branch": "main"
     }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

This plugin is owned by an org, but the PR bot wouldn't allow me to use that repo url (https://github.com/exoascension/vault-chat) because it didn't match my user. So I've forked it for that purpose, but we would really prefer to use the org repo! Is that possible?

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/kristenbrann/vault-chat

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [n/a]  Android _(if applicable)_
  - [n/a]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
