### PR TITLE
Unpublish obsidian-audio-speed-plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2478,13 +2478,6 @@
         "repo": "twentytwokhz/quote-of-the-day"
     },
     {
-        "id": "obsidian-audio-speed-plugin",
-        "name": "Audio Speed Plugin",
-        "description": "Change the playback rate of audio files during markdown preview.",
-        "author": "kaizau",
-        "repo": "kaizau/obsidian-audio-speed-plugin"
-    },
-    {
         "id": "obsidian-limelight",
         "name": "Limelight",
         "description": "Spotlight your active pane",


### PR DESCRIPTION

# I am ~~submitting a new~~ unpublishing a Community Plugin

It's no longer needed, since Obsidian now has this feature.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/kaizau/obsidian-audio-speed-plugin

## Release Checklist

- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [ ] `main.js`
  - [ ] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ ] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
