### PR TITLE
Bring back Kindle Highlights plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6211,6 +6211,13 @@
         "author": "Karthik S Raju",
         "description": "Enhanced highlights for Obsidian",
         "repo": "KarthikRaju391/obsidian-float"
+    },
+    {
+        "id": "obsidian-kindle-plugin",
+        "name": "Kindle Highlights",
+        "description": "Sync your Kindle book highlights",
+        "author": "Hady Osman",
+        "repo": "hadynz/obsidian-kindle-plugin"
     }
 ]
 


### PR DESCRIPTION
The Kindle Highlights plugin was [delisted][1] because it had built in Sentry tracking for errors.

Sentry tracking has now been [removed][2] to adhere to Obsidian's new data and privacy policy in version [1.9.0][3].

cc @joethei

[1]: https://github.com/obsidianmd/obsidian-releases/commit/487ac5de20f24a8b210baacc71a67c2b4d98ba01#diff-3ce999c674f451146be9000351de965fbb63c3397f70991ad617d6e9e468e5b7
[2]: https://github.com/hadynz/obsidian-kindle-plugin/compare/1.8.1...1.9.0
[3]: https://github.com/hadynz/obsidian-kindle-plugin/releases/tag/1.9.0

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [ ] `main.js`
  - [ ] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
