### PR TITLE
Update information for the short-internal-links-to-headings plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5673,10 +5673,10 @@
     },
     {
         "id": "short-internal-links-to-headings",
-        "name": "Short Internal Links to Headings",
-        "description": "Display internal links to headings as just the heading name.",
+        "name": "Short links",
+        "description": "Display short internal links to files, notes, headings, and blocks.",
         "author": "Scott Moore",
-        "repo": "scottwillmoore/obsidian-short-internal-links-to-headings"
+        "repo": "scottwillmoore/obsidian-short-links"
     },
     {
         "id": "obsidian-hyphenation",


### PR DESCRIPTION
# I am **UPDATING** my Community Plugin

I wanted to change the name, description and repository URL for my plugin.

Link to my plugin: https://github.com/scottwillmoore/obsidian-short-links
