### PR TITLE
New plugin to reveal file in explorer clicking title

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6218,6 +6218,13 @@
         "author": "Karthik S Raju",
         "description": "Enhanced highlights for Obsidian",
         "repo": "KarthikRaju391/obsidian-float"
+    },
+    {
+        "id": "show-file-in-explorer",
+        "name": "Show file in explorer",
+        "author": "Karthik S Raju",
+        "description": "Clicking header title reveal active file in explorer",
+        "repo": "1C0D/Obsidian-Show-File-in-explorer"
     }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6220,11 +6220,11 @@
         "repo": "KarthikRaju391/obsidian-float"
     },
     {
-        "id": "show-file-in-explorer",
-        "name": "Show file in explorer",
-        "author": "Karthik S Raju",
+        "id": "reveal-file-in-explorer",
+        "name": "Reveal file in explorer",
+        "author": "1C0D",
         "description": "Clicking header title reveal active file in explorer",
-        "repo": "1C0D/Obsidian-Show-File-in-explorer"
+        "repo": "1C0D/Obsidian-Reveal-File-in-explorer"
     }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [x ] I have tested the plugin on
  - [x ]  Windows
  - [ x]  macOS
  - [ x]  Linux
  - [ x]  Android _(if applicable)_
  - [ x]  iOS _(if applicable)_
- [x ] My GitHub release contains all required files
  - [x ] `main.js`
  - [ x] `manifest.json`
  - [x ] `styles.css` _(optional)_
- [ x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x ] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x ] I have added a license in the LICENSE file.
- [x ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
