### PR TITLE
feat: add proper-dark theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1332,5 +1332,12 @@
         "repo": "ScottKirvan/GitHubDHC",
         "screenshot": "imgs/thumbnail.png",
         "modes": ["dark"]
+    },
+    {
+        "name": "Proper Dark",
+        "author": "Lukas Bach",
+        "repo": "lukasbach/obsidian-proper-dark",
+        "screenshot": "thumb.png",
+        "modes": ["dark", "light"]
     }
 ]


### PR DESCRIPTION
<!--- Delete this section if submitting a plugin -->
# I am submitting a new Community Theme

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my theme: https://github.com/lukasbach/obsidian-proper-dark


## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `manifest.json`
  - [x] `theme.css`
  - [x] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.
