### PR TITLE
Add Obsidian People Link plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3626,13 +3626,6 @@
         "repo": "juracy/obsidian-asciidoc-blocks"
     },
     {
-        "id": "obsidian-people-link",
-        "name": "Obsidian People Link",
-        "author": "Reorx",
-        "description": "Easily create links to people within your notes.",
-        "repo": "reorx/obsidian-people-link"
-    },
-    {
         "id": "fleeting-notes-obsidian",
         "name": "Fleeting Notes Sync",
         "author": "Matthew Wong",
@@ -6421,5 +6414,12 @@
         "author": "1C0D",
         "description": "toggle sidebars double-clicking middle mouse button or each sidebar clicking middle mouse button and moving mouse towards the corresponding sidebar.",
         "repo": "1C0D/obsidian-easy-toggle-sidebars"
+    },
+    {
+        "id": "obsidian-people-link",
+        "name": "Obsidian People Link",
+        "author": "Reorx",
+        "description": "Easily create links to people within your notes.",
+        "repo": "reorx/obsidian-people-link"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3626,6 +3626,13 @@
         "repo": "juracy/obsidian-asciidoc-blocks"
     },
     {
+        "id": "obsidian-people-link",
+        "name": "Obsidian People Link",
+        "author": "Reorx",
+        "description": "Easily create links to people within your notes.",
+        "repo": "reorx/obsidian-people-link"
+    },
+    {
         "id": "fleeting-notes-obsidian",
         "name": "Fleeting Notes Sync",
         "author": "Matthew Wong",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/reorx/obsidian-people-link

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
