### PR TITLE
Create Folgezettel Renaming plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -304,7 +304,7 @@
         "id": "folgezettel-renaming",
         "name": "Folgezettel Renaming",
         "author": "Next Day Games",
-        "description": "Display a list of recently opened files",
+        "description": "Rename `1a1 Medicine` to `3a1 Medicine` and all children of `1a1` will be renamed like so `3a1a Cardiology`.",
         "repo": "nextdaygames/folgezettel-renaming",
         "branch": "master"
     },

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -301,6 +301,14 @@
         "repo": "agathauy/wikilinks-to-mdlinks-obsidian"
     },
     {
+        "id": "folgezettel-renaming",
+        "name": "Folgezettel Renaming",
+        "author": "Next Day Games",
+        "description": "Display a list of recently opened files",
+        "repo": "nextdaygames/folgezettel-renaming",
+        "branch": "master"
+    },
+    {
         "id": "smart-random-note",
         "name": "Smart Random Note",
         "author": "Eric Hall",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6217,8 +6217,7 @@
         "name": "Folgezettel Renaming",
         "author": "Next Day Games",
         "description": "Rename `1a1 Medicine` to `3a1 Medicine` and all children of `1a1` will be renamed like so `3a1a Cardiology`.",
-        "repo": "nextdaygames/folgezettel-renaming",
-        "branch": "master"
+        "repo": "nextdaygames/folgezettel-renaming"
     }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -301,14 +301,6 @@
         "repo": "agathauy/wikilinks-to-mdlinks-obsidian"
     },
     {
-        "id": "folgezettel-renaming",
-        "name": "Folgezettel Renaming",
-        "author": "Next Day Games",
-        "description": "Rename `1a1 Medicine` to `3a1 Medicine` and all children of `1a1` will be renamed like so `3a1a Cardiology`.",
-        "repo": "nextdaygames/folgezettel-renaming",
-        "branch": "master"
-    },
-    {
         "id": "smart-random-note",
         "name": "Smart Random Note",
         "author": "Eric Hall",
@@ -6219,6 +6211,14 @@
         "author": "Karthik S Raju",
         "description": "Enhanced highlights for Obsidian",
         "repo": "KarthikRaju391/obsidian-float"
+    },
+    {
+        "id": "folgezettel-renaming",
+        "name": "Folgezettel Renaming",
+        "author": "Next Day Games",
+        "description": "Rename `1a1 Medicine` to `3a1 Medicine` and all children of `1a1` will be renamed like so `3a1a Cardiology`.",
+        "repo": "nextdaygames/folgezettel-renaming",
+        "branch": "master"
     }
 ]
 


### PR DESCRIPTION
Rename `1a1 Medicine` to `3a1 Medicine` and all children of `1a1` will be renamed like so `3a1a Cardiology`.

* [Community Plugin](?template=plugin.md)
