### PR TITLE
Update description of Grappling Hook

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5894,7 +5894,7 @@
         "id": "grappling-hook",
         "name": "🪝 Grappling Hook",
         "author": "pseudometa",
-        "description": "Obsidian Plugin for blazingly fast file switching with starred files. For people for whom using the Quick Switcher still takes too much time.",
+        "description": "Obsidian Plugin for blazingly fast file switching to bookmarked files. For people for whom using the Quick Switcher still takes too much time.",
         "repo": "chrisgrieser/grappling-hook"
     },
     {


### PR DESCRIPTION
Since the new Obsidian release switches from starred notes to bookmarked notes, the plugin description has been adapted to reflect this change.

This is so users looking for plugins interacting with bookmarks will be able to find the plugin.
