### PR TITLE
Added Askify to Community Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6211,6 +6211,13 @@
         "author": "Karthik S Raju",
         "description": "Enhanced highlights for Obsidian",
         "repo": "KarthikRaju391/obsidian-float"
+    },
+       {
+        "id": "askify-obsidian-sync-plugin",
+        "name": "Askify Obsidian Sync",
+        "author": "Kishlay Raj",
+        "description": "A Plugin for syncing between Obsidian and Askify. ",
+        "repo": "helloworldkr/Askify-Obsidian-Sync"
     }
 ]
 


### PR DESCRIPTION
Added Askify to Community Plugin

# I am submitting a new Community Plugin

## Repo URL
https://github.com/helloworldkr/Askify-Obsidian-Sync

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: 
https://github.com/helloworldkr/Askify-Obsidian-Sync

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
