### PR TITLE
Add Code::stats plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6407,5 +6407,13 @@
         "author": "1C0D",
         "description": "toggle sidebars double-clicking middle mouse button or each sidebar clicking middle mouse button and moving mouse towards the corresponding sidebar.",
         "repo": "1C0D/obsidian-easy-toggle-sidebars"
+    },
+    {
+        "id": "codestats-obsidian",
+        "name": "Code::Stats plugin for Obsidian",
+        "author": "MiskaMyasa",
+        "description": "The Code::Stats plugin for Obsidian allows you to track your coding progress and earn XP for writing code in the Obsidian editor",
+        "repo": "Miskamyasa/obsidian-codestats",
+        "branch": "main"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

[Link to my plugin:](https://github.com/Miskamyasa/obsidian-codestats)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
