### PR TITLE
Added Bulk open selected links

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6414,5 +6414,12 @@
         "author": "1C0D",
         "description": "toggle sidebars double-clicking middle mouse button or each sidebar clicking middle mouse button and moving mouse towards the corresponding sidebar.",
         "repo": "1C0D/obsidian-easy-toggle-sidebars"
+    },
+    {
+        "id": "bulkopen-selected-links",
+        "name": "Bulk open selected links",
+        "author": "Steven Jin",
+        "description": "This plugin allows users to easily open all selected links in edit mode.",
+        "repo": "autohub7/obsidian-open-selected-links"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin
## Repo URL
Link to my plugin: https://github.com/autohub7/obsidian-open-selected-links

## Release Checklist
* [x]  I have tested the plugin on
  * [x]   Windows
  * [x]   macOS
  * [ ]   Linux
  * [ ]   Android _(if applicable)_
  * [x]   iOS _(if applicable)_
* [x]  My GitHub release contains all required files
  * [x]  `main.js`
  * [x]  `manifest.json`
  * [ ]  `styles.css` _(optional)_
* [x]  GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
* [x]  The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
* [x]  My README.md describes the plugin's purpose and provides clear usage instructions.
* [x]  I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
* [x]  I have added a license in the LICENSE file.
* [x]  My project respects and is compatible with the original license of any code from other plugins that I'm using.
  I have given proper attribution to these other projects in my `README.md`.