### PR TITLE
Remove Sekund from community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3276,13 +3276,6 @@
         "repo": "quorafind/obsidian-big-calendar"
     },
     {
-        "id": "sekund",
-        "name": "Obsidian Social (Sekund)",
-        "author": "Candide Kemmler",
-        "description": "Share notes and gather feedback",
-        "repo": "Sekund/sekund-plugin-react"
-    },
-    {
         "id": "obsidian-command-palette-minus-plugin",
         "name": "Command Palette--",
         "author": "qawatake",


### PR DESCRIPTION
I will never have the time to properly maintain this plugin. My original intention was to propose an idea, but it looks like it never really picked up. Too bad.