### PR TITLE
Update name for Simple note quiz

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3137,10 +3137,10 @@
     },
     {
         "id": "simple-note-quiz",
-        "name": "Simple note quiz",
-        "author": "dorisxx",
+        "name": "Simple Note Quiz",
+        "author": "beginner137",
         "description": "Start a simple quiz on your current note.",
-        "repo": "dorisxx/Obsidian-simple-note-quiz"
+        "repo": "beginner137/Obsidian-simple-note-quiz"
     },
     {
         "id": "obsidian-local-rest-api",


### PR DESCRIPTION
Changed github username, and therefore need to update name for Simple note quiz

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
