### PR TITLE
Cleanup tasks for plugin descriptions

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3,14 +3,14 @@
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",
-    "description": "Create date-links based on natural language",
+    "description": "Create date-links based on natural language.",
     "repo": "argenos/nldates-obsidian"
   },
   {
     "id": "hotkeysplus-obsidian",
     "name": "Hotkeys++",
     "author": "Argentina Ortega Sainz",
-    "description": "Additional hotkeys to do common things in Obsidian",
+    "description": "Additional hotkeys to do common things in Obsidian.",
     "repo": "argenos/hotkeysplus-obsidian"
   },
   {
@@ -38,77 +38,77 @@
     "id": "cm-show-whitespace-obsidian",
     "name": "Show Whitespace",
     "author": "death_au",
-    "description": "Show whitespace in the editor",
+    "description": "Show whitespace in the editor.",
     "repo": "deathau/cm-show-whitespace-obsidian"
   },
   {
     "id": "table-editor-obsidian",
     "name": "Advanced Tables",
     "author": "Tony Grosinger",
-    "description": "Improved table navigation, formatting, and manipulation",
+    "description": "Improved table navigation, formatting, and manipulation.",
     "repo": "tgrosinger/advanced-tables-obsidian"
   },
   {
     "id": "leader-hotkeys-obsidian",
     "name": "Leader Hotkeys",
     "author": "Tony Grosinger",
-    "description": "Add leader hotkey support to any command (like tmux or vim)",
+    "description": "Add leader hotkey support to any command (like tmux or vim).",
     "repo": "tgrosinger/leader-hotkeys-obsidian"
   },
   {
     "id": "slated-obsidian",
     "name": "Slated",
     "author": "Tony Grosinger",
-    "description": "Task management and repetition",
+    "description": "Task management and repetition.",
     "repo": "tgrosinger/slated-obsidian"
   },
   {
     "id": "recent-files-obsidian",
     "name": "Recent Files",
     "author": "Tony Grosinger",
-    "description": "Display a list of recently opened files",
+    "description": "Display a list of recently opened files.",
     "repo": "tgrosinger/recent-files-obsidian"
   },
   {
     "id": "ledger-obsidian",
     "name": "Ledger",
     "author": "Tony Grosinger",
-    "description": "Plain text accounting",
+    "description": "Plain text accounting.",
     "repo": "tgrosinger/ledger-obsidian"
   },
   {
     "id": "note-refactor-obsidian",
     "name": "Note Refactor",
     "author": "James Lynch",
-    "description": "Extract note content into new notes and split notes",
+    "description": "Extract note content into new notes and split notes.",
     "repo": "lynchjames/note-refactor-obsidian"
   },
   {
     "id": "calendar",
     "name": "Calendar",
     "author": "Liam Cain",
-    "description": "Simple calendar widget for Obsidian",
+    "description": "Simple calendar widget for Obsidian.",
     "repo": "liamcain/obsidian-calendar-plugin"
   },
   {
     "id": "mrj-text-expand",
     "name": "Text {{expand}}",
     "author": "MrJackphil",
-    "description": "Search and paste/transclude links to founded files",
+    "description": "Search and paste/transclude links to found files.",
     "repo": "mrjackphil/obsidian-text-expand"
   },
   {
     "id": "mrj-jump-to-link",
     "name": "Jump to link",
     "author": "MrJackphil",
-    "description": "This plugin allows open a link in current document using hotkey",
+    "description": "Quickly navigate between links, or jump to any word on the page using hotkeys.",
     "repo": "mrjackphil/obsidian-jump-to-link"
   },
   {
     "id": "obsidian-reading-time",
     "name": "Reading Time",
     "author": "avr",
-    "description": "Add the current note's reading time to Obsidian's status bar",
+    "description": "Add the current note's reading time to Obsidian's status bar.",
     "repo": "avr/obsidian-reading-time"
   },
   {
@@ -129,14 +129,14 @@
     "id": "shortcuts-extender",
     "name": "Shortcuts extender",
     "author": "kitchenrunner",
-    "description": "Use shortcuts for input special symbols without language switching",
+    "description": "Use shortcuts for input special symbols without language switching.",
     "repo": "ryjjin/Obsidian-shortcuts-extender"
   },
   {
     "id": "mrj-crosslink-between-notes",
     "name": "Add links to current note",
     "author": "MrJackphil",
-    "description": "This plugin adds a command which allows to add a link to the current note at the bottom of selected notes",
+    "description": "Adds a command to add a link to the current note at the bottom of selected notes.",
     "repo": "mrjackphil/obsidian-crosslink-between-notes"
   },
   {
@@ -157,7 +157,7 @@
     "id": "cm-editor-syntax-highlight-obsidian",
     "name": "Editor Syntax Highlight",
     "author": "death_au",
-    "description": "Show syntax highlighing in code blocks the editor",
+    "description": "Show syntax highlighing in code blocks the editor.",
     "repo": "deathau/cm-editor-syntax-highlight-obsidian"
   },
   {
@@ -171,21 +171,21 @@
     "id": "obsidian-hider",
     "name": "Hider",
     "author": "@kepano",
-    "description": "Hide UI elements such as tooltips, status, titlebar and more",
+    "description": "Hide UI elements such as tooltips, status, titlebar and more.",
     "repo": "kepano/obsidian-hider"
   },
   {
     "id": "obsidian-minimal-settings",
     "name": "Minimal Theme Settings",
     "author": "@kepano",
-    "description": "Control the colors and fonts in Minimal Theme",
+    "description": "Control the colors and fonts in Minimal Theme.",
     "repo": "kepano/obsidian-minimal-settings"
   },
   {
     "id": "obsidian-system-dark-mode",
     "name": "System Dark Mode",
     "author": "@kepano",
-    "description": "Automatically use the operating system's setting to switch between light and dark mode",
+    "description": "Automatically use the operating system's setting to switch between light and dark mode.",
     "repo": "kepano/obsidian-system-dark-mode"
   },
   {
@@ -199,28 +199,28 @@
     "id": "templater-obsidian",
     "name": "Templater",
     "author": "SilentVoid",
-    "description": "Create and use templates",
+    "description": "Create and use templates.",
     "repo": "SilentVoid13/Templater"
   },
   {
     "id": "convert-url-to-iframe",
     "name": "Convert url to preview (iframe)",
     "author": "FHachez",
-    "description": "Convert an url (ex, youtube) into an iframe (preview)",
+    "description": "Convert an url (e.g. YouTube) into an iframe (preview).",
     "repo": "FHachez/obsidian-convert-url-to-iframe"
   },
   {
     "id": "code-block-copy",
     "name": "Copy button for code blocks",
     "author": "Daniel Brandenburg",
-    "description": "Copy button for code blocks",
+    "description": "Copy button for code blocks.",
     "repo": "jdbrice/obsidian-code-block-copy"
   },
   {
     "id": "searchpp",
     "name": "Search++",
     "author": "Noureddine Haouari",
-    "description": "Allow inserting text context search results on the active note, the plugin is based on the plugin mrj-text-expand-witb-text of MrJackphil.",
+    "description": "Allow inserting text context search results on the active note, the plugin is based on the plugin mrj-text-expand-witb-text by MrJackphil.",
     "repo": "nhaouari/searchpp"
   },
   {
@@ -241,7 +241,7 @@
     "id": "obsidian-latex-environments",
     "name": "Latex Environments",
     "author": "Zach Raines",
-    "description": "Allows to quickly insert and change latex environments within math environments.",
+    "description": "Allows to quickly insert and change LaTeX environments within math environments.",
     "repo": "raineszm/obsidian-latex-environments"
   },
   {
@@ -261,14 +261,14 @@
   {
     "id": "css-snippets",
     "name": "css snippets",
-    "description": "Load and manage css snippets",
+    "description": "Load and manage CSS snippets.",
     "author": "Daniel Brandenburg",
     "repo": "jdbrice/obsidian-css-snippets"
   },
   {
     "id": "obsidian-link-indexer",
     "name": "Link indexer",
-    "description": "Generate index notes with links based on various conditions",
+    "description": "Generate index notes with links based on various conditions.",
     "author": "Yuliya Bagriy",
     "repo": "aviskase/obsidian-link-indexer"
   },
@@ -282,7 +282,7 @@
   {
     "id": "extract-highlights-plugin",
     "name": "Extract Highlights",
-    "description": "Allows to extracts all ==highlights== in a note into your clipboard",
+    "description": "Allows to extracts all ==highlights== in a note into your clipboard.",
     "author": "Alexis Rondeau",
     "repo": "akaalias/extract-highlights-plugin"
   },
@@ -297,21 +297,21 @@
     "id": "wikilinks-to-mdlinks-obsidian",
     "name": "Wikilinks to MDLinks (Markdown Links)",
     "author": "Agatha Uy",
-    "description": "Convert wikilinks to markdown links and vice versa",
+    "description": "Convert wikilinks to Markdown links and vice versa.",
     "repo": "agathauy/wikilinks-to-mdlinks-obsidian"
   },
   {
     "id": "smart-random-note",
     "name": "Smart Random Note",
     "author": "Eric Hall",
-    "description": "Open random notes with greater control",
+    "description": "Open random notes with greater control.",
     "repo": "erichalldev/obsidian-smart-random-note"
   },
   {
     "id": "cycle-through-panes",
     "name": "Cycle through Panes",
     "author": "Vinadon & phibr0",
-    "description": "Cycle through your open Panes with `ctrl + Tab`, just like with Tabs in your Browser!",
+    "description": "Cycle through your open panes with `ctrl + Tab`, just like with tabs in your browser!",
     "repo": "phibr0/cycle-through-panes"
   },
   {
@@ -353,14 +353,14 @@
     "id": "maximise-active-pane-obsidian",
     "name": "Maximise Active Pane",
     "author": "death_au",
-    "description": "Simply fills the workspace with the active pane",
+    "description": "Simply fills the workspace with the active pane.",
     "repo": "deathau/maximise-active-pane-obsidian"
   },
   {
     "id": "obsidian-juliandate",
     "name": "Julian Date Quick Insert",
     "author": "thek3nger",
-    "description": "Add a shortuct to insert the current Julian Date for astronomical observations.",
+    "description": "Add a shortcut to insert the current Julian date for astronomical observations.",
     "repo": "THeK3nger/obsidian-juliandate"
   },
   {
@@ -374,7 +374,7 @@
     "id": "obsidian-fullscreen-plugin",
     "name": "Fullscreen Focus Mode",
     "author": "Razum",
-    "description": "Adds a command to view a single document leaf in a fullscreen focus mode",
+    "description": "Adds a command to view a single document leaf in a fullscreen focus mode.",
     "repo": "razumihin/obsidian-fullscreen-plugin"
   },
   {
@@ -388,7 +388,7 @@
     "id": "obsidian-mind-map",
     "name": "Mind Map",
     "author": "James Lynch",
-    "description": "Displays markdown notes as mind maps using Markmap.",
+    "description": "Displays Markdown notes as mind maps using Markmap.",
     "repo": "lynchjames/obsidian-mind-map"
   },
   {
@@ -402,14 +402,14 @@
     "id": "completed-area",
     "name": "Completed Area",
     "author": "Daha",
-    "description": "Move completed to-do items to a seperate completed area.",
+    "description": "Move completed to-do items to a separate completed area.",
     "repo": "DahaWong/obsidian-completed-area"
   },
   {
     "id": "obsidian-citation-plugin",
     "name": "Citations",
     "author": "Jon Gauthier",
-    "description": "Automatically search and insert citations from a Zotero library",
+    "description": "Automatically search and insert citations from a Zotero library.",
     "repo": "hans/obsidian-citation-plugin"
   },
   {
@@ -423,7 +423,7 @@
     "id": "obsidian-rollover-daily-todos",
     "name": "Rollover Daily Todos",
     "author": "Matt Sessions",
-    "description": "This plugin will rollover any unchecked checkboxes from your last daily note into today's note",
+    "description": "This plugin will rollover any unchecked checkboxes from your last daily note into today's note.",
     "repo": "shichongrui/obsidian-rollover-daily-todos"
   },
   {
@@ -437,14 +437,14 @@
     "id": "obsidian-export-to-tex",
     "name": "Export To TeX",
     "author": "Zach Raines",
-    "description": "Export vault files in a format amenable to pasting into a TeX document",
+    "description": "Export vault files in a format amenable to pasting into a TeX document.",
     "repo": "raineszm/obsidian-export-to-tex"
   },
   {
     "id": "obsidian-latex",
     "name": "Extended MathJax",
     "author": "Xavier Denis & Ng Wei En",
-    "description": "Enables additional MathJax packages and adds a global preamble for MathJax",
+    "description": "Enables additional MathJax packages and adds a global preamble for MathJax.",
     "repo": "wei2912/obsidian-latex"
   },
   {
@@ -472,7 +472,7 @@
     "id": "snippets",
     "name": "Snippets plugin",
     "author": "Pelao",
-    "description": "Execute simple scripts/snippets from obsidian. This plugin is experimental",
+    "description": "Execute simple scripts/snippets from Obsidian. This plugin is experimental.",
     "repo": "cristianvasquez/obsidian-snippets-plugin"
   },
   {
@@ -486,7 +486,7 @@
     "id": "obsidian-relative-line-numbers",
     "name": "Relative Line Numbers",
     "author": "Nadav Spiegelman",
-    "description": "Enables relative line numbers in editor mode",
+    "description": "Enables relative line numbers in editor mode.",
     "repo": "nadavspi/obsidian-relative-line-numbers"
   },
   {
@@ -500,7 +500,7 @@
     "id": "discordian-plugin",
     "name": "Discordian Theme",
     "author": "@radekkozak",
-    "description": "Fine-grained control of Discordian Theme",
+    "description": "Fine-grained control of Discordian Theme.",
     "repo": "radekkozak/discordian-plugin"
   },
   {
@@ -514,91 +514,91 @@
     "id": "completed-task-display",
     "name": "Completed Task Display",
     "author": "Ben Lee-Cohen",
-    "description": "Provides controls for displaying or hiding completed tasks",
+    "description": "Provides controls for displaying or hiding completed tasks.",
     "repo": "heliostatic/completed-task-display"
   },
   {
     "id": "obsidian-extract-pdf-highlights",
     "name": "PDF Highlights",
     "author": "Alexis Rondeau",
-    "description": "Extract highlights, underlines and annotations from your PDFs into Obsidian",
+    "description": "Extract highlights, underlines and annotations from your PDFs into Obsidian.",
     "repo": "akaalias/obsidian-extract-pdf-highlights"
   },
   {
     "id": "youhavebeenstaring-plugin",
     "name": "YouHaveBeenStaring",
     "author": "Felix Almer",
-    "description": "Tells you in the status bar for how long you've been staring at your obsidian vault. Well - at least how long your vault is open.",
+    "description": "Tells you in the status bar for how long you've been staring at your Obsidian vault. Well - at least how long your vault is open.",
     "repo": "fxal/obsidian-youhavebeenstaring-plugin"
   },
   {
     "id": "obsidian-metatemplates",
     "name": "metatemplates",
     "author": "avirut",
-    "description": "Generate notes from templates using YAML front-matter",
+    "description": "Generate notes from templates using YAML frontmatter.",
     "repo": "avirut/obsidian-metatemplates"
   },
   {
     "id": "obsidian-query2table",
     "name": "query2table",
     "author": "avirut",
-    "description": "Represent files returned by a query as a table of their YAML frontmatter",
+    "description": "Represent files returned by a query as a table of their YAML frontmatter.",
     "repo": "avirut/obsidian-query2table"
   },
   {
     "id": "obsidian-imgur-plugin",
     "name": "Imgur Plugin",
     "author": "Kirill Gavrilov",
-    "description": "This plugin uploads images from your clipboard to imgur.com and embeds uploaded image to your note",
+    "description": "This plugin uploads images from your clipboard to imgur.com and embeds uploaded image to your note.",
     "repo": "gavvvr/obsidian-imgur-plugin"
   },
   {
     "id": "obsidian-checklist-plugin",
     "name": "Checklist",
     "author": "delashum",
-    "description": "Consolidate checklists across all files into a single view",
+    "description": "Consolidate checklists across all files into a single view.",
     "repo": "delashum/obsidian-checklist-plugin"
   },
   {
     "id": "obsidian-text-expander",
     "name": "Text Expander",
     "author": "Nikita Konodyuk",
-    "description": "Expand text shortcuts, run shell commands and python scripts right in your editor",
+    "description": "Expand text shortcuts, run shell commands and Python scripts right in your editor.",
     "repo": "konodyuk/obsidian-text-expander"
   },
   {
     "id": "search-on-internet",
     "name": "Search on Internet",
     "author": "Emile",
-    "description": "Add context menu items to search the internet based on the title of your note",
+    "description": "Add context menu items to search the internet based on the title of your note.",
     "repo": "HEmile/obsidian-search-on-internet"
   },
   {
     "id": "obsidian-file-path-to-uri",
     "name": "File path to URI",
     "author": "Michal Bureš",
-    "description": "Convert file path to uri for easier use of links to local files outside of Obsidian",
+    "description": "Convert file path to uri for easier use of links to local files outside of Obsidian.",
     "repo": "MichalBures/obsidian-file-path-to-uri"
   },
   {
     "id": "page-heading-from-links",
     "name": "Page Heading From Links",
     "author": "Mark Beattie",
-    "description": "Inserts a heading into blank pages from the filename",
+    "description": "Inserts a heading into blank pages from the file name.",
     "repo": "beet/page-headings-obsidian-plugin"
   },
   {
     "id": "obsidian-icons-plugin",
     "name": "Icons Plugin",
     "author": "Camillo Visini",
-    "description": "Add icons to your notes",
+    "description": "Add icons to your notes.",
     "repo": "visini/obsidian-icons-plugin"
   },
   {
     "id": "folder-note-plugin",
     "name": "Folder Note",
     "author": "xpgo",
-    "description": "Add description note to a folder",
+    "description": "Add description note to a folder.",
     "repo": "xpgo/obsidian-folder-note-plugin"
   },
   {
@@ -619,7 +619,7 @@
     "id": "obsidian-min3ditorhotkeys-plugin",
     "name": "Min3ditorHotkeys",
     "author": "Davor Sauer",
-    "description": "Additional editor hotkeys inspired by coding editors",
+    "description": "Additional editor hotkeys inspired by coding editors.",
     "repo": "d-sauer/Obsidian-Min3ditorHotkeys-plugin"
   },
   {
@@ -633,7 +633,7 @@
     "id": "things-logbook",
     "name": "Things Logbook",
     "author": "Liam Cain",
-    "description": "Sync your Things logbook with your daily notes",
+    "description": "Sync your Things logbook with your daily notes.",
     "repo": "liamcain/obsidian-things-logbook"
   },
   {
@@ -646,7 +646,7 @@
   {
     "id": "obsidian-filename-heading-sync",
     "name": "Filename Heading Sync",
-    "description": "Obsidian plugin for keeping the filename with the first heading of a file in sync",
+    "description": "Obsidian plugin for keeping the filename with the first heading of a file in sync.",
     "author": "dvcrn",
     "repo": "dvcrn/obsidian-filename-heading-sync"
   },
@@ -654,14 +654,14 @@
     "id": "obsidian-orthography",
     "name": "Obsidian Orthography",
     "author": "denisoed",
-    "description": "Obsidian plugin to check & fix orthography errors in text",
+    "description": "Obsidian plugin to check & fix orthography errors in text.",
     "repo": "denisoed/obsidian-orthography"
   },
   {
     "id": "obsidian-query-language",
     "name": "Obsidian Query Language",
     "author": "Joost Plattel",
-    "description": "This plugin allows you to query notes and represent data within Obsidian",
+    "description": "This plugin allows you to query notes and represent data within Obsidian.",
     "repo": "jplattel/obsidian-query-language"
   },
   {
@@ -675,21 +675,21 @@
     "id": "obsidian-journey-plugin",
     "name": "Journey",
     "author": "Alexis Rondeau",
-    "description": "Discover the story between your notes",
+    "description": "Discover the story between your notes.",
     "repo": "akaalias/obsidian-journey-plugin"
   },
   {
     "id": "tag-wrangler",
     "name": "Tag Wrangler",
     "author": "PJ Eby",
-    "description": "Rename, merge, toggle, and search tags from the tag pane",
+    "description": "Rename, merge, toggle, and search tags from the tag pane.",
     "repo": "pjeby/tag-wrangler"
   },
   {
     "id": "better-pdf-plugin",
     "name": "Better PDF Plugin",
     "author": "MSzturc",
-    "description": "Insert, scale, rotate and cut-out pdf pages into your notes",
+    "description": "Insert, scale, rotate and cut-out PDF pages into your notes.",
     "repo": "MSzturc/obsidian-better-pdf-plugin"
   },
   {
@@ -703,69 +703,69 @@
     "id": "periodic-notes",
     "name": "Periodic Notes",
     "author": "Liam Cain",
-    "description": "Create/manage your daily, weekly, and monthly notes",
+    "description": "Create/manage your daily, weekly, and monthly notes.",
     "repo": "liamcain/obsidian-periodic-notes"
   },
   {
     "id": "obsidian-show-file-path",
     "name": "Show Current File Path",
     "author": "Ravi Mashru",
-    "description": "Show the full path of the currently open file in the status bar",
+    "description": "Show the full path of the currently open file in the status bar.",
     "repo": "ravimashru/obsidian-show-file-path"
   },
   {
     "id": "obsidian-paper-cut",
     "name": "PaperCut",
     "author": "darakah",
-    "description": "Express an idea in the simplest possible way ... or else",
+    "description": "Express an idea in the simplest possible way ... or else.",
     "repo": "Darakah/obsidian-paper-cut"
   },
   {
     "id": "obsidian-comments",
     "name": "Comments",
     "author": "darakah",
-    "description": "Add, track and easily navigate between a note's Comments",
+    "description": "Add, track and easily navigate between a note's comments.",
     "repo": "Darakah/obsidian-comments-plugin"
   },
   {
     "id": "ini-obsidian",
     "name": "ini Editor",
     "author": "death_au",
-    "description": "Edit ini files in Obsidian",
+    "description": "Edit .ini files in Obsidian.",
     "repo": "deathau/ini-obsidian"
   },
   {
     "id": "various-complements",
     "name": "Various Complements",
     "author": "tadashi-aikawa",
-    "description": "This plugin enables you to complete words like the auto-completion of IDE",
+    "description": "This plugin enables you to complete words like the auto-completion of IDE.",
     "repo": "tadashi-aikawa/obsidian-various-complements-plugin"
   },
   {
     "id": "obsidian-timelines",
     "name": "Timelines",
     "author": "darakah",
-    "description": "Create a timeline view of all notes with the specified combination of tags",
+    "description": "Create a timeline view of all notes with the specified combination of tags.",
     "repo": "Darakah/obsidian-timelines"
   },
   {
     "id": "txt-as-md-obsidian",
     "name": "txt as md",
     "author": "death_au",
-    "description": "Edit txt files as markdown in Obsidian",
+    "description": "Edit .txt files as Markdown in Obsidian.",
     "repo": "deathau/txt-as-md-obsidian"
   },
   {
     "id": "note-folder-autorename",
     "name": "Note Folder Autorename",
     "author": "PJ Eby",
-    "description": "Turn notes into folders and automaticaly move/rename their folders when they move or are renamed",
+    "description": "Turn notes into folders and automaticaly move/rename their folders when they move or are renamed.",
     "repo": "pjeby/note-folder-autorename"
   },
   {
     "id": "daily-activity",
     "name": "Daily Activity",
-    "description": "This outputs a list of the files changed/created today in the active file",
+    "description": "This outputs a list of the files changed/created today in the active file.",
     "author": "trydalch",
     "repo": "trydalch/obsidian-daily-activity"
   },
@@ -828,7 +828,7 @@
   {
     "id": "mochi-cards-exporter",
     "name": "Mochi Cards Exporter",
-    "description": "Export Markdown notes to Mochi cards from within obsidian",
+    "description": "Export Markdown notes to Mochi cards from within Obsidian",
     "author": "kalbetre",
     "repo": "kalbetredev/mochi-cards-exporter"
   },
@@ -842,28 +842,28 @@
   {
     "id": "obsidian-furigana",
     "name": "Furigana",
-    "description": "Helper plugin for furigana and <ruby>",
+    "description": "Helper plugin for furigana and <ruby>.",
     "author": "Koppa",
     "repo": "uonr/obsidian-furigana"
   },
   {
     "id": "obsidian-vault-changelog",
     "name": "Vault Changelog",
-    "description": "Maintain a changelog of recently edited files in your vault",
+    "description": "Maintain a changelog of recently edited files in your vault.",
     "author": "Badr Bouslikhin",
     "repo": "mrzeroo00/obsidian-vault-changelog"
   },
   {
     "id": "chesser-obsidian",
     "name": "Chesser",
-    "description": "A chess game viewer/editor",
+    "description": "A chess game viewer/editor.",
     "author": "SilentVoid",
     "repo": "SilentVoid13/Chesser"
   },
   {
     "id": "obsidian-activity-history",
     "name": "Activity History",
-    "description": "Track activity of specified projects, Github like activity board",
+    "description": "Track activity of specified projects, Github like activity board.",
     "author": "darakah",
     "repo": "Darakah/obsidian-activity-history"
   },
@@ -884,7 +884,7 @@
   {
     "id": "obsidian-gallery",
     "name": "Gallery",
-    "description": "Interactive Card like gallery display of images",
+    "description": "Interactive card-like gallery display of images.",
     "author": "darakah",
     "repo": "Darakah/obsidian-gallery"
   },
@@ -906,20 +906,20 @@
     "id": "format-hotkeys-obsidian",
     "name": "Format Hotkeys",
     "author": "Ansel Santosa",
-    "description": "Google Docs style formatting hotkeys for Obsidian",
+    "description": "Google Docs style formatting hotkeys for Obsidian.",
     "repo": "anstosa/format-hotkeys-obsidian"
   },
   {
     "id": "obsidian-leaflet-plugin",
     "name": "Obsidian Leaflet",
-    "description": "Interactive maps inside your notes",
+    "description": "Interactive maps inside your notes.",
     "author": "Jeremy Valentine",
     "repo": "javalent/obsidian-leaflet"
   },
   {
     "id": "remember-cursor-position",
     "name": "Remember cursor position",
-    "description": "Remember cursor and scroll position for each note",
+    "description": "Remember cursor and scroll position for each note.",
     "author": "Dmitry Savosh",
     "repo": "dy-sh/obsidian-remember-cursor-position"
   },
@@ -927,7 +927,7 @@
     "id": "pane-relief",
     "name": "Pane Relief",
     "author": "PJ Eby",
-    "description": "Per-pane history, hotkeys for pane movement + navigation, and more",
+    "description": "Per-pane history, hotkeys for pane movement + navigation, and more.",
     "repo": "pjeby/pane-relief"
   },
   {
@@ -954,21 +954,21 @@
   {
     "id": "consistent-attachments-and-links",
     "name": "Consistent attachments and links",
-    "description": "Move note attachments and update links automatically",
+    "description": "Move note attachments and update links automatically.",
     "author": "Dmitry Savosh",
     "repo": "dy-sh/obsidian-consistent-attachments-and-links"
   },
   {
     "id": "obsidian-plantuml",
     "name": "PlantUML",
-    "description": "Generate PlantUML diagrams",
+    "description": "Generate PlantUML diagrams.",
     "author": "Johannes Theiner",
     "repo": "joethei/obsidian-plantuml"
   },
   {
     "id": "imdone-obsidian-plugin",
-    "name": "Open cards in imdone from obsidian.",
-    "description": "Open cards in imdone kanban from their source in obsidian.  Open cards from imdone in obsidian at their source.",
+    "name": "Open cards in imdone from Obsidian.",
+    "description": "Open cards in imdone kanban from their source in Obsidian.  Open cards from imdone in Obsidian at their source.",
     "author": "saxmanjes",
     "repo": "imdone/imdone-obsidian-plugin"
   },
@@ -982,7 +982,7 @@
   {
     "id": "unique-attachments",
     "name": "Unique attachments",
-    "description": "Rename attachments, making their names unique (based on hashing of file content)",
+    "description": "Rename attachments, making their names unique (based on hashing of file content).",
     "author": "Dmitry Savosh",
     "repo": "dy-sh/obsidian-unique-attachments"
   },
@@ -996,84 +996,84 @@
   {
     "id": "obsidian-languagetool-plugin",
     "name": "LanguageTool Integration",
-    "description": "advanced spell/grammar checks with the help of language-tool",
+    "description": "advanced spell/grammar checks with the help of language-tool.",
     "author": "Clemens Ertle",
     "repo": "Clemens-E/obsidian-languagetool-plugin"
   },
   {
     "id": "obsidian-commits",
     "name": "Commits",
-    "description": "Track & show commits in obsidian vault or specified project.",
+    "description": "Track & show commits in Obsidian vault or specified project.",
     "author": "darakah",
     "repo": "Darakah/obsidian-commits"
   },
   {
     "id": "obsidian-outliner",
     "name": "Outliner",
-    "description": "Work with your lists like in Workflowy or RoamResearch.",
+    "description": "Work with your lists like in Workflowy or Roam Research.",
     "author": "Viacheslav Slinko",
     "repo": "vslinko/obsidian-outliner"
   },
   {
     "id": "extract-url",
     "name": "Extract url content",
-    "description": "Extract url converting content into markdown",
+    "description": "Extract url converting content into Markdown.",
     "author": "Stephen Solka",
     "repo": "trashhalo/obsidian-extract-url"
   },
   {
     "id": "find-and-replace-in-selection",
     "name": "Find and replace in selection",
-    "description": "Finds what you are looking for in the selected text and replaces it with the specified text",
+    "description": "Finds what you are looking for in the selected text and replaces it with the specified text.",
     "author": "Dmitry Savosh",
     "repo": "dy-sh/obsidian-find-and-replace-in-selection"
   },
   {
     "id": "buttons",
     "name": "Buttons",
-    "description": "Create Buttons in your Obsidian notes to run commands, open links, and insert templates",
+    "description": "Create Buttons in your Obsidian notes to run commands, open links, and insert templates.",
     "author": "Sam Morrison",
     "repo": "shabegom/buttons"
   },
   {
     "id": "obsidian-admonition",
     "name": "Admonition",
-    "description": "Admonition block-styled content for Obsidian.md",
+    "description": "Admonition block-styled content for Obsidian.",
     "author": "Jeremy Valentine",
     "repo": "javalent/admonitions"
   },
   {
     "id": "obsidian-tracker",
     "name": "Tracker",
-    "description": "Tracks occurrences and numbers in your notes",
+    "description": "Tracks occurrences and numbers in your notes.",
     "author": "pyrochlore",
     "repo": "pyrochlore/obsidian-tracker"
   },
   {
     "id": "obsidian-hotkeys-for-templates",
     "name": "Hotkeys for templates",
-    "description": "Add commands to insert specific templates with a hotkey",
+    "description": "Add commands to insert specific templates with a hotkey.",
     "author": "Vinzent",
     "repo": "Vinzent03/obsidian-hotkeys-for-templates"
   },
   {
     "id": "obsidian-style-settings",
     "name": "Style Settings",
-    "description": "Offers controls for adjusting theme, plugin, and snippet CSS variables",
+    "description": "Offers controls for adjusting theme, plugin, and snippet CSS variables.",
     "author": "mgmeyers",
     "repo": "mgmeyers/obsidian-style-settings"
   },
   {
     "id": "obsidian-advanced-uri",
     "name": "Advanced URI",
-    "description": "Control everything in Obsidian with URI",
+    "description": "Control everything in Obsidian with URI.",
     "author": "Vinzent",
     "repo": "Vinzent03/obsidian-advanced-uri"
   },
   {
     "id": "obsidian-fountain",
     "name": "Fountain",
-    "description": "Fountain Support for Obsidian",
+    "description": "Fountain support for Obsidian.",
     "author": "darakah",
     "repo": "Darakah/obsidian-fountain"
   },
@@ -1081,20 +1081,20 @@
     "id": "cm-chs-patch",
     "name": "Word Splitting for Simplified Chinese in Edit Mode and Vim Mode",
     "author": "AidenLx",
-    "description": "A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting",
+    "description": "A patch for Obsidian's built-in CodeMirror Editor to support Simplified Chinese word splitting.",
     "repo": "aidenlx/cm-chs-patch"
   },
   {
     "id": "table-extended",
     "name": "Table Extended",
     "author": "AidenLx",
-    "description": "Enable extended table support with MultiMarkdown 6 syntax",
+    "description": "Enable extended table support with MultiMarkdown 6 syntax.",
     "repo": "aidenlx/table-extended"
   },
   {
     "id": "privacy-glasses",
     "name": "Privacy Glasses",
-    "description": "Provides a ribbon icon and command to blur onscreen text for better privacy",
+    "description": "Provides a ribbon icon and command to blur onscreen text for better privacy.",
     "author": "Jill Alberts",
     "repo": "jillalberts/privacy-glasses"
   },
@@ -1109,13 +1109,13 @@
     "id": "media-extended",
     "name": "Media Extended",
     "author": "AidenLx",
-    "description": "Improve media (video/audio) playing in Obsidian",
+    "description": "Improve media (video/audio) playing in Obsidian.",
     "repo": "aidenlx/media-extended"
   },
   {
     "id": "obsidian-regex-pipeline",
     "name": "Regex Pipeline",
-    "description": "Allows users setup custom regex rules to automatically format notes",
+    "description": "Allows users setup custom regex rules to automatically format notes.",
     "author": "No3371",
     "repo": "No3371/obsidian-regex-pipeline"
   },
@@ -1151,34 +1151,34 @@
     "id": "obsidian-icon-swapper",
     "name": "Icon Swapper",
     "author": "mgmeyers",
-    "description": "Allows swapping out Obsidian's default icons",
+    "description": "Allows swapping out Obsidian's default icons.",
     "repo": "mgmeyers/obsidian-icon-swapper"
   },
   {
     "id": "mdx-as-md-obsidian",
     "name": "mdx as md",
     "author": "Nikolay Kozhukharenko",
-    "description": "Edit mdx files as markdown in Obsidian",
+    "description": "Edit mdx files as Markdown in Obsidian.",
     "repo": "mkozhukharenko/mdx-as-md-obsidian"
   },
   {
     "id": "obsidian-excalidraw-plugin",
     "name": "Excalidraw",
     "author": "Zsolt Viczian",
-    "description": "An Obsidian plugin to edit and view Excalidraw drawings",
+    "description": "An Obsidian plugin to edit and view Excalidraw drawings.",
     "repo": "zsviczian/obsidian-excalidraw-plugin"
   },
   {
     "id": "obsidian-auto-link-title",
     "name": "Auto Link Title",
-    "description": "This plugin automatically fetches the titles of links from the web",
+    "description": "This plugin automatically fetches the titles of links from the web.",
     "author": "Matt Furden",
     "repo": "zolrath/obsidian-auto-link-title"
   },
   {
     "id": "python-lab-plugin",
     "name": "Python lab plugin",
-    "description": "An interface to experiment with python scripts and more.",
+    "description": "An interface to experiment with Python scripts and more.",
     "author": "Cristian Vasquez",
     "repo": "cristianvasquez/obsidian-lab"
   },
@@ -1186,7 +1186,7 @@
     "id": "obsidian-kanban",
     "name": "Kanban",
     "author": "mgmeyers",
-    "description": "Create markdown-backed Kanban boards in Obsidian",
+    "description": "Create Markdown-backed Kanban boards in Obsidian.",
     "repo": "mgmeyers/obsidian-kanban"
   },
   {
@@ -1199,14 +1199,14 @@
   {
     "id": "obsidian-kindle-plugin",
     "name": "Kindle Highlights",
-    "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file",
+    "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file.",
     "author": "Hady Osman",
     "repo": "hadynz/obsidian-kindle-plugin"
   },
   {
     "id": "obsidian-metatable",
     "name": "Metatable",
-    "description": "Display the whole frontmatter section as a collapsible table",
+    "description": "Display the whole frontmatter section as a collapsible table.",
     "author": "Arnau Siches",
     "repo": "arnau/obsidian-metatable"
   },
@@ -1234,7 +1234,7 @@
   {
     "id": "beeminder-word-count-plugin",
     "name": "Beeminder Word Count Plugin",
-    "description": "Post word counts directly from obsidian md file to Beeminder",
+    "description": "Post word counts directly from Obsidian md file to Beeminder.",
     "author": "Yuta Miyama",
     "repo": "kenzan100/beeminder-obsidian-word-count"
   },
@@ -1248,7 +1248,7 @@
   {
     "id": "obsidian-qrcode-plugin",
     "name": "QR Code Generator Plugin",
-    "description": "This is a QR Code Generator",
+    "description": "QR code generator.",
     "author": "Rudi Häusler",
     "repo": "rudimuc/obsidian-qrcode"
   },
@@ -1262,7 +1262,7 @@
   {
     "id": "obsidian-underline",
     "name": "Underline",
-    "description": "Add underline with shortcut",
+    "description": "Add underline with shortcut.",
     "author": "Benature",
     "repo": "Benature/obsidian-underline"
   },
@@ -1270,7 +1270,7 @@
     "id": "oz-clear-unused-images",
     "name": "Clear Unused Images",
     "author": "Ozan Tellioglu",
-    "description": "Clear the images that you are not using anymore in your markdown notes to save space.",
+    "description": "Clear the images that you are not using anymore in your Markdown notes to save space.",
     "repo": "ozntel/oz-clear-unused-images-obsidian"
   },
   {
@@ -1290,7 +1290,7 @@
   {
     "id": "obsidian-image-auto-upload-plugin",
     "name": "Image auto upload Plugin",
-    "description": "This plugin uploads images from your clipboard by PicGo",
+    "description": "This plugin uploads images from your clipboard by PicGo.",
     "author": "renmu123",
     "repo": "renmu123/obsidian-image-auto-upload-plugin"
   },
@@ -1304,7 +1304,7 @@
   {
     "id": "obsidian-open-link-with",
     "name": "Open Link With",
-    "description": "Open external link with specific browser in Obsidian",
+    "description": "Open external link with specific browser in Obsidian.",
     "author": "MamoruDS",
     "repo": "MamoruDS/obsidian-open-link-with"
   },
@@ -1318,7 +1318,7 @@
   {
     "id": "supercharged-links-obsidian",
     "name": "Supercharged Links",
-    "description": "Adds attributes to internal links with the values of target note's frontmatter attributes",
+    "description": "Adds attributes to internal links with the values of target note's frontmatter attributes.",
     "author": "mdelobelle",
     "repo": "mdelobelle/obsidian_supercharged_links"
   },
@@ -1340,7 +1340,7 @@
     "id": "koncham-workspace",
     "name": "koncham workspace",
     "author": "mano",
-    "description": "obsidian workspace management",
+    "description": "Obsidian workspace management.",
     "repo": "manogna4/obsidian-koncham-workspace"
   },
   {
@@ -1360,14 +1360,14 @@
   {
     "id": "readwise-mirror",
     "name": "Readwise Mirror",
-    "description": "Mirror your Readwise library directly into an Obsidian vault",
+    "description": "Mirror your Readwise library directly into an Obsidian vault.",
     "author": "jsonmartin",
     "repo": "jsonMartin/readwise-mirror"
   },
   {
     "id": "obsidian-auto-pair-chinese-symbol",
     "name": "Auto pair chinese symbol",
-    "description": "Auto pair chinese symbol",
+    "description": "Auto-pair Chinese symbols.",
     "author": "renmu123",
     "repo": "renmu123/obsidian-auto-pair-chinese-symbol"
   },
@@ -1381,7 +1381,7 @@
   {
     "id": "obsidian-5e-statblocks",
     "name": "Fantasy Statblocks",
-    "description": "Create Fantasy Statblocks in Obsidian.md",
+    "description": "Create Fantasy Statblocks in Obsidian.",
     "author": "Jeremy Valentine",
     "repo": "javalent/fantasy-statblocks"
   },
@@ -1409,7 +1409,7 @@
   {
     "id": "obsidian-dictionary-plugin",
     "name": "Dictionary",
-    "description": "This is a multilingual Dictionary for the Obsidian Note-Taking Tool.",
+    "description": "A multilingual dictionary for Obsidian.",
     "author": "phibr0",
     "repo": "phibr0/obsidian-dictionary"
   },
@@ -1417,13 +1417,13 @@
     "id": "liquid-templates",
     "name": "Liquid Templates",
     "author": "Diomede Tripicchio",
-    "description": "Create your templates with LiquidJS tags support",
+    "description": "Create your templates with LiquidJS tags support.",
     "repo": "oeN/liquid-template"
   },
   {
     "id": "better-fn",
     "name": "Better footnote",
-    "description": "Footnote popover for Obsidian",
+    "description": "Footnote popover for Obsidian.",
     "author": "AidenLx",
     "repo": "aidenlx/better-fn"
   },
@@ -1444,14 +1444,14 @@
   {
     "id": "obsidian-static-file-server",
     "name": "Static File Server",
-    "description": "Host obsidian subfolders as static file servers.",
+    "description": "Host Obsidian subfolders as static file servers.",
     "author": "Elias Sundqvist",
     "repo": "elias-sundqvist/obsidian-static-file-server"
   },
   {
     "id": "easy-typing-obsidian",
     "name": "Easy Typing",
-    "description": "Auto format when typing",
+    "description": "Auto format when typing.",
     "author": "yaozhuwa",
     "repo": "Yaozhuwa/easy-typing-obsidian"
   },
@@ -1465,7 +1465,7 @@
   {
     "id": "zoottelkeeper-obsidian-plugin",
     "name": "Zoottelkeeper Plugin",
-    "description": "It maintains index files in all of your folders in your vault: if you create/delete/move a note, the index files will be updated automatically. It can be used to show folders in Graph View",
+    "description": "It maintains index files in all of your folders in your vault: if you create/delete/move a note, the index files will be updated automatically. It can be used to show folders in Graph View.",
     "author": "Akos Balasko",
     "repo": "akosbalasko/zoottelkeeper-obsidian-plugin"
   },
@@ -1501,14 +1501,14 @@
     "id": "obsidian-text-format",
     "name": "Text Format",
     "author": "Benature",
-    "description": "Format selected text upper/lower/capitalize",
+    "description": "Format selected text upper/lower/capitalize.",
     "repo": "Benature/obsidian-text-format"
   },
   {
     "id": "adjacency-matrix-maker",
     "name": "Adjacency Matrix Maker",
     "author": "SkepticMystic",
-    "description": "Create an interactive adjacency matrix of your vault",
+    "description": "Create an interactive adjacency matrix of your vault.",
     "repo": "SkepticMystic/adjacency-matrix-maker"
   },
   {
@@ -1528,7 +1528,7 @@
   {
     "id": "obsidian-argdown-plugin",
     "name": "Argument Map with Argdown",
-    "description": "Allows you to write argdown codeblocks and view the maps in Preview",
+    "description": "Allows you to write argdown code blocks and view the maps in Preview.",
     "author": "amdecker",
     "repo": "amdecker/obsidian-argdown-plugin"
   },
@@ -1556,7 +1556,7 @@
   {
     "id": "obsidian-title-index",
     "name": "Obsidian title index",
-    "description": "A simple plugin to add serial numbers to your markdown title.",
+    "description": "A simple plugin to add serial numbers to your Markdown title.",
     "author": "renmu123",
     "repo": "renmu123/obsidian-markdown-index"
   },
@@ -1585,13 +1585,13 @@
     "id": "tq-obsidian",
     "name": "tq",
     "author": "Tony Grosinger",
-    "description": "File-based Task Management",
+    "description": "File-based Task Management.",
     "repo": "tgrosinger/tq-obsidian"
   },
   {
     "id": "obsidian-habit-tracker",
     "name": "Habit Tracker",
-    "description": "This plguin for Obsidian creates a simple month view for visualizing your punch records.",
+    "description": "This plugin for Obsidian creates a simple month view for visualizing your punch records.",
     "author": "duo",
     "repo": "duoani/obsidian-habit-tracker"
   },
@@ -1599,7 +1599,7 @@
     "id": "obsidian-amazingmarvin-plugin",
     "name": "Amazing Marvin",
     "author": "Shirayuki Nekomata",
-    "description": "A simple plugin to help getting data from Amazing Marvin",
+    "description": "A simple plugin to help getting data from Amazing Marvin.",
     "repo": "ikuyarihS/obsidian-amazingmarvin-plugin"
   },
   {
@@ -1634,14 +1634,14 @@
     "id": "copy-url-in-preview",
     "name": "Copy Image and URL context menu",
     "author": "NomarCub",
-    "description": "Copy Image, Copy URL and Open PDF externally context menu in reading view (formerly preview mode)",
+    "description": "Copy Image, Copy URL and Open PDF externally context menu in reading view.",
     "repo": "NomarCub/obsidian-copy-url-in-preview"
   },
   {
     "id": "initiative-tracker",
     "name": "Initiative Tracker",
     "author": "Jeremy Valentine",
-    "description": "TTRPG Initiative Tracker for Obsidian.md",
+    "description": "TTRPG Initiative Tracker for Obsidian.",
     "repo": "javalent/initiative-tracker"
   },
   {
@@ -1655,21 +1655,21 @@
     "id": "obsidian-enhancing-mindmap",
     "name": "Enhancing mindmap",
     "author": "Mark",
-    "description": "This is a enhancing mindmap plugin for obsidian. You can edit mindmap on markdown.",
+    "description": "This is a enhancing mindmap plugin for Obsidian. You can edit mindmap on Markdown.",
     "repo": "MarkMindCkm/obsidian-enhancing-mindmap"
   },
   {
     "id": "breadcrumbs",
     "name": "Breadcrumbs",
     "author": "SkepticMystic",
-    "description": "Visualise the hierarchy of your vault using a breadcrumb trail or matrix view",
+    "description": "Visualise the hierarchy of your vault using a breadcrumb trail or matrix view.",
     "repo": "SkepticMystic/breadcrumbs"
   },
   {
     "id": "open-vscode",
-    "name": "Open vault in VSCode",
+    "name": "Open vault in VS Code",
     "author": "NomarCub",
-    "description": "Ribbon button and command to open vault as a Visual Studio Code workspace",
+    "description": "Ribbon button and command to open vault as a Visual Studio Code workspace.",
     "repo": "NomarCub/obsidian-open-vscode"
   },
   {
@@ -1703,7 +1703,7 @@
   {
     "id": "obsidian-find-and-replace-in-selection",
     "name": "Find & Replace in Selection",
-    "description": "Replace text within your current selection",
+    "description": "Replace text within your current selection.",
     "author": "TClark1011",
     "repo": "TClark1011/obsidian-find-and-replace-in-selection"
   },
@@ -1732,13 +1732,13 @@
     "id": "mx-bili-plugin",
     "name": "Media Extended BiliBili Plugin",
     "author": "AidenLx",
-    "description": "Add advanced bilibili videos support for Media Extended plugin",
+    "description": "Add advanced bilibili videos support for Media Extended plugin.",
     "repo": "aidenlx/mx-bili-plugin"
   },
   {
     "id": "cmenu-plugin",
     "name": "cMenu",
-    "description": "An Obsidian.md plugin that adds a minimal text editor modal for a smoother writing/editing experience ✍🏽.",
+    "description": "An Obsidian plugin that adds a minimal text editor modal for a smoother writing/editing experience.",
     "author": "Chetachi",
     "repo": "chetachiezikeuzor/cMenu-Plugin"
   },
@@ -1746,14 +1746,14 @@
     "id": "obsidian-daf-yomi",
     "name": "Daf Yomi",
     "author": "lyonsquark",
-    "description": "Prepare Daf Yomi notes",
+    "description": "Prepare Daf Yomi notes.",
     "repo": "lyonsquark/obsidian-daf-yomi"
   },
   {
     "id": "markdown-attributes",
     "name": "Markdown Attributes",
     "author": "Jeremy Valentine",
-    "description": "Add markdown attributes to elements in Obsidian.md",
+    "description": "Add Markdown attributes to elements in Obsidian.",
     "repo": "javalent/markdown-attributes"
   },
   {
@@ -1781,7 +1781,7 @@
     "id": "obsidian-pocket",
     "name": "Pocket integration",
     "author": "Nimalan Mahendran",
-    "description": "Access your Pocket reading list entries and create notes for them easily",
+    "description": "Access your Pocket reading list entries and create notes for them easily.",
     "repo": "nybbles/obsidian-pocket"
   },
   {
@@ -1850,7 +1850,7 @@
   {
     "id": "obsidian-linter",
     "name": "Linter",
-    "description": "Formats and styles your notes. It can be used to format YAML tags, aliases, arrays, and metadata; footnotes; headings; spacing; math blocks; regular markdown contents like list, italics, and bold styles; and more with the use of custom rule options as well.",
+    "description": "Formats and styles your notes. It can be used to format YAML tags, aliases, arrays, and metadata; footnotes; headings; spacing; math blocks; regular Markdown contents like list, italics, and bold styles; and more with the use of custom rule options as well.",
     "author": "Victor Tao",
     "repo": "platers/obsidian-linter"
   },
@@ -1863,8 +1863,8 @@
   },
   {
     "id": "obsidian-view-mode-by-frontmatter",
-    "name": "Force note view mode by front matter",
-    "description": "This plugin allows to force the view mode for a note by using front matter: YAML block with 'obsidian_ui_mode' as key.",
+    "name": "Force note view mode by frontmatter",
+    "description": "This plugin allows to force the view mode for a note by using frontmatter: YAML block with 'obsidian_ui_mode' as key.",
     "author": "Benny Wydooghe",
     "repo": "bwydoogh/obsidian-force-view-mode-of-note"
   },
@@ -1872,7 +1872,7 @@
     "id": "file-explorer-markdown-titles",
     "name": "File Explorer Markdown Titles",
     "author": "Dylan Elliott",
-    "description": "Shows the first markdown header of a note in the file explorer",
+    "description": "Shows the first Markdown header of a note in the file explorer.",
     "repo": "Dyldog/file-explorer-markdown-titles"
   },
   {
@@ -1892,7 +1892,7 @@
   {
     "id": "emoji-shortcodes",
     "name": "Emoji Shortcodes",
-    "description": "This Plugin enables the use of Markdown Emoji Shortcodes :smile:, just like in Slack or Discord",
+    "description": "Enable the use of Markdown Emoji shortcodes :smile:, just like in Slack or Discord.",
     "author": "phibr0",
     "repo": "phibr0/obsidian-emoji-shortcodes"
   },
@@ -1900,21 +1900,21 @@
     "id": "obsidian-reminder-plugin",
     "name": "Reminder",
     "author": "uphy",
-    "description": "Manage markdown TODOs with reminder.",
+    "description": "Manage Markdown TODOs with reminder.",
     "repo": "uphy/obsidian-reminder"
   },
   {
     "id": "obsidian-go-to-line",
     "name": "Go to Line",
     "author": "phibr0",
-    "description": "This Plugin provides a go to Line Command",
+    "description": "Provides a Go to Line Command",
     "repo": "phibr0/obsidian-go-to-line"
   },
   {
     "id": "open-with",
     "name": "Open with",
     "author": "phibr0",
-    "description": "This Plugin allows you to add multiple other programs to open notes with.",
+    "description": "Allows you to add multiple other programs to open notes with.",
     "repo": "phibr0/obsidian-open-with"
   },
   {
@@ -1935,7 +1935,7 @@
     "id": "obsidian-rich-links",
     "name": "Obsidian Rich Links",
     "author": "dhamaniasad",
-    "description": "Rich Links plugin that allows you to convert URLs in your notes to rich link previews",
+    "description": "Rich Links plugin that allows you to convert URLs in your notes to rich link previews.",
     "repo": "dhamaniasad/obsidian-rich-links"
   },
   {
@@ -1956,14 +1956,14 @@
     "id": "tag-page-preview",
     "name": "Tag Page Preview",
     "author": "aidurber",
-    "description": "Clicking a tag opens a dialog listing pages that use that tag",
+    "description": "Clicking a tag opens a dialog listing pages that use that tag.",
     "repo": "aidurber/tag-page-preview"
   },
   {
     "id": "obsidian-relative-find",
     "name": "Relative Find",
     "author": "phibr0",
-    "description": "This Plugin lets you search relative to your Cursor Position.",
+    "description": "Search relative to your cursor position.",
     "repo": "phibr0/obsidian-relative-find"
   },
   {
@@ -1997,7 +1997,7 @@
   {
     "id": "obsidian-code-block-enhancer",
     "name": "Code Block Enhancer",
-    "description": "Enhance obsidian markdown code block,provides copy button,linenumber,language name tip and so on.",
+    "description": "Enhance Obsidian Markdown code block,provides copy button,linenumber,language name tip and so on.",
     "author": "hafuhafu",
     "repo": "nyable/obsidian-code-block-enhancer"
   },
@@ -2011,7 +2011,7 @@
   {
     "id": "drawio-obsidian",
     "name": "Diagrams",
-    "description": "Create and edit Draw.io diagrams in obsidian",
+    "description": "Create and edit Draw.io diagrams in Obsidian.",
     "author": "Sam Greenhalgh",
     "repo": "zapthedingbat/drawio-obsidian"
   },
@@ -2026,7 +2026,7 @@
     "id": "luhman",
     "name": "Luhman",
     "author": "Dylan Elliott",
-    "description": "Commands for handling a zettelkasten with Luhman-style IDs as filenames",
+    "description": "Commands for handling a zettelkasten with Luhman-style IDs as filenames.",
     "repo": "Dyldog/luhman-obsidian-plugin"
   },
   {
@@ -2046,7 +2046,7 @@
   {
     "id": "obsidian-annotator",
     "name": "Annotator",
-    "description": "A plugin for reading and annotating PDFs and EPUBs in obsidian.",
+    "description": "A plugin for reading and annotating PDFs and EPUBs in Obsidian.",
     "author": "Elias Sundqvist",
     "repo": "elias-sundqvist/obsidian-annotator"
   },
@@ -2054,13 +2054,13 @@
     "id": "customjs",
     "name": "CustomJS",
     "author": "Sam Lewis",
-    "description": "Reuse custom javascript across desktop and mobile.",
+    "description": "Reuse custom JavaScript across desktop and mobile.",
     "repo": "samlewis0602/obsidian-custom-js"
   },
   {
     "id": "random-structural-diary-plugin",
     "name": "Random Structural Diary",
-    "description": "This is a plugin for picking random questions from prepared question list. It allows you answer on different questions each time.",
+    "description": "This is a plugin for picking random questions from a prepared question list. It allows you answer on different questions each time.",
     "author": "Timur Sidoriuk",
     "repo": "ShockThunder/RandomStructuralDiary"
   },
@@ -2117,7 +2117,7 @@
     "id": "obsidian-jupyter",
     "name": "Jupyter",
     "author": "tillahoffmann",
-    "description": "Run python code in Obsidian using jupyter.",
+    "description": "Run Python code in Obsidian using Jupyter.",
     "repo": "tillahoffmann/obsidian-jupyter"
   },
   {
@@ -2159,7 +2159,7 @@
     "id": "obsidian-markmind",
     "name": "Obsidian markmind",
     "author": "Mark",
-    "description": "Mind map, outline and pdf annotate tool for Obsidian. (Closed Source)",
+    "description": "Mind map, outline and PDF annotate tool for Obsidian. (Closed Source)",
     "repo": "MarkMindCkm/obsidian-markmind"
   },
   {
@@ -2221,42 +2221,42 @@
   {
     "id": "obsidian-read-it-later",
     "name": "Obsidian ReadItLater",
-    "description": "Collect interesting information from you clipboard into your vault. A website will be converted to MD, Tweets and Youtube Videos embedded, plain text will just saved into a new notice.",
+    "description": "Collect interesting information from you clipboard into your vault. A website will be converted to MD, Tweets and YouTube Videos embedded, plain text will just saved into a new notice.",
     "author": "Dominik Pieper",
     "repo": "DominikPieper/obsidian-ReadItLater"
   },
   {
     "id": "obsidian42-text-transporter",
     "name": "Obsidian42 - Text Transporter",
-    "description": "Advanced text tools for working with text in your vault",
+    "description": "Advanced text tools for working with text in your vault.",
     "author": "TfTHacker",
     "repo": "TfTHacker/obsidian42-text-transporter"
   },
   {
     "id": "marginnote-companion",
     "name": "MarginNote Companion",
-    "description": "An Obsidian plugin to bridge MarginNote 3 and Obsidian",
+    "description": "An Obsidian plugin to bridge MarginNote 3 and Obsidian.",
     "author": "AidenLx",
     "repo": "aidenlx/marginnote-companion"
   },
   {
     "id": "netwik",
     "name": "Netwik",
-    "description": "Union Vault. This plugin provides access to global network of notes. Anyone can create, view or edit notes. All changes will be synchronized between all participants",
+    "description": "Union Vault. This plugin provides access to global network of notes. Anyone can create, view or edit notes. All changes will be synchronized between all participants.",
     "author": "Boris Bondarenko",
     "repo": "fivol/netwik-obsidian"
   },
   {
     "id": "obsidian-prominent-starred-files",
     "name": "Prominent Bookmarked Files",
-    "description": "Prominently display bookmarked notes in the file explorer",
+    "description": "Prominently display bookmarked notes in the file explorer.",
     "author": "Jeremy Valentine",
     "repo": "javalent/prominent-files"
   },
   {
     "id": "ozanshare-publish",
     "name": "OzanShare Publish",
-    "description": "Publish your markdown notes with a single click from your vault. (Closed Source)",
+    "description": "Publish your Markdown notes with a single click from your vault. (Closed Source)",
     "author": "Ozan Tellioglu",
     "repo": "ozntel/ozanshare-publish-plugin"
   },
@@ -2264,7 +2264,7 @@
     "id": "obsidian-editor-shortcuts",
     "name": "Code Editor Shortcuts",
     "author": "Tim Hor",
-    "description": "Add keyboard shortcuts (hotkeys) commonly found in code editors such as Visual Studio Code (vscode) or Sublime Text",
+    "description": "Add keyboard shortcuts (hotkeys) commonly found in code editors such as Visual Studio Code (VS Code) or Sublime Text.",
     "repo": "timhor/obsidian-editor-shortcuts"
   },
   {
@@ -2283,8 +2283,8 @@
   },
   {
     "id": "quick-latex",
-    "name": "Quick Latex for Obsidian",
-    "description": "A simple plugin to simplify and speedup latex math typing.",
+    "name": "Quick LaTeX for Obsidian",
+    "description": "A simple plugin to simplify and speed up LaTeX math typing.",
     "author": "joeyuping",
     "repo": "joeyuping/quick_latex_obsidian"
   },
@@ -2305,21 +2305,21 @@
   {
     "id": "update-time-on-edit",
     "name": "Update frontmatter time on edit",
-    "description": "Keep front matter in sync with the last edit time",
+    "description": "Keep frontmatter in sync with the last edit time.",
     "author": "beaussan",
     "repo": "beaussan/update-time-on-edit-obsidian"
   },
   {
     "id": "obsidian-nomnoml-diagram",
     "name": "Nomnoml Diagram",
-    "description": "Draw nomnoml diagrams in Obsidian notes",
+    "description": "Draw nomnoml diagrams in Obsidian notes.",
     "author": "Daeik Kim",
     "repo": "Daeik/obsidian-nomnoml-diagram"
   },
   {
     "id": "map-of-content",
     "name": "Map of Content",
-    "description": "Automatically generate a Map of Content for your vault",
+    "description": "Automatically generate a Map of Content for your vault.",
     "author": "Robin Haupt",
     "repo": "Robin-Haupt-1/Obsidian-Map-of-Content"
   },
@@ -2333,7 +2333,7 @@
   {
     "id": "obsidian-vocabulary-view",
     "name": "Vocabulary View",
-    "description": "Write down some words with their explanations and preview them in a vocabulary test style",
+    "description": "Write down some words with their explanations and preview them in a vocabulary test style.",
     "author": "nnshi-s",
     "repo": "nnshi-s/obsidian-vocabulary-view-plugin"
   },
@@ -2348,7 +2348,7 @@
     "id": "snippet-commands-obsidian",
     "name": "Snippet Commands",
     "author": "death_au",
-    "description": "Registers custom css snippets as commands (which you can bind hotkeys to)",
+    "description": "Registers custom CSS snippets as commands (which you can bind hotkeys to).",
     "repo": "deathau/snippet-commands-obsidian"
   },
   {
@@ -2417,7 +2417,7 @@
   {
     "id": "obsidian-hypothesis-plugin",
     "name": "Hypothesis Highlights",
-    "description": "Sync your Hypothesis highlights",
+    "description": "Sync your Hypothesis highlights.",
     "author": "weichenw",
     "repo": "weichenw/obsidian-hypothesis-plugin"
   },
@@ -2467,27 +2467,27 @@
     "id": "improved-vimcursor",
     "name": "Improved VimCursor",
     "author": "hhhapz",
-    "description": "An improved experience with the cursor in obsidian",
+    "description": "An improved experience with the cursor in Obsidian.",
     "repo": "hhhapz/improved-obsidian-vimcursor"
   },
   {
     "id": "quote-of-the-day",
     "name": "Quote of the Day",
-    "description": "Inserts random quotes in the editor",
+    "description": "Inserts random quotes in the editor.",
     "author": "Florin Bobis",
     "repo": "twentytwokhz/quote-of-the-day"
   },
   {
     "id": "obsidian-audio-speed-plugin",
     "name": "Audio Speed Plugin",
-    "description": "Change the playback rate of audio files during markdown preview.",
+    "description": "Change the playback rate of audio files during Markdown preview.",
     "author": "kaizau",
     "repo": "kaizau/obsidian-audio-speed-plugin"
   },
   {
     "id": "obsidian-limelight",
     "name": "Limelight",
-    "description": "Spotlight your active pane",
+    "description": "Spotlight your active pane.",
     "author": "Scott Mikula",
     "repo": "smikula/obsidian-limelight"
   },
@@ -2509,7 +2509,7 @@
     "id": "obsidian-chess",
     "name": "Obsidian Chess",
     "author": "pmorim",
-    "description": "All you need to create your Chess related notes",
+    "description": "All you need to create your chess-related notes.",
     "repo": "pmorim/obsidian-chess"
   },
   {
@@ -2529,7 +2529,7 @@
   {
     "id": "stenography-obsidian",
     "name": "Stenography",
-    "description": "Translate code blocks into simple English using Machine Learning with the Stenography API",
+    "description": "Translate code blocks into simple English using Machine Learning with the Stenography API.",
     "author": "bramses",
     "repo": "bramses/stenography-obsidian"
   },
@@ -2550,14 +2550,14 @@
   {
     "id": "obsidian-habitica-integration",
     "name": "Habitica Sync",
-    "description": "This plugin helps integrate Habitica user tasks and stats into Obsidian",
+    "description": "This plugin helps integrate Habitica user tasks and stats into Obsidian.",
     "author": "Leoh and Ran",
     "repo": "SuperChamp234/habitica-sync"
   },
   {
     "id": "obsidian-oura-plugin",
     "name": "Oura Plugin for Obsidian",
-    "description": "A plugin for importing oura ring data into a note",
+    "description": "A plugin for importing oura ring data into a note.",
     "author": "Andrew Lombardi",
     "repo": "kinabalu/obsidian-oura-plugin"
   },
@@ -2578,49 +2578,49 @@
   {
     "id": "graph-analysis",
     "name": "Graph Analysis",
-    "description": "Find hidden connections between notes in your vault using cool graph algorithms",
+    "description": "Find hidden connections between notes in your vault using cool graph algorithms.",
     "author": "SkepticMystic & Emile",
     "repo": "SkepticMystic/graph-analysis"
   },
   {
     "id": "obsidian-custom-attachment-location",
     "name": "Custom Attachment Location",
-    "description": "Customize attachment location with variables($filename, $data, etc) like typora.",
+    "description": "Customize attachment location with variables($filename, $data, etc) like Typora.",
     "author": "RainCat1998",
     "repo": "RainCat1998/obsidian-custom-attachment-location"
   },
   {
     "id": "cryptsidian",
     "name": "Cryptsidian",
-    "description": "Encrypt all files in your Obsidian Vault with a password.",
+    "description": "Encrypt all files in your Obsidian vault with a password.",
     "author": "triumphantomato",
     "repo": "triumphantomato/cryptsidian"
   },
   {
     "id": "obsidian-crypto-lookup",
     "name": "Crypto Lookup for Obsidian",
-    "description": "A plugin for Obsidian which uses the Cryptonator API to pull back prices for crypto in a target currency",
+    "description": "A plugin for Obsidian which uses the Cryptonator API to pull back prices for crypto in a target currency.",
     "author": "Andrew Lombardi",
     "repo": "kinabalu/obsidian-crypto-lookup"
   },
   {
     "id": "copy-as-latex",
-    "name": "Copy as Latex",
-    "description": "Plugin to quickly copy markdown as Latex, with citations",
+    "name": "Copy as LaTeX",
+    "description": "Plugin to quickly copy Markdown as LaTeX, with citations.",
     "author": "mo-seph",
     "repo": "mo-seph/obsidian-copy-as-latex"
   },
   {
     "id": "obsidian-auto-split",
     "name": "Auto Split",
-    "description": "Open notes with split editor & preview",
+    "description": "Open notes with split editor & preview.",
     "author": "James Sartelle",
     "repo": "jsartelle/obsidian-auto-split"
   },
   {
     "id": "obsidian-word-sprint",
     "name": "Word Sprint for Obsidian",
-    "description": "Word Sprint for Obsidian plugin for your writing projects like Nanowrimo",
+    "description": "Word Sprint for Obsidian plugin for your writing projects like NaNoWriMo.",
     "author": "Andrew Lombardi",
     "repo": "kinabalu/obsidian-word-sprint"
   },
@@ -2635,13 +2635,13 @@
     "id": "card-board",
     "name": "CardBoard",
     "author": "roovo",
-    "description": "Display markdown tasks on kanban-style boards.",
+    "description": "Display Markdown tasks on kanban-style boards.",
     "repo": "roovo/obsidian-card-board"
   },
   {
     "id": "obsidian-bible-reference",
     "name": "Bible Reference",
-    "description": "Taking Bible Study note in Obsidian.md application easily. Automatically suggesting Bible Verses as references.",
+    "description": "Take Bible study notes in Obsidian easily. Automatically suggests Bible verses as references.",
     "author": "tim-hub",
     "repo": "tim-hub/obsidian-bible-reference"
   },
@@ -2649,7 +2649,7 @@
     "id": "obsidian-sentence-navigator",
     "name": "Sentence Navigator",
     "author": "Tim Hor & Andrew Brown",
-    "description": "Manipulate sentences as a unit of movement",
+    "description": "Manipulate sentences as a unit of movement.",
     "repo": "timhor/obsidian-sentence-navigator"
   },
   {
@@ -2662,7 +2662,7 @@
   {
     "id": "auto-class",
     "name": "Auto Class",
-    "description": "Automatically apply CSS classes to markdown views based on a note's path.",
+    "description": "Automatically apply CSS classes to Markdown views based on a note's path.",
     "author": "OfficerHalf",
     "repo": "OfficerHalf/obsidian-auto-class"
   },
@@ -2670,20 +2670,20 @@
     "id": "obsidian-cloudinary-uploader",
     "name": "Obsidian Cloudinary Uploader",
     "author": "Jordan Handy",
-    "description": "Upload pasted images from your clipboard to Cloudinary",
+    "description": "Upload pasted images from your clipboard to Cloudinary.",
     "repo": "jordanhandy/obsidian-cloudinary-uploader"
   },
   {
     "id": "rss-reader",
     "name": "RSS Reader",
-    "description": "Read articles from RSS feeds and incorporate them into your notes",
+    "description": "Read articles from RSS feeds and incorporate them into your notes.",
     "author": "Johannes Theiner",
     "repo": "joethei/obsidian-rss"
   },
   {
     "id": "mousewheel-image-zoom",
     "name": "Mousewheel Image zoom",
-    "description": "This plugin enables you to increase/decrease the size of an image by scrolling",
+    "description": "This plugin enables you to increase/decrease the size of an image by scrolling.",
     "author": "Nico Jeske",
     "repo": "nicojeske/mousewheel-image-zoom"
   },
@@ -2718,14 +2718,14 @@
   {
     "id": "cooklang-obsidian",
     "name": "CookLang Editor",
-    "description": "Edit and display CookLang recipes in Obsidian",
+    "description": "Edit and display CookLang recipes in Obsidian.",
     "author": "death_au",
     "repo": "deathau/cooklang-obsidian"
   },
   {
     "id": "highlightr-plugin",
     "name": "Highlightr",
-    "description": "A minimal and aesthetically pleasing highlighting menu that makes color-coded highlighting much easier with a configurable assortment of highlight colors 🎨.",
+    "description": "A minimal and aesthetically pleasing highlighting menu that makes color-coded highlighting much easier with a configurable assortment of highlight colors.",
     "author": "Chetachi",
     "repo": "chetachiezikeuzor/Highlightr-Plugin"
   },
@@ -2739,14 +2739,14 @@
   {
     "id": "obsidian-notes-from-template",
     "name": "From Template",
-    "description": "Create new notes from Templates - for each Template, provides a Command to trigger it, and a form to fill in any variables in the template",
+    "description": "Create new notes from Templates - for each Template, provides a Command to trigger it, and a form to fill in any variables in the template.",
     "author": "mo-seph",
     "repo": "mo-seph/obsidian-note-from-template"
   },
   {
     "id": "obsidian-overdue",
     "name": "Overdue",
-    "description": "Marks items as [[Overdue]] if they are not checked off by their due date",
+    "description": "Marks items as [[Overdue]] if they are not checked off by their due date.",
     "author": "Peter Parente",
     "repo": "parente/obsidian-overdue"
   },
@@ -2760,7 +2760,7 @@
   {
     "id": "obsidian-title-serial-number-plugin",
     "name": "Title Serial Number Plugin",
-    "description": "This plugin adds serial numbers to your markdown title.",
+    "description": "This plugin adds serial numbers to your Markdown title.",
     "author": "Domenic",
     "repo": "yalvhe2009/obsidian-title-serial-number-plugin"
   },
@@ -2774,14 +2774,14 @@
   {
     "id": "generic-initiative-tracker",
     "name": "Generic Initiative Tracker",
-    "description": "TTRPG Generic Initiative Tracker",
+    "description": "TTRPG Generic Initiative Tracker.",
     "author": "Beau Shinkle",
     "repo": "beaushinkle/obsidian-generic-initiative-tracker"
   },
   {
     "id": "obsidian-ankibridge",
     "name": "AnkiBridge",
-    "description": "Yet Another Anki Bridge. Focuses on a strict grammar and integrity of your data",
+    "description": "Yet Another Anki Bridge. Focuses on a strict grammar and integrity of your data.",
     "author": "JeppeKlitgaard",
     "repo": "JeppeKlitgaard/ObsidianAnkiBridge"
   },
@@ -2816,7 +2816,7 @@
   {
     "id": "get-info-plugin",
     "name": "Get Info",
-    "description": "Get Info is a plugin that tucks a menu inside your status bar and shows helpful information for your chosen file 📄.",
+    "description": "Get Info is a plugin that tucks a menu inside your status bar and shows helpful information for your chosen file.",
     "author": "Chetachi",
     "repo": "chetachiezikeuzor/Get-Info-Plugin"
   },
@@ -2837,14 +2837,14 @@
   {
     "id": "obsidian-wordpress",
     "name": "Publish to WordPress for Obsidian",
-    "description": "A plugin to publish your Obsidian documents to WordPress",
+    "description": "A plugin to publish your Obsidian documents to WordPress.",
     "author": "devbean",
     "repo": "devbean/obsidian-wordpress"
   },
   {
     "id": "obsidian-icon-shortcodes",
     "name": "Icon Shortcodes",
-    "description": "Insert emoji and custom icons with shortcodes",
+    "description": "Insert emoji and custom icons with shortcodes.",
     "author": "AidenLx",
     "repo": "aidenlx/obsidian-icon-shortcodes"
   },
@@ -2859,13 +2859,13 @@
     "id": "obsidian-advanced-slides",
     "name": "Advanced Slides",
     "author": "MSzturc",
-    "description": "Create markdown-based presentations in Obsidian",
+    "description": "Create Markdown-based presentations in Obsidian.",
     "repo": "MSzturc/obsidian-advanced-slides"
   },
   {
     "id": "obsidian-graphviz",
     "name": "Obsidian Graphviz",
-    "description": "Render Graphviz Diagrams",
+    "description": "Render Graphviz diagrams.",
     "author": "Feng Peng",
     "repo": "QAMichaelPeng/obsidian-graphviz"
   },
@@ -2908,13 +2908,13 @@
     "id": "obsidian-native-scrollbars",
     "name": "Native Scrollbars",
     "author": "mgmeyers",
-    "description": "Enables native OS scrollbars throughout obsidian",
+    "description": "Enables native OS scrollbars throughout Obsidian.",
     "repo": "mgmeyers/obsidian-native-scrollbars"
   },
   {
     "id": "obsidian-wrap-with-shortcuts",
     "name": "Wrap with shortcuts",
-    "description": "Wrap selected text in custom tags with shortcuts. E.g.: underline, sub, ruby(フリガナ)",
+    "description": "Wrap selected text in custom tags with shortcuts. E.g.: underline, sub, ruby(フリガナ).",
     "author": "Manic Chuang",
     "repo": "manic/obsidian-wrap-with-shortcuts"
   },
@@ -2922,14 +2922,14 @@
     "id": "obsidian-tomorrows-daily-note",
     "name": "Tomorrow's Daily Note",
     "author": "Will Olson",
-    "description": "An obsidian plugin that creates tomorrow's daily note for preemtive planning.",
+    "description": "An Obsidian plugin that creates tomorrow's daily note for preemtive planning.",
     "repo": "frankolson/obsidian-tomorrows-daily-note"
   },
   {
     "id": "obsidian-rant",
     "name": "Rant-Lang",
     "author": "Leander Neiß",
-    "description": "Thin wrapper around the high-level procedural templating language Rant",
+    "description": "Thin wrapper around the high-level procedural templating language Rant.",
     "repo": "lanice/obsidian-rant"
   },
   {
@@ -2942,7 +2942,7 @@
   {
     "id": "obsidian-global-hotkeys",
     "name": "Global Hotkeys",
-    "description": "Configurable system-wide hotkeys for running commands in Obsidian's desktop app",
+    "description": "Configurable system-wide hotkeys for running commands in Obsidian's desktop app.",
     "author": "Marc Jessome",
     "repo": "mjessome/obsidian-global-hotkeys"
   },
@@ -2957,20 +2957,20 @@
     "id": "obsidian-import-json",
     "name": "JSON/CSV Importer",
     "author": "farling42",
-    "description": "Import a JSON file containing an array of data, creating notes from a Handlebars template file",
+    "description": "Import a JSON file containing an array of data, creating notes from a Handlebars template file.",
     "repo": "farling42/obsidian-import-json"
   },
   {
     "id": "import-foundry",
     "name": "Foundry world Importer",
     "author": "farling42",
-    "description": "Imports your journal entries from your selected Foundry VTT world into a folder within your Obsidian Vault",
+    "description": "Imports your journal entries from your selected Foundry VTT world into a folder within your Obsidian vault.",
     "repo": "farling42/obsidian-import-foundry"
   },
   {
     "id": "obsidian-attachment-name-formatting",
     "name": "Attachment Name Formatting",
-    "description": "Formatting attachments name (filename attachmentType indexNumber.xxx)",
+    "description": "Formatting attachments name (filename attachmentType indexNumber.xxx).",
     "author": "JYC333",
     "repo": "JYC333/obsidian-attachment-name-formatting"
   },
@@ -2978,13 +2978,13 @@
     "id": "obsidian-completr",
     "name": "Completr",
     "author": "tth05",
-    "description": "This plugin provides advanced auto-completion functionality for LaTeX, Frontmatter and standard writing.",
+    "description": "This plugin provides advanced auto-completion functionality for LaTeX, frontmatter and standard writing.",
     "repo": "tth05/obsidian-completr"
   },
   {
     "id": "obsidian-binary-file-manager-plugin",
     "name": "Binary File Manager",
-    "description": "Detects new binary files in the vault and create markdown files with metadata.",
+    "description": "Detects new binary files in the vault and create Markdown files with metadata.",
     "author": "qawatake",
     "repo": "qawatake/obsidian-binary-file-manager-plugin"
   },
@@ -3118,14 +3118,14 @@
     "id": "multi-column-markdown",
     "name": "Multi-Column Markdown",
     "author": "Cameron Robinson",
-    "description": "Create markdown documents with multiple columns of content viewable within Obsidian's preview mode.",
+    "description": "Create Markdown documents with multiple columns of content viewable within Obsidian's preview mode.",
     "repo": "ckRobinson/multi-column-markdown"
   },
   {
     "id": "copy-as-html",
     "name": "Copy as HTML",
     "author": "Bailey Jennings",
-    "description": "This is a simple plugin that converts the selected markdown to HTML and copies it to the clipboard.",
+    "description": "This is a simple plugin that converts the selected Markdown to HTML and copies it to the clipboard.",
     "repo": "jenningsb2/copy-as-html"
   },
   {
@@ -3230,27 +3230,27 @@
     "id": "insert-heading-link",
     "name": "Insert Heading Link",
     "author": "Signynt",
-    "description": "Add a command to create a Link to a Heading.",
+    "description": "Add a command to create a link to a heading.",
     "repo": "Signynt/insert-heading-link"
   },
   {
     "id": "settings-search",
     "name": "Settings Search",
     "author": "Jeremy Valentine",
-    "description": "Globally search settings in Obsidian.md",
+    "description": "Globally search settings in Obsidian.",
     "repo": "javalent/settings-search"
   },
   {
     "id": "japanese-word-splitter",
     "name": "Word Splitting for Japanese in Edit Mode",
     "author": "sonarAIT",
-    "description": "A patch for Obsidian's built-in CodeMirror Editor to support Japanese word splitting",
+    "description": "A patch for Obsidian's built-in CodeMirror Editor to support Japanese word splitting.",
     "repo": "sonarAIT/cm-japanese-patch"
   },
   {
     "id": "alx-folder-note-folderv",
     "name": "AidenLx's Folder Note - folderv Component",
-    "description": "Optional `folderv` Component for alx-folder-note",
+    "description": "Optional `folderv` component for alx-folder-note.",
     "author": "AidenLx",
     "repo": "aidenlx/alx-folder-note-folderv"
   },
@@ -3265,7 +3265,7 @@
     "id": "todoist-text",
     "name": "Todoist Text",
     "author": "Wes Moncrief",
-    "description": "This obsidian plugin integrates your Todoist tasks with markdown checkboxes.",
+    "description": "This Obsidian plugin integrates your Todoist tasks with Markdown checkboxes.",
     "repo": "wesmoncrief/obsidian-todoist-text"
   },
   {
@@ -3279,28 +3279,28 @@
     "id": "obsidian-command-palette-minus-plugin",
     "name": "Command Palette--",
     "author": "qawatake",
-    "description": "Command palette without unwanted commands",
+    "description": "Command palette without unwanted commands.",
     "repo": "qawatake/obsidian-command-palette-minus-plugin"
   },
   {
     "id": "obsidian-remember-file-state",
     "name": "Remember File State",
     "author": "Ludovic Chabant",
-    "description": "Remembers cursor position, selection, scrolling, and more for each file",
+    "description": "Remembers cursor position, selection, scrolling, and more for each file.",
     "repo": "ludovicchabant/obsidian-remember-file-state"
   },
   {
     "id": "obsidian-things-link",
     "name": "Things Link",
     "author": "@gavmn",
-    "description": "Seamlessly link an Obsidian Note to a Things Project",
+    "description": "Seamlessly link an Obsidian Note to a Things Project.",
     "repo": "gavinmn/obsidian-things-link"
   },
   {
     "id": "markdown-shortcuts",
     "name": "Markdown shortcuts",
     "author": "Jules Guesnon",
-    "description": "Allows to write markdown from shortcuts",
+    "description": "Allows to write Markdown from shortcuts",
     "repo": "JulesGuesnon/obsidian-markdown-shortcuts"
   },
   {
@@ -3313,7 +3313,7 @@
   {
     "id": "obsidian-living-graph",
     "name": "Living Graph",
-    "description": "A for-fun graph plugin",
+    "description": "A for-fun graph plugin.",
     "author": "Garrett",
     "repo": "geoffreysflaminglasersword/obsidian-living-graph"
   },
@@ -3321,21 +3321,21 @@
     "id": "obsidian-hotkeys-chords",
     "name": "Hotkeys Chords",
     "author": "Dario Balboni",
-    "description": "Configurable hotkeys chords to activate obsidian commands",
+    "description": "Configurable hotkeys chords to activate Obsidian commands.",
     "repo": "trenta3/obsidian-hotkeys-chords"
   },
   {
     "id": "obsidian-key-sequence-shortcut",
     "name": "Key Sequence Shortcut",
     "author": "anselmwang",
-    "description": "Execute obsidian commands with short key sequences. For example, 'tp' for 'Toggle Preview' and 'tb' for 'Toggle Sidebar'. Easier to remember.",
+    "description": "Execute Obsidian commands with short key sequences. For example, 'tp' for 'Toggle Preview' and 'tb' for 'Toggle Sidebar'. Easier to remember.",
     "repo": "anselmwang/obsidian-key-sequence-shortcut"
   },
   {
     "id": "obsidian-full-calendar",
     "name": "Full Calendar",
     "author": "Davis Haupt (@davish)",
-    "description": "Keep events and manage your calendar alongside all your other notes in your Obsidian Vault.",
+    "description": "Keep events and manage your calendar alongside all your other notes in your Obsidian vault.",
     "repo": "davish/obsidian-full-calendar"
   },
   {
@@ -3363,7 +3363,7 @@
     "id": "obsidian-mark-and-select",
     "name": "Mark and Select",
     "author": "anselmwang",
-    "description": "Allow users to set mark, move cursors freely and select from mark to cursor position",
+    "description": "Allow users to set mark, move cursors freely and select from mark to cursor position.",
     "repo": "anselmwang/obsidian-mark-and-select"
   },
   {
@@ -3377,21 +3377,21 @@
     "id": "obsidian-circuitjs",
     "name": "Obsidian CircuitJS",
     "author": "Steven Gann",
-    "description": "Embeds CircuitJS circuit simulations into notes",
+    "description": "Embeds CircuitJS circuit simulations into notes.",
     "repo": "StevenGann/obsidian-circuitjs"
   },
   {
     "id": "creases",
     "name": "Creases",
     "author": "Liam Cain",
-    "description": "Tools for effectively folding markdown sections in Obsidian",
+    "description": "Tools for effectively folding Markdown sections in Obsidian.",
     "repo": "liamcain/obsidian-creases"
   },
   {
     "id": "obsidian-kobo-highlights-importer-plugin",
     "name": "Kobo Highlights Importer",
     "author": "Kevin Hellemun & Flavio Cordari",
-    "description": "Import highlights from Kobo devices",
+    "description": "Import highlights from Kobo devices.",
     "repo": "OGKevin/obsidian-kobo-highlights-import"
   },
   {
@@ -3419,7 +3419,7 @@
     "id": "obsidian-search-everywhere-plugin",
     "name": "Search Everywhere",
     "author": "Mom0",
-    "description": "Search Everywhere with pressing Double Shift like in IntelliJ",
+    "description": "Search everywhere by pressing double shift like in IntelliJ.",
     "repo": "mom0aut/obsidian-search-everywhere"
   },
   {
@@ -3447,7 +3447,7 @@
     "id": "obsidian-extract-pdf-annotations",
     "name": "Extract PDF Annotations",
     "author": "Franz Achermann",
-    "description": "Extract PDF Annotations (Notes and Highlights) and sort them by topics",
+    "description": "Extract PDF Annotations (Notes and Highlights) and sort them by topics.",
     "repo": "munach/obsidian-extract-pdf-annotations"
   },
   {
@@ -3461,7 +3461,7 @@
     "id": "obsidian-card-view-switcher-plugin",
     "name": "Card View Switcher",
     "author": "qawatake",
-    "description": "Quick switcher with card view",
+    "description": "Quick switcher with card view.",
     "repo": "qawatake/obsidian-card-view-switcher-plugin"
   },
   {
@@ -3475,14 +3475,14 @@
     "id": "heycalmdown-navigate-cursor-history",
     "name": "Navigate Cursor History",
     "author": "heycalmdown",
-    "description": "This plugin remembers the recent cursor positions history and allows you to jump to them back and forth like VSCode",
+    "description": "This plugin remembers the recent cursor positions history and allows you to jump to them back and forth like VS Code.",
     "repo": "heycalmdown/navigate-cursor-history"
   },
   {
     "id": "obsidian-matrix",
     "name": "Obsidian matrix",
     "author": "Jonas Mohr",
-    "description": "Utility to easily create LaTeX matrices",
+    "description": "Utility to easily create LaTeX matrices.",
     "repo": "NastyGamer/obsidian-matrix"
   },
   {
@@ -3496,7 +3496,7 @@
     "id": "obsidian-hover-editor",
     "name": "Hover Editor",
     "author": "NothingIsLost",
-    "description": "Transform the Page Preview hover popover into a fully working editor instance",
+    "description": "Transform the Page Preview hover popover into a fully working editor instance.",
     "repo": "nothingislost/obsidian-hover-editor"
   },
   {
@@ -3517,7 +3517,7 @@
     "id": "obsidian-format-code",
     "name": "Format code blocks of various languages",
     "author": "iVariable",
-    "description": "This plugin introduces commands to format code (internally uses prettier)",
+    "description": "This plugin introduces commands to format code (internally uses prettier).",
     "repo": "iVariable/Obsidian-Format-Code"
   },
   {
@@ -3531,14 +3531,14 @@
     "id": "lapel",
     "name": "Lapel",
     "author": "Liam Cain",
-    "description": "Show the heading levels in the gutter of the editor",
+    "description": "Show the heading levels in the gutter of the editor.",
     "repo": "liamcain/obsidian-lapel"
   },
   {
     "id": "obsidian-desmos",
     "name": "Desmos",
     "author": "Nigecat",
-    "description": "Embed Desmos graphs into your notes",
+    "description": "Embed Desmos graphs into your notes.",
     "repo": "Nigecat/obsidian-desmos"
   },
   {
@@ -3552,14 +3552,14 @@
     "id": "obsidian-etherpad-plugin",
     "name": "Etherpad Lite",
     "author": "egradman",
-    "description": "Copy and sync notes with an Etherpad Lite server to unlock easy web-based collaboration with others",
+    "description": "Copy and sync notes with an Etherpad Lite server to unlock easy web-based collaboration with others.",
     "repo": "egradman/obsidian-etherpad-lite"
   },
   {
     "id": "obsidian-quiet-outline",
     "name": "Quiet Outline",
     "author": "the_tree",
-    "description": "Make outline quiet and more powerful, including no-auto-expand, rendering heading as markdown, and search support.",
+    "description": "Make outline quiet and more powerful, including no-auto-expand, rendering heading as Markdown, and search support.",
     "repo": "guopenghui/obsidian-quiet-outline"
   },
   {
@@ -3587,7 +3587,7 @@
     "id": "obsidian-path-title",
     "name": "Path Title",
     "author": "Justin Deal",
-    "description": "Adds path (or optional replacement) to the filename title of each pane",
+    "description": "Adds path (or optional replacement) to the filename title of each pane.",
     "repo": "jdeal/obsidian-path-title-plugin"
   },
   {
@@ -3608,7 +3608,7 @@
     "id": "control-characters",
     "name": "Control Characters",
     "author": "Johannes Theiner",
-    "description": "Show control/non-printing characters in edit mode",
+    "description": "Show control/non-printing characters in edit mode.",
     "repo": "joethei/obsidian-control-characters"
   },
   {
@@ -3622,7 +3622,7 @@
     "id": "fleeting-notes-obsidian",
     "name": "Fleeting Notes Sync",
     "author": "Matthew Wong",
-    "description": "This is a plugin to sync Fleeting Notes with Obsidian",
+    "description": "This is a plugin to sync Fleeting Notes with Obsidian.",
     "repo": "fleetingnotes/fleeting-notes-obsidian"
   },
   {
@@ -3636,56 +3636,56 @@
     "id": "obsidian-doubleshift",
     "name": "Doubleshift",
     "author": "Qwyntex",
-    "description": "Open the command palette by pressing Shift (or any other key) twice like in IntelliJ and create your own shortcuts",
+    "description": "Open the command palette by pressing Shift (or any other key) twice like in IntelliJ and create your own shortcuts.",
     "repo": "qwyntex/doubleshift"
   },
   {
     "id": "obsidian-list-modified",
     "name": "List Modified",
     "author": "Francis Kafieh",
-    "description": "A simple obsidian plugin that links all modified files meeting certain criteria to a daily note",
+    "description": "A simple Obsidian plugin that links all modified files meeting certain criteria to a daily note.",
     "repo": "franciskafieh/obsidian-list-modified"
   },
   {
     "id": "obsidian-latex-suite",
     "name": "Latex Suite",
     "author": "artisticat1",
-    "description": "Make typesetting LaTeX math as fast as handwriting through snippets, text expansion, and editor enhancements",
+    "description": "Make typesetting LaTeX math as fast as handwriting through snippets, text expansion, and editor enhancements.",
     "repo": "artisticat1/obsidian-latex-suite"
   },
   {
     "id": "obsidian-better-codeblock",
     "name": "Better CodeBlock",
     "author": "StarGrey",
-    "description": "Add title, line numbers, and collapse button to code blocks in reading view",
+    "description": "Add title, line numbers, and collapse button to code blocks in reading view.",
     "repo": "stargrey/obsidian-better-codeblock"
   },
   {
     "id": "obsidian-wordnik",
     "name": "Obsidian Wordnik Definitions",
     "author": "Henry Gustafson",
-    "description": "Grabs information from Wordnik for a topic and brings it into Obsidian notes",
+    "description": "Grabs information from Wordnik for a topic and brings it into Obsidian notes.",
     "repo": "lizard-heart/obsidian-wordnik-definitions"
   },
   {
     "id": "typing-speed",
     "name": "Typing speed",
     "author": "supercyp",
-    "description": "A plugin for showing the current typing speed in the status bar",
+    "description": "A plugin for showing the current typing speed in the status bar.",
     "repo": "supercip971/obsidian-typing-speed"
   },
   {
     "id": "obsidian-google-tasks",
     "name": "Google Tasks",
     "author": "YukiGasai",
-    "description": "Interact with your Google Tasks from inside Obsidian",
+    "description": "Interact with your Google Tasks from inside Obsidian.",
     "repo": "YukiGasai/obsidian-google-tasks"
   },
   {
     "id": "obsidian-jtab",
     "name": "Obsidian jTab",
     "author": "davfive",
-    "description": "Add guitar chords and tabs to your notes with jTab codeblocks",
+    "description": "Add guitar chords and tabs to your notes with jTab code blocks.",
     "repo": "davfive/obsidian-jtab"
   },
   {
@@ -3720,7 +3720,7 @@
     "id": "obsidian-snippet-downloader",
     "name": "Snippet Downloader",
     "author": "Mara-Li",
-    "description": "A obsidian's plugin to help to manage css snippets (download / update) from repository",
+    "description": "A Obsidian's plugin to help to manage CSS snippets (download / update) from repository.",
     "repo": "Lisandra-dev/obsidian-snippet-downloader"
   },
   {
@@ -3748,7 +3748,7 @@
     "id": "obsidian-drag-n-drop-plugin",
     "name": "Drag-n-Drop for blocks",
     "author": "Artem Barmin",
-    "description": "Allow moving/copying/and creation embeds for blocks with drag-n-drop just like Logseq or Roam",
+    "description": "Allow moving/copying/and creation embeds for blocks with drag-n-drop just like Logseq or Roam Research.",
     "repo": "artem-barmin/obsidian-block-drag-n-drop"
   },
   {
@@ -3762,7 +3762,7 @@
     "id": "obsidian-columns",
     "name": "Obsidian Columns",
     "author": "Trevor Nichols",
-    "description": "Allows you to create columns in Obsidian Markdown",
+    "description": "Allows you to create columns in Obsidian Markdown.",
     "repo": "tnichols217/obsidian-columns"
   },
   {
@@ -3776,7 +3776,7 @@
     "id": "obsidian-notion-video",
     "name": "Notion Video Embed",
     "author": "lastknightcoder",
-    "description": "embed your notion video in obsidian",
+    "description": "Embed your Notion video in Obsidian.",
     "repo": "LastKnightCoder/obsidian-notion-video"
   },
   {
@@ -3790,7 +3790,7 @@
     "id": "obsidian-todoist-link",
     "name": "Todoist Link",
     "author": "dennisseidel",
-    "description": "Create Todoist tasks and projects including bidirectional links from Obsidian",
+    "description": "Create Todoist tasks and projects including bidirectional links from Obsidian.",
     "repo": "dennisseidel/obsidian-todoist-link"
   },
   {
@@ -3811,7 +3811,7 @@
     "id": "omnisearch",
     "name": "Omnisearch",
     "author": "Simon Cambier",
-    "description": "Intelligent search for your notes, PDFs, and OCR for images",
+    "description": "Intelligent search for your notes, PDFs, and OCR for images.",
     "repo": "scambier/obsidian-omnisearch"
   },
   {
@@ -3832,7 +3832,7 @@
     "id": "notion-like-tables",
     "name": "Notion-Like Tables",
     "author": "Trey Wallis",
-    "description": "Create markdown tables using an interface similar to that found in Notion.so.",
+    "description": "Create Markdown tables using an interface similar to that found in Notion.",
     "repo": "trey-wallis/obsidian-notion-like-tables"
   },
   {
@@ -3853,14 +3853,14 @@
     "id": "obsidian-folder-index",
     "name": "Folder Index",
     "author": "turulix",
-    "description": "Automatic MOC for folders",
+    "description": "Automatic MOC for folders.",
     "repo": "turulix/obsidian-folder-index"
   },
   {
     "id": "obsidian-filename-emoji-remover",
     "name": "Filename Emoji Remover",
     "author": "Yüksel Tolun",
-    "description": "This is a simple plugin to automatically remove emojis from filenames. Main purpose is to get rid of Dropbox sync issues for Readwise imported content",
+    "description": "This is a simple plugin to automatically remove emojis from filenames. Main purpose is to get rid of Dropbox sync issues for Readwise imported content.",
     "repo": "YTolun/obsidian-filename-emoji-remover"
   },
   {
@@ -3881,7 +3881,7 @@
     "id": "obsidian-enhancing-export",
     "name": "Obsidian Enhancing Export",
     "author": "YISH",
-    "description": "A enhancing export plugin base on pandoc for Obsidian. It allows to export to formats like Html, DOCX, ePub and PDF or Hugo.",
+    "description": "A enhancing export plugin base on pandoc for Obsidian. It allows to export to formats like HTML, DOCX, ePub and PDF or Hugo.",
     "repo": "mokeyish/obsidian-enhancing-export"
   },
   {
@@ -3895,7 +3895,7 @@
     "id": "obsidian-release-timeline",
     "name": "Release Timeline",
     "author": "cakechaser",
-    "description": "Release timeline rendered based on notes metadata with a dataview-like syntax.",
+    "description": "Release timeline rendered based on notes metadata with a Dataview-like syntax.",
     "repo": "cakechaser/obsidian-release-timeline"
   },
   {
@@ -3909,7 +3909,7 @@
     "id": "obsidian-bbcode",
     "name": "BBCode Convertor",
     "author": "Alex Lockhart",
-    "description": "Convert Markdown files to BBCode",
+    "description": "Convert Markdown files to BBCode.",
     "repo": "salockhart/obsidian-bbcode"
   },
   {
@@ -3923,14 +3923,14 @@
     "id": "nuke-orphans",
     "name": "Nuke Orphans",
     "author": "Sandorex",
-    "description": "Plugin that trashes orphaned files and attachments",
+    "description": "Plugin that trashes orphaned files and attachments.",
     "repo": "sandorex/nuke-orphans-plugin"
   },
   {
     "id": "obsidian-front-matter-title-plugin",
     "name": "Front Matter Title",
     "author": "Snezhig",
-    "description": "Lets you define a title in frontmatter to be displayed as the filename",
+    "description": "Lets you define a title in frontmatter to be displayed as the filename.",
     "repo": "Snezhig/obsidian-front-matter-title"
   },
   {
@@ -3944,7 +3944,7 @@
     "id": "obsidian-functionplot",
     "name": "Function Plot",
     "author": "leonhma",
-    "description": "Render mathematical functions in a markdown codeblock.",
+    "description": "Render mathematical functions in a Markdown codeblock.",
     "repo": "leonhma/obsidian-functionplot"
   },
   {
@@ -3965,7 +3965,7 @@
     "id": "obsidian-state-switcher",
     "name": "Yaml Manager",
     "author": "Lijyze",
-    "description": "Keep you away from directly operating yaml front matter.",
+    "description": "Keep you away from directly operating YAML frontmatter.",
     "repo": "lijyze/obsidian-state-switcher"
   },
   {
@@ -3993,7 +3993,7 @@
     "id": "excalibrain",
     "name": "ExcaliBrain",
     "author": "Zsolt Viczian",
-    "description": "ExcaliBrain is inspired by TheBrain and Breadcrumbs. It is an interactive, structured mind-map of your Obsidian Vault generated based on the folders and files in your Vault by interpreting the links, dataview fields, tags and YAML front matter in your markdown files.",
+    "description": "ExcaliBrain is inspired by TheBrain and Breadcrumbs. It is an interactive, structured mind-map of your Obsidian vault generated based on the folders and files in your vault by interpreting the links, Dataview fields, tags and YAML frontmatter in your Markdown files.",
     "repo": "zsviczian/excalibrain"
   },
   {
@@ -4007,7 +4007,7 @@
     "id": "dbfolder",
     "name": "Database folder",
     "author": "RafaelGB",
-    "description": "Folder with the capability to store and retrieve data from a folder like database",
+    "description": "Folder with the capability to store and retrieve data from a folder like database.",
     "repo": "RafaelGB/obsidian-db-folder"
   },
   {
@@ -4035,35 +4035,35 @@
     "id": "obsidian-camera",
     "name": "Obsidian Camera",
     "author": "Aldrin Jenson",
-    "description": "Create and save Snaps or Video Recordings directly from Obsidian-Desktop",
+    "description": "Create and save Snaps or Video Recordings directly from Obsidian desktop.",
     "repo": "aldrinjenson/obsidian-camera"
   },
   {
     "id": "obsidian-markbase",
     "name": "Markbase for Obsidian",
     "author": "Markbase",
-    "description": "Official Markbase plugin to share your Obsidian notes online in your own digital garden",
+    "description": "Official Markbase plugin to share your Obsidian notes online in your own digital garden.",
     "repo": "markbase-obsidian/obsidian-markbase"
   },
   {
     "id": "obsidian-user-plugins",
     "name": "User Plugins",
     "author": "mnowotnik",
-    "description": "Use js files or snippets to code your own quick and dirty plugins",
+    "description": "Use js files or snippets to code your own quick and dirty plugins.",
     "repo": "mnowotnik/obsidian-user-plugins"
   },
   {
     "id": "obsidian-better-internal-link-inserter",
     "name": "Obsidian Better Internal Link Inserter",
     "author": "Salmund",
-    "description": "Allow to use the selected word as an alias in link suggestion",
+    "description": "Allow to use the selected word as an alias in link suggestion.",
     "repo": "salmund/obsidian-better-link-inserter"
   },
   {
     "id": "obsidian-ghost-publish",
     "name": "Obsidian Ghost Publish",
     "author": "@jaynguyens",
-    "description": "Publish to Ghost site with a single click",
+    "description": "Publish to Ghost site with a single click.",
     "repo": "jaynguyens/obsidian-ghost-publish"
   },
   {
@@ -4077,21 +4077,21 @@
     "id": "linkify",
     "name": "Linkify",
     "author": "Matthew Chan",
-    "description": "Converts matching text into links",
+    "description": "Converts matching text into links.",
     "repo": "matthewhchan/linkify"
   },
   {
     "id": "braincache",
     "name": "braincache",
     "author": "XSPGMike",
-    "description": "Create braincache flashcards from Obsidian",
+    "description": "Create braincache flashcards from Obsidian.",
     "repo": "XSPGMike/braincache_obsidian"
   },
   {
     "id": "obsidian-share-as-gist",
     "name": "Share as Gist",
     "author": "timrogers",
-    "description": "Shares an Obsidian note as a GitHub.com gist",
+    "description": "Shares an Obsidian note as a GitHub.com Gist.",
     "repo": "timrogers/obsidian-share-as-gist"
   },
   {
@@ -4105,13 +4105,13 @@
     "id": "obsidian-google-lookup",
     "name": "Google Calendar and Contacts Lookup",
     "author": "ntawileh",
-    "description": "Import contact and calendar event information from your Google account",
+    "description": "Import contact and calendar event information from your Google account.",
     "repo": "ntawileh/obsidian-google-lookup"
   },
   {
     "id": "obsidian-stack-overflow",
     "name": "Stack Overflow Answers",
-    "description": "Copy and Paste Stack Overflow answers directly into Obsidian.",
+    "description": "Copy and paste Stack Overflow answers directly into Obsidian.",
     "author": "bramses",
     "repo": "bramses/obsidian-stack-overflow"
   },
@@ -4140,7 +4140,7 @@
     "id": "obsidian-to-notion",
     "name": "Obsidian shared to Notion",
     "author": "Easychris",
-    "description": "This is a  plugin for Obsidian. This plugin share obsidian md file to notion with notion api",
+    "description": "This plugin shares Obsidian files to Notion with the Notion API",
     "repo": "Easychris/obsidian-to-notion"
   },
   {
@@ -4154,7 +4154,7 @@
     "id": "obsidian-thumbnails",
     "name": "Thumbnails",
     "author": "Michael Harris",
-    "description": "Insert youtube thumbnails into your notes",
+    "description": "Insert YouTube thumbnails into your notes",
     "repo": "Meikul/obsidian-thumbnails"
   },
   {
@@ -4189,7 +4189,7 @@
     "id": "obsidian-echarts",
     "name": "echarts",
     "author": "windily-cloud && Cuman",
-    "description": "Render echarts in obsidian",
+    "description": "Render echarts in Obsidian",
     "repo": "cumany/obsidian-echarts"
   },
   {
@@ -4202,7 +4202,7 @@
   {
     "id": "obsidian-weread-plugin",
     "name": "Weread Plugin",
-    "description": "This is obsidian plugin for Tencent weread.",
+    "description": "This is Obsidian plugin for Tencent weread.",
     "author": "hank zhao",
     "repo": "zhaohongxuan/obsidian-weread-plugin"
   },
@@ -4238,7 +4238,7 @@
     "id": "typing-transformer-obsidian",
     "name": "Typing Transformer",
     "author": "aptend",
-    "description": "Improved, configurable auto formatting as typing",
+    "description": "Improved, configurable auto formatting as typing.",
     "repo": "aptend/typing-transformer-obsidian"
   },
   {
@@ -4259,21 +4259,21 @@
     "id": "metadata-menu",
     "name": "Metadata Menu",
     "author": "mdelobelle",
-    "description": "For data quality enthusiasts and dataview users: access and manage the metadata of your notes",
+    "description": "For data quality enthusiasts and Dataview users: access and manage the metadata of your notes.",
     "repo": "mdelobelle/metadatamenu"
   },
   {
     "id": "obsidian-plugin-time-diff",
     "name": "TimeDiff plugin",
     "author": "Grzegorz Dominiczak",
-    "description": "Calculates and displays diff in hours and minutes between two dates in `timediff` markdown block",
+    "description": "Calculates and displays diff in hours and minutes between two dates in `timediff` Markdown block.",
     "repo": "dominiczaq/obsidian-plugin-time-diff"
   },
   {
     "id": "obsidian-trim-whitespace",
     "name": "Trim Whitespace",
     "author": "Zack Lovatt",
-    "description": "Trims unnecessary whitespace from your Obsidian documents",
+    "description": "Trims unnecessary whitespace from your Obsidian documents.",
     "repo": "zlovatt/obsidian-trim-whitespace"
   },
   {
@@ -4322,21 +4322,21 @@
     "id": "obsidian-file-cooker",
     "name": "File Cooker",
     "author": "iuian",
-    "description": "Deal batch notes from Search results、current file、Dataview query string...",
+    "description": "Deal batch notes from search results,current file, or Dataview query string.",
     "repo": "ivaneye/obsidian-files-cooker"
   },
   {
     "id": "hard-breaks",
     "name": "Hard Breaks",
     "author": "Börge Kiss",
-    "description": "Turn soft line breaks in Markdown into hard line breaks",
+    "description": "Turn soft line breaks in Markdown into hard line breaks.",
     "repo": "bkis/obsidian-hard-breaks"
   },
   {
     "id": "open-related-url",
     "name": "Open Related Url",
     "author": "Dan Pickett",
-    "description": "Opens URLs found in a note's YAML frontmatter",
+    "description": "Opens URLs found in a note's YAML frontmatter.",
     "repo": "dpickett/open-related-url"
   },
   {
@@ -4371,14 +4371,14 @@
     "id": "better-inline-fields",
     "name": "Better Inline Fields",
     "author": "David Sarman",
-    "description": "Enhances Dataview style inline fields",
+    "description": "Enhances Dataview style inline fields.",
     "repo": "dsarman/better-inline-fields"
   },
   {
     "id": "no-dupe-leaves",
     "name": "No Dupe Leaves",
     "author": "Simon Cambier",
-    "description": "Don't reopen notes that are already open",
+    "description": "Don't reopen notes that are already open.",
     "repo": "scambier/obsidian-no-dupe-leaves"
   },
   {
@@ -4392,14 +4392,14 @@
     "id": "obsidian-heading-shifter",
     "name": "Heading Shifter",
     "author": "kasahala",
-    "description": "Easily Shift and Change markdown headings.",
+    "description": "Easily Shift and Change Markdown headings.",
     "repo": "k4a-l/obsidian-heading-shifter"
   },
   {
     "id": "obsidian-group-snippets",
     "name": "Group Snippets",
     "author": "Mara-Li",
-    "description": "Create folder of snippets to activate them in one click !",
+    "description": "Create folder of snippets to activate them in one click!",
     "repo": "Lisandra-dev/obsidian-group-snippets"
   },
   {
@@ -4420,7 +4420,7 @@
     "id": "obsidian-dashing-cursor",
     "name": "Dashing Cursor",
     "author": "Shukai Ni",
-    "description": "Enables dashing cursor that follows the page scroll",
+    "description": "Enables dashing cursor that follows the page scroll.",
     "repo": "9r0x/obsidian-dashing-cursor"
   },
   {
@@ -4447,7 +4447,7 @@
   {
     "id": "literate-haskell",
     "name": "Literate Haskell",
-    "description": "An obsidian plugin for integrating `.lhs` files into your PKM.",
+    "description": "An Obsidian plugin for integrating .lhs files into your PKM.",
     "author": "James Jensen",
     "repo": "jajaperson/obsidian-literate-haskell"
   },
@@ -4455,14 +4455,14 @@
     "id": "embed-code-file",
     "name": "Embed Code File",
     "author": "Abdullah Almariah",
-    "description": "Embed code file from vault using code blocks",
+    "description": "Embed code file from vault using code blocks.",
     "repo": "almariah/embed-code-file"
   },
   {
     "id": "obsidian-bulk-rename-plugin",
     "name": "Bulk Rename",
     "author": "Oleg Lustenko",
-    "description": "Now You Can Rename Files Based On Pattern",
+    "description": "Rename files based on a pattern.",
     "repo": "OlegLustenko/obsidian-bulk-rename"
   },
   {
@@ -4483,28 +4483,28 @@
     "id": "obsidian-open-in-other-editor",
     "name": "Open In Other Editor",
     "author": "Yekingyan",
-    "description": "Open current active file in gVim or VScode.",
+    "description": "Open current active file in gVim or VS Code.",
     "repo": "yekingyan/obsidian-open-in-other-editor"
   },
   {
     "id": "obsidian-simple-mention",
     "name": "Simple Mention",
     "author": "der-tobi",
-    "description": "Get highlighted mentions and mention suggestions. Find all occurrences of a mention",
+    "description": "Get highlighted mentions and mention suggestions. Find all occurrences of a mention.",
     "repo": "der-tobi/obsidian-simple-mention"
   },
   {
     "id": "obsidian-auto-hide",
     "name": "Auto Hide",
     "author": "skelato1",
-    "description": "Collapse sidebars when clicking on the editor/viewer panel",
+    "description": "Collapse sidebars when clicking on the editor/viewer panel.",
     "repo": "skelato1/obsidian-auto-hide"
   },
   {
     "id": "janitor",
     "name": "Janitor",
     "author": "Gabriele Cannata",
-    "description": "Performs cleanup tasks on the Obsidian vault",
+    "description": "Performs cleanup tasks on the Obsidian vault.",
     "repo": "Canna71/obsidian-janitor"
   },
   {
@@ -4539,21 +4539,21 @@
     "id": "todoist-completed-tasks-plugin",
     "name": "Todoist completed tasks",
     "author": "Andrey Kulishov",
-    "description": "Add completed Todoist tasks to your Obsidian notes",
+    "description": "Add completed Todoist tasks to your Obsidian notes.",
     "repo": "Ledaryy/obsidian-todoist-completed-tasks"
   },
   {
     "id": "quick-snippets-and-navigation",
     "name": "Quick snippets and navigation",
     "author": "@aciq",
-    "description": "Keyboard navigation up/down for headings\n- Configurable default code block and callout\n- Copy code block via keyboard shortcut",
+    "description": "Keyboard navigation up/down for headings\n- Configurable default code block and callout\n- Copy code block via keyboard shortcut.",
     "repo": "aciq/obsidian-keyboard-shortcuts"
   },
   {
     "id": "google-calendar",
     "name": "Google Calendar",
     "author": "YukiGasai",
-    "description": "Interact with your Google Calendar from inside Obsidian",
+    "description": "Interact with your Google Calendar from inside Obsidian.",
     "repo": "YukiGasai/obsidian-google-calendar"
   },
   {
@@ -4588,21 +4588,21 @@
     "id": "custom-sort",
     "name": "Custom File Explorer sorting",
     "author": "SebastianMC",
-    "description": "Allows for manual and automatic, config-driven reordering and sorting of files and folders in File Explorer",
+    "description": "Allows for manual and automatic, config-driven reordering and sorting of files and folders in File Explorer.",
     "repo": "SebastianMC/obsidian-custom-sort"
   },
   {
     "id": "obsidian-table-generator",
     "name": "Table Generator",
     "author": "Boninall",
-    "description": "A plugin for generate markdown table quickly like Typora.",
+    "description": "A plugin for generate Markdown table quickly like Typora.",
     "repo": "quorafind/obsidian-table-generator"
   },
   {
     "id": "aosr",
     "name": "Aosr",
     "author": "linanwx",
-    "description": "Another obsidian spaced repetition. It uses flashcards to help review and remember knowledge.",
+    "description": "Another Obsidian spaced repetition. It uses flashcards to help review and remember knowledge.",
     "repo": "linanwx/aosr"
   },
   {
@@ -4644,21 +4644,21 @@
     "id": "chronology",
     "name": "Chronology",
     "author": "Gabriele Cannata",
-    "description": "Provides a calendar and a timeline of the notes creation and modification",
+    "description": "Provides a calendar and a timeline of the notes creation and modification.",
     "repo": "Canna71/obsidian-chronology"
   },
   {
     "id": "duplicate-line",
     "name": "Duplicate Line",
     "author": "1C0D",
-    "description": "To duplicate a line",
+    "description": "To duplicate a line.",
     "repo": "1C0D/duplicate-line-obsidian"
   },
   {
     "id": "obsidian-toggle-list",
     "name": "ToggleList",
     "author": "Lite C",
-    "description": "This is a simple plugin to toggle the checklist states (paragraph/list/checklist/custom sytles...)",
+    "description": "A simple plugin to toggle the checklist states (paragraph/list/checklist/custom sytles...).",
     "repo": "thingnotok/obsidian-toggle-list"
   },
   {
@@ -4707,14 +4707,14 @@
     "id": "mathlinks",
     "name": "MathLinks",
     "author": "Zhaoshen Zhai",
-    "description": "Render MathJax in your links",
+    "description": "Render MathJax in your links.",
     "repo": "zhaoshenzhai/obsidian-mathlinks"
   },
   {
     "id": "note-synchronizer",
     "name": "Note Synchronizer",
     "author": "Songchen Tan",
-    "description": "This is a plugin for synchornizing Obsidian notes to other note-based softwares like Anki, following more strictly the principles of Zettelkasten and treating each Obsidian file as a note.",
+    "description": "This is a plugin for synchronizing Obsidian notes to other note-based softwares like Anki, following more strictly the principles of Zettelkasten and treating each Obsidian file as a note.",
     "repo": "tansongchen/obsidian-note-synchronizer"
   },
   {
@@ -4728,7 +4728,7 @@
     "id": "obsidian-douban-plugin",
     "name": "Douban",
     "author": "Wanxp",
-    "description": "This is a plugin that can import movies/books/musics/notes/games info data from Douban for Obsidian .",
+    "description": "This is a plugin that can import movies/books/musics/notes/games info data from Douban for Obsidian.",
     "repo": "Wanxp/obsidian-douban"
   },
   {
@@ -4742,14 +4742,14 @@
     "id": "keyboard-analyzer",
     "name": "Keyboard Analyzer",
     "author": "cogscides",
-    "description": "See and analyse your keyboard hotkeys and shortcuts",
+    "description": "See and analyse your keyboard hotkeys and shortcuts.",
     "repo": "cogscides/obsidian-keyboard-analyzer"
   },
   {
     "id": "obsidian-plugin-update-tracker",
     "name": "Plugin Update Tracker",
     "author": "Steven Swartz",
-    "description": "Know when installed plugins have updates and evaluate the risk of upgrading",
+    "description": "Know when installed plugins have updates and evaluate the risk of upgrading.",
     "repo": "swar8080/obsidian-plugin-update-tracker"
   },
   {
@@ -4791,7 +4791,7 @@
     "id": "obsidian-dynamic-background",
     "name": "Dynamic Background",
     "author": "Samuel Song",
-    "description": "Adding dynamic background effects to the Obsidian editor",
+    "description": "Adding dynamic background effects to the Obsidian editor.",
     "repo": "samuelsong70/obsidian-dynamic-background"
   },
   {
@@ -4819,7 +4819,7 @@
     "id": "obsidian-ocr",
     "name": "Obsidian OCR",
     "author": "Jonas Mohr",
-    "description": "Use optical character recognition to search for text in you images and PDFs",
+    "description": "Use optical character recognition to search for text in you images and PDFs.",
     "repo": "MohrJonas/obsidian-ocr"
   },
   {
@@ -4833,7 +4833,7 @@
     "id": "obsidian-account-linker",
     "name": "Account Linker",
     "author": "qwegat",
-    "description": "Plugin for describing external service accounts in the front matter",
+    "description": "Plugin for describing external service accounts in the frontmatter.",
     "repo": "qwegat/Obsidian-Account-Linker"
   },
   {
@@ -4847,14 +4847,14 @@
     "id": "obsidian-mtg",
     "name": "Obsidian MtG",
     "author": "omardelarosa",
-    "description": "A plugin for managing Magic: The Gathering decks and card lists as Obsidian notes",
+    "description": "A plugin for managing Magic: The Gathering decks and card lists as Obsidian notes.",
     "repo": "omardelarosa/obsidian-mtg"
   },
   {
     "id": "obsidian-markdown-file-suffix",
     "name": "More Markdown file suffix (.mdx/.svx)",
     "author": "swissmation.com",
-    "description": "Use additional files like .mdx / .svx as if they were markdown.",
+    "description": "Use additional files like .mdx / .svx as if they were Markdown.",
     "repo": "git-no/obsidian-markdown-file-suffix"
   },
   {
@@ -4881,7 +4881,7 @@
   {
     "id": "status-bar-quote",
     "name": "Status Bar Quote",
-    "description": "Show your favorite quote in obsidian status bar",
+    "description": "Show your favorite quote in Obsidian status bar.",
     "author": "Jinu",
     "repo": "yesjinu/StatusBarQuote"
   },
@@ -4889,7 +4889,7 @@
     "id": "qmd-as-md-obsidian",
     "name": "qmd as md",
     "author": "Daniel Borek",
-    "description": "This plugin provides an initial support for viewing files with .qmd extension. QMD files contain a combination of markdown and executable code cells and are a format supported by Quarto open source publishing system.",
+    "description": "This plugin provides an initial support for viewing files with .qmd extension. QMD files contain a combination of Markdown and executable code cells and are a format supported by Quarto open source publishing system.",
     "repo": "danieltomasz/qmd-as-md-obsidian"
   },
   {
@@ -4903,21 +4903,21 @@
     "id": "obsidian-things3-sync",
     "name": "Obsidian Things3 Sync",
     "author": "royx",
-    "description": "A Plugin for syncing between Obsidian and Things3. Supporting with Multi Language, Tags and Date.",
+    "description": "A plugin for syncing between Obsidian and Things3. Supporting multi-language, tags and dates.",
     "repo": "royxue/obsidian-things3-sync"
   },
   {
     "id": "mathpad",
     "name": "Mathpad",
     "author": "Gabriele Cannata",
-    "description": "Computer Algebra System and Calculator for Onsidian",
+    "description": "Computer Algebra System and calculator for Obsidian",
     "repo": "Canna71/obsidian-mathpad"
   },
   {
     "id": "list-style",
     "name": "Ordered List Style",
     "author": "erykwalder",
-    "description": "Set ordered list style inline. Alphabetic lists, roman numeral lists, etc.",
+    "description": "Set ordered list style inline. Alphabetic lists, Roman numeral lists, etc.",
     "repo": "erykwalder/obsidian-list-style"
   },
   {
@@ -4952,7 +4952,7 @@
     "id": "obsidian-daily-note-outline",
     "name": "Daily Note Outline",
     "author": "iiz",
-    "description": "Add a custom view which shows outline of multiple daily notes with headings, links, tags and list items",
+    "description": "Add a custom view which shows outline of multiple daily notes with headings, links, tags and list items.",
     "repo": "iiz00/obsidian-daily-note-outline"
   },
   {
@@ -4987,7 +4987,7 @@
     "id": "ava",
     "name": "Ava",
     "author": "louis030195",
-    "description": "Quickly format your notes with ChatGPT",
+    "description": "Quickly format your notes with ChatGPT.",
     "repo": "louis030195/obsidian-ava"
   },
   {
@@ -5000,7 +5000,7 @@
   {
     "id": "obsidian-old-note-admonitor",
     "name": "Old Note Admonitor",
-    "description": "This Obsidian plugin shows warnings if the note has not been updated for over specific days",
+    "description": "This Obsidian plugin shows warnings if the note has not been updated for over specific days.",
     "author": "tadashi-aikawa",
     "repo": "tadashi-aikawa/obsidian-old-note-admonitor"
   },
@@ -5028,7 +5028,7 @@
   {
     "id": "obsidian-dynbedded",
     "name": "Dynbedded",
-    "description": "Dynamic Embeds for Obsidian.md",
+    "description": "Dynamic embeds for Obsidian.",
     "author": "Marcus Breiden",
     "repo": "MMoMM-org/obsidian-dynbedded"
   },
@@ -5050,7 +5050,7 @@
     "id": "obsidian-dirtreeist",
     "name": "Dirtreeist",
     "author": "kasahala",
-    "description": "Render a directory Structure Diagram from a markdown lists in codeblock.",
+    "description": "Render a directory Structure Diagram from a Markdown lists in codeblock.",
     "repo": "k4a-l/obsidian-dirtreeist"
   },
   {
@@ -5085,7 +5085,7 @@
     "id": "emo-uploader",
     "name": "Emo",
     "author": "yaleiyale",
-    "description": "Embed markdown online file/image links. This plugin is for uploading images to hosting or files to github in Obsidian.",
+    "description": "Embed Markdown online file/image links. This plugin is for uploading images to hosting or files to github in Obsidian.",
     "repo": "yaleiyale/obsidian-emo-uploader"
   },
   {
@@ -5099,13 +5099,13 @@
     "id": "obsidian-quran-lookup",
     "name": "Quran Lookup",
     "author": "Abu Ibrahim",
-    "description": "Easily add Quran verses and translations in Obsidian with this text replacement plugin",
+    "description": "Easily add Quran verses and translations in Obsidian with this text replacement plugin.",
     "repo": "abuibrahim2/quranlookup"
   },
   {
     "id": "sigma",
     "name": "Obsidian Sigma",
-    "description": "A plugin to enable using obsidian notes as calculation sheets.",
+    "description": "A plugin to enable using Obsidian notes as calculation sheets.",
     "author": "monesga",
     "repo": "monesga/obsidian-sigma"
   },
@@ -5113,7 +5113,7 @@
     "id": "better-reading-mode",
     "name": "Better Reading Mode",
     "author": "Boninall",
-    "description": "A plugin to enable bionic reading mode in Live preview mode of Obsidian.",
+    "description": "A plugin to enable bionic reading mode in Live Preview mode of Obsidian.",
     "repo": "quorafind/obsidian-better-reading-mode"
   },
   {
@@ -5127,7 +5127,7 @@
     "id": "obsidian-md-to-jira",
     "name": "Markdown to Jira Converter",
     "author": "muckmuck",
-    "description": "A plugin for converting notes or selections to jira markup and vice versa",
+    "description": "A plugin for converting notes or selections to Jira markup and vice versa.",
     "repo": "muckmuck96/obsidian-md-to-jira"
   },
   {
@@ -5141,14 +5141,14 @@
     "id": "obsidian-code-preview",
     "name": "Code Preview",
     "author": "Hank",
-    "description": "CodeBlock preview by file path",
+    "description": "Code block preview by file path.",
     "repo": "zjhcn/obsidian-code-preview"
   },
   {
     "id": "obsidian-toggle-meta-yaml-plugin",
     "name": "Toggle Meta Yaml",
     "author": "hua",
-    "description": "This is a simple plugin to toggle meta yaml.",
+    "description": "This is a simple plugin to toggle meta YAML.",
     "repo": "hua03/obsidian-toggle-meta-yaml-plugin"
   },
   {
@@ -5176,7 +5176,7 @@
     "id": "obsidian-image-layouts",
     "name": "Image Layouts",
     "author": "Luke Chadwick",
-    "description": "Add beautiful image layouts to your notes",
+    "description": "Add beautiful image layouts to your notes.",
     "repo": "vertis/obsidian-image-layouts"
   },
   {
@@ -5218,34 +5218,34 @@
     "id": "numerals",
     "name": "Numerals",
     "author": "RyanC",
-    "description": "Numerals turns any code block into an advanced calculator. Evaluates math expressions on each line of a code block, including units, currency, and optional TeX rendering",
+    "description": "Numerals turns any code block into an advanced calculator. Evaluates math expressions on each line of a code block, including units, currency, and optional TeX rendering.",
     "repo": "gtg922r/obsidian-numerals"
   },
   {
     "id": "obsidian-plugin-dynamodb",
     "name": "AWS DynamoDB For Obsidian",
     "author": "Lee Nattress",
-    "description": "Query AWS DynamoDB and render tables inside documents",
+    "description": "Query AWS DynamoDB and render tables inside documents.",
     "repo": "leenattress/obsidian-plugin-dynamodb"
   },
   {
     "id": "hidden-folder-obsidian",
     "name": "Hidden Folder",
     "author": "ptrsvltns",
-    "description": "Hidden Folder",
+    "description": "Hidden Folder.",
     "repo": "ptrsvltns/hidden-folder-obsidian"
   },
   {
     "id": "make-md",
     "name": "MAKE.md",
-    "description": "Make.md brings you features that supercharges Obsidian. Sort your files in custom order and add file icons using Spaces. Edit inline embeds with Flow Editor. And style your text and add new markdown blocks without writing markdown using Maker Mode.",
+    "description": "Make.md brings you features that supercharges Obsidian. Sort your files in custom order and add file icons using Spaces. Edit inline embeds with Flow Editor. And style your text and add new Markdown blocks without writing Markdown using Maker Mode.",
     "author": "MAKE.md",
     "repo": "Make-md/makemd"
   },
   {
     "id": "obsidian-markdown-export-plugin",
-    "name": "Obsidian markdown export",
-    "description": "This is a markdown export plugin for Obsidian.",
+    "name": "Obsidian Markdown export",
+    "description": "This is a Markdown export plugin for Obsidian.",
     "author": "bingryan",
     "repo": "bingryan/obsidian-markdown-export-plugin"
   },
@@ -5253,28 +5253,28 @@
     "id": "sync-graph-settings",
     "name": "Sync Graph Settings",
     "author": "Xallt",
-    "description": "This is a plugin for syncing Global Graph settings (like Color Groups) to Local Graphs",
+    "description": "This is a plugin for syncing Global Graph settings (like Color Groups) to Local Graphs.",
     "repo": "Xallt/sync-graph-settings"
   },
   {
     "id": "writing",
     "name": "Writing",
     "author": "johackim",
-    "description": "Write and format your next book directly from Obsidian",
+    "description": "Write and format your next book directly from Obsidian.",
     "repo": "johackim/obsidian-writing"
   },
   {
     "id": "obsidian-transcription",
     "name": "Transcription",
     "author": "djmango (Sulaiman Ghori)",
-    "description": "Plugin to create high-quality transcriptions via Whisper from markdown linked audio files",
+    "description": "Plugin to create high-quality transcriptions via Whisper from Markdown linked audio files.",
     "repo": "djmango/obsidian-transcription"
   },
   {
     "id": "obsidian-mindmap-nextgen",
     "name": "Obsidian Mindmap Nextgen",
     "author": "VeroCloud Pty Ltd (original by James Lynch)",
-    "description": "A plugin to preview notes as Markmap mind maps",
+    "description": "A plugin to preview notes as Markmap mind maps.",
     "repo": "verocloud/obsidian-mindmap-nextgen"
   },
   {
@@ -5316,21 +5316,21 @@
     "id": "obsidian-autoscroll",
     "name": "Autoscroll",
     "author": "Petr Nazarov",
-    "description": "This plugin allows you to automatically scroll down the content with the provided speed",
+    "description": "This plugin allows you to automatically scroll down the content with the provided speed.",
     "repo": "petr-nazarov/obsidian-autoscroll"
   },
   {
     "id": "obsidian-stylist",
     "name": "Obsidian Stylist",
     "author": "ixth",
-    "description": "Obsidian plugin that allows to add classes and styles on markdown blocks",
+    "description": "Obsidian plugin that allows to add classes and styles on Markdown blocks.",
     "repo": "ixth/obsidian-stylist"
   },
   {
     "id": "obsidian-dataset-aid",
     "name": "Text Dataset Aid Plugin",
     "author": "Conner Ohnesorge",
-    "description": "This plugin for obsidian aids in the creation of fine-tuning datasets for language models.",
+    "description": "This plugin for Obsidian aids in the creation of fine-tuning datasets for language models.",
     "repo": "conneroisu/Text-Dataset-Aid-Plugin"
   },
   {
@@ -5344,7 +5344,7 @@
     "id": "crumbs-obsidian",
     "name": "Crumbs",
     "author": "Tony Grosinger",
-    "description": "Breadcrumb navigation",
+    "description": "Breadcrumb navigation.",
     "repo": "tgrosinger/crumbs-obsidian"
   },
   {
@@ -5371,7 +5371,7 @@
   {
     "id": "obsidian-fuzzytag",
     "name": "FuzzyTag",
-    "description": "Fuzzy match autocomplete tags in Frontmatter",
+    "description": "Fuzzy match autocomplete tags in frontmatter.",
     "author": "Adrian",
     "repo": "adriandersen/obsidian-fuzzytag"
   },
@@ -5379,7 +5379,7 @@
     "id": "obsidian-project-garden",
     "name": "Project Garden",
     "author": "Ben Goosman",
-    "description": "See all your projects in one place",
+    "description": "See all your projects in one place.",
     "repo": "bgoosman/obsidian-project-garden"
   },
   {
@@ -5393,7 +5393,7 @@
     "id": "obsidian-readlater",
     "name": "Read Later",
     "author": "Gabriele Cannata",
-    "description": "Synch web pages to markdown and integrate with read-it-later apps (Pocket, Instapaper)",
+    "description": "Synch web pages to Markdown and integrate with read-it-later apps (Pocket, Instapaper).",
     "repo": "Canna71/obsidian-readlater"
   },
   {
@@ -5407,7 +5407,7 @@
     "id": "obsidian-toggle-case",
     "name": "Toggle Case",
     "author": "automattech",
-    "description": "This plugin allows you to set a hotkey to toggle between `lowercase` `UPPERCASE` and `Title Case`",
+    "description": "This plugin allows you to set a hotkey to toggle between `lowercase` `UPPERCASE` and `Title Case`.",
     "repo": "MatthewAlner/obsidian-toggle-case"
   },
   {
@@ -5426,16 +5426,16 @@
   },
   {
     "id": "obsidian-paste-as-html",
-    "name": "Paste As Html",
+    "name": "Paste As HTML",
     "author": "maotong06",
-    "description": "Paste As Html, Keep the original css style. Paste from web browser",
+    "description": "Paste As HTML, Keep the original CSS style. Paste from web browser.",
     "repo": "maotong06/obsidian-paste-as-html-plugin"
   },
   {
     "id": "file-forgetting-curve-obsidian",
     "name": "File Forgetting Curve",
     "author": "ptrsvltns",
-    "description": "File Forgetting Curve",
+    "description": "File Forgetting Curve.",
     "repo": "ptrsvltns/file-forgetting-curve-obsidian"
   },
   {
@@ -5448,7 +5448,7 @@
   {
     "id": "todo-sort",
     "name": "Todo sort",
-    "description": "Sort todos by completion status",
+    "description": "Sort todos by completion status.",
     "author": "Ryan Gomba",
     "repo": "ryangomba/obsidian-todo-sort"
   },
@@ -5477,14 +5477,14 @@
     "id": "obsidian-local-images-plus",
     "name": "Local images plus",
     "author": "catalysm, aleksey-rezvov, Sergei Korneev",
-    "description": "Local Images plus plugin is a reincarnation of obsidian-local-images which main aim was downloading images in md notes to local storage.",
+    "description": "Local Images plus plugin is a reincarnation of Obsidian-local-images which main aim was downloading images in md notes to local storage.",
     "repo": "Sergei-Korneev/obsidian-local-images-plus"
   },
   {
     "id": "google-photos",
     "name": "Google Photos",
     "author": "Alan Grainger",
-    "description": "Google Photos integration for Obsidian",
+    "description": "Google Photos integration for Obsidian.",
     "repo": "alangrainger/obsidian-google-photos"
   },
   {
@@ -5505,14 +5505,14 @@
     "id": "obsidian-review-notes-plugin",
     "name": "Review Notes Plugin",
     "author": "tjandy98",
-    "description": "This plugin shows recently modified and newly created files",
+    "description": "This plugin shows recently modified and newly created files.",
     "repo": "tjandy98/obsidian-review-notes-plugin"
   },
   {
     "id": "gpt3-notes",
     "name": "GPT-3 Notes",
     "author": "micahke",
-    "description": "Generate notes on any subject using OpenAI's GPT-3 language model",
+    "description": "Generate notes on any subject using OpenAI's GPT-3 language model.",
     "repo": "micahke/obsidian-gpt3-notes"
   },
   {
@@ -5526,14 +5526,14 @@
     "id": "obsidian-checklist-reset",
     "name": "Checklist Reset",
     "author": "Luke Hansford",
-    "description": "Adds a command to reset the state of any checklists in a document",
+    "description": "Adds a command to reset the state of any checklists in a document.",
     "repo": "lhansford/obsidian-checklist-reset"
   },
   {
     "id": "mermaid-tools",
     "name": "Mermaid Tools",
     "author": "dartungar",
-    "description": "Improved Mermaid.js experience for Obsidian: visual toolbar with common elements & more",
+    "description": "Improved Mermaid.js experience for Obsidian: visual toolbar with common elements & more.",
     "repo": "dartungar/obsidian-mermaid"
   },
   {
@@ -5547,7 +5547,7 @@
     "id": "webpage-html-export",
     "name": "Webpage HTML Export",
     "author": "Nathan George",
-    "description": "Exports an obsidian document, folder, or vault as an HTML document / webpage / website with correct styling. Also has an interactive embedded dark / light theme toggle, and document outline.",
+    "description": "Exports an Obsidian document, folder, or vault as an HTML document / webpage / website with correct styling. Also has an interactive embedded dark / light theme toggle, and document outline.",
     "repo": "KosmosisDire/obsidian-webpage-export"
   },
   {
@@ -5561,14 +5561,14 @@
     "id": "set-in-obsidian",
     "name": "Set In Obsidian",
     "author": "Sandorex",
-    "description": "Plugin for time planning",
+    "description": "Plugin for time planning.",
     "repo": "sandorex/set-in-obsidian-plugin"
   },
   {
     "id": "hugo-preview-obsidian",
-    "name": "Hugo preview obsidian",
+    "name": "Hugo preview Obsidian",
     "author": "fzdwx",
-    "description": "hugo preview for obsidian",
+    "description": "Hugo preview for Obsidian.",
     "repo": "fzdwx/hugo-preview-obsidian"
   },
   {
@@ -5588,7 +5588,7 @@
   {
     "id": "obsidian-archivebox-plugin",
     "name": "ArchiveBox",
-    "description": "ArchiveBox.io support for external Obsidian links",
+    "description": "ArchiveBox.io support for external Obsidian links.",
     "author": "invariant",
     "repo": "invariant/obsidian-archivebox-plugin"
   },
@@ -5596,13 +5596,13 @@
     "id": "quote-share",
     "name": "Quote Share",
     "author": "DuocNV",
-    "description": "This plugin allow your to easily generate beautiful gradient images from text and share them on social media",
+    "description": "This plugin allow your to easily generate beautiful gradient images from text and share them on social media.",
     "repo": "nguyenvanduocit/quote-share"
   },
   {
     "id": "canvas-randomnote",
     "name": "Canvas Random Note",
-    "description": "Add random notes from your vault to the Obsidian canvas",
+    "description": "Add random notes from your vault to the Obsidian canvas.",
     "author": "jmilldotdev",
     "repo": "jmilldotdev/obsidian-canvas-randomnote"
   },
@@ -5610,7 +5610,7 @@
     "id": "spoiler-block-obsidian",
     "name": "Spoiler Block",
     "author": "AllJavi",
-    "description": "Just a simple obsidian plugin to hide information until you want to reveal it",
+    "description": "Just a simple Obsidian plugin to hide information until you want to reveal it.",
     "repo": "AllJavi/spoiler-block-obsidian"
   },
   {
@@ -5687,7 +5687,7 @@
     "id": "obsidian-audio-player",
     "name": "Audio Player",
     "author": "noonesimg",
-    "description": "Audio player with background playback, bookmarks and wave visualiser instead of the default html5 audio",
+    "description": "Audio player with background playback, bookmarks and wave visualiser instead of the default HTML5 audio.",
     "repo": "noonesimg/obsidian-audio-player"
   },
   {
@@ -5707,7 +5707,7 @@
   {
     "id": "obsidian-gpt",
     "name": "GPT",
-    "description": "Obsidian plugin for getting language model completions from ChatGPT, GPT-3, and others",
+    "description": "Obsidian plugin for getting language model completions from ChatGPT, GPT-3, and others.",
     "author": "Jonathan Miller",
     "repo": "jmilldotdev/obsidian-gpt"
   },
@@ -5729,7 +5729,7 @@
     "id": "code-emitter",
     "name": "Code Emitter",
     "author": "YISH",
-    "description": "An obsidian plugin that allows code blocks executed interactively in sandbox like jupyter notebooks. Supported language rust、kotlin、python、Javascript、TypeScript etc.",
+    "description": "An Obsidian plugin that allows code blocks executed interactively in sandbox like Jupyter notebooks. Supported language Rust, Kotlin, Python, JavaScript, TypeScript, etc.",
     "repo": "mokeyish/obsidian-code-emitter"
   },
   {
@@ -5757,7 +5757,7 @@
     "id": "image-captions",
     "name": "Image Captions",
     "author": "Alan Grainger",
-    "description": "Adds captions to images when there is alt-text specified",
+    "description": "Adds captions to images when there is alt-text specified.",
     "repo": "alangrainger/obsidian-image-captions"
   },
   {
@@ -5778,7 +5778,7 @@
     "id": "khoj",
     "name": "Khoj",
     "author": "Debanjum Singh Solanky",
-    "description": "Natural, Incremental Search for your Second Brain 🦅",
+    "description": "Natural, Incremental Search for your Second Brain.",
     "repo": "debanjum/khoj"
   },
   {
@@ -5820,14 +5820,14 @@
     "id": "adamantine-pick",
     "name": "Adamantine Pick",
     "author": "Urist McMiner",
-    "description": "Embeddable Pikchr diagrams renderer plugin for Obsidian",
+    "description": "Embeddable Pikchr diagrams renderer plugin for Obsidian.",
     "repo": "notlibrary/obsidian-adamantine-pick"
   },
   {
     "id": "antidote-grammar-checker-integration",
     "name": "Antidote Grammar Checker Integration",
     "author": "Heziode",
-    "description": "Unofficial integration of Antidote, a powerful English and French grammar checker",
+    "description": "Unofficial integration of Antidote, a powerful English and French grammar checker.",
     "repo": "heziode/obsidian-antidote"
   },
   {
@@ -5855,14 +5855,14 @@
     "id": "obs-text-wrapper",
     "name": "Text Wrapper",
     "author": "smx0",
-    "description": "Quickly wrap selected text with HTML tags by using a shortcut or from the command palette",
+    "description": "Quickly wrap selected text with HTML tags by using a shortcut or from the command palette.",
     "repo": "smx0/obs-text-wrapper"
   },
   {
     "id": "kill-and-yank",
     "name": "Kill and Yank",
     "author": "INOUE Takuya",
-    "description": "Enable kill and yank (like Emacs) in the editor",
+    "description": "Enable kill and yank (like Emacs) in the editor.",
     "repo": "inouetakuya/obsidian-kill-and-yank"
   },
   {
@@ -5890,7 +5890,7 @@
     "id": "ytranscript",
     "name": "YTranscript",
     "author": "Łukasz Strzępek",
-    "description": "Easily fetch transcription for any Youtube video",
+    "description": "Easily fetch transcription for any YouTube video.",
     "repo": "lstrzepek/obsidian-yt-transcript"
   },
   {
@@ -5911,7 +5911,7 @@
     "id": "quip",
     "name": "Quip",
     "author": "sblakey",
-    "description": "Commands to publish Obsidian notes to Quip.com",
+    "description": "Commands to publish Obsidian notes to Quip.com.",
     "repo": "sblakey/obsidian-quip"
   },
   {
@@ -5924,7 +5924,7 @@
   {
     "id": "babashka",
     "name": "Babashka",
-    "description": "Evaluate Clojure(Script) codeblocks in Babashka.",
+    "description": "Evaluate Clojure(Script) code blocks in Babashka.",
     "author": "Filipe Silva",
     "repo": "filipesilva/obsidian-babashka"
   },
@@ -5988,13 +5988,13 @@
     "id": "material-symbols",
     "name": "Material Symbols",
     "author": "Cristoph Berane",
-    "description": "This plugin adds the material symbols (outlined) to obsidian",
+    "description": "This plugin adds the material symbols (outlined) to Obsidian.",
     "repo": "cberane/obsidian-material-symbols"
   },
   {
     "id": "unicode-search",
     "name": "Unicode Search",
-    "description": "Search and insert Unicode characters into your editor",
+    "description": "Search and insert Unicode characters into your editor.",
     "author": "BambusControl",
     "repo": "BambusControl/obsidian-unicode-search"
   },
@@ -6009,13 +6009,13 @@
     "id": "latex-algorithms",
     "name": "LaTeX Algorithms",
     "author": "SamZhang02",
-    "description": "Plugin to facilitate writing algorithm blocks in LaTeX",
+    "description": "Plugin to facilitate writing algorithm blocks in LaTeX.",
     "repo": "SamZhang02/obsidian-latex-algorithms"
   },
   {
     "id": "contextual-comments",
     "name": "Contextual Comments",
-    "description": "General comments or langage related (in codeblocks) + 2 commands trim end lines (All doc/codeblocks).",
+    "description": "General comments or langage related (in code blocks) + 2 commands trim end lines (all doc/code blocks).",
     "author": "1C0D",
     "repo": "1C0D/Obsidian-Contextual-Comments"
   },
@@ -6050,7 +6050,7 @@
   {
     "id": "o2",
     "name": "O2",
-    "description": "This is a syntax converting plugin to make obsidian markdown syntax compatible with other markdown syntax.",
+    "description": "This is a syntax converting plugin to make Obsidian Markdown syntax compatible with other Markdown syntax.",
     "author": "haril song",
     "repo": "songkg7/o2"
   },
@@ -6058,7 +6058,7 @@
     "id": "close-similar-tabs",
     "name": "Close Similar Tabs",
     "author": "1C0D",
-    "description": "Avoid to have a file opened several times in your tabs. (+setting: by window or everywhere)",
+    "description": "Avoid to have a file opened several times in your tabs. (+setting: by window or everywhere).",
     "repo": "1C0D/Obsidian-Close-Similar-Tabs"
   },
   {
@@ -6078,7 +6078,7 @@
   {
     "id": "msg-handler",
     "name": "MSG Handler",
-    "description": "Easily display and search MSG files from Outlook in your Obsidian Vault",
+    "description": "Easily display and search MSG files from Outlook in your Obsidian vault.",
     "author": "Ozan Tellioglu",
     "repo": "ozntel/obsidian-msg-handler"
   },
@@ -6107,7 +6107,7 @@
     "id": "mixa",
     "name": "Mixa",
     "author": "Mixa Team",
-    "description": "Publish your notes and blog posts with Mixa directly from Obsidian",
+    "description": "Publish your notes and blog posts with Mixa directly from Obsidian.",
     "repo": "mixasite/obsidian-mixa"
   },
   {
@@ -6135,14 +6135,14 @@
     "id": "callout-integrator",
     "author": "Cleoche",
     "name": "Callout Integrator",
-    "description": "Integrate long blocks of text into callouts",
+    "description": "Integrate long blocks of text into callouts.",
     "repo": "Cleoche/obsidian-callout-integrator"
   },
   {
     "id": "emoji-magic",
     "name": "Emoji Magic",
     "author": "simplgy",
-    "description": "Easily add emoji, with a powerful keyword search. 🔮 ✨ 🐇",
+    "description": "Easily add emoji, with a powerful keyword search.",
     "repo": "simplgy/obsidian-emoji-magic"
   },
   {
@@ -6190,7 +6190,7 @@
   {
     "id": "ibook",
     "name": "ibook",
-    "description": "plugin for Apple ibook.",
+    "description": "Export your Apple iBook hightlights and annotations into your Obsidian vault.",
     "author": "bingryan",
     "repo": "bingryan/obsidian-ibook-plugin"
   },
@@ -6198,7 +6198,7 @@
     "id": "floating-highlights",
     "name": "Floating Highlights",
     "author": "Karthik S Raju",
-    "description": "Enhanced highlights for Obsidian",
+    "description": "Enhanced highlights for Obsidian.",
     "repo": "KarthikRaju391/obsidian-float"
   },
   {
@@ -6212,27 +6212,27 @@
     "id": "nl-fast-image-cleaner",
     "name": "Fast Image Cleaner",
     "author": "Nathaniel",
-    "description": "This plugin allows you to quickly remove image attachment and referenced link from your documents in both LIVE , READ mode by right-click menu",
+    "description": "This plugin allows you to quickly remove image attachment and referenced link from your documents in both LIVE , READ mode by right-click menu.",
     "repo": "martinniee/Obsidian-fast-image-cleaner"
   },
   {
     "id": "fantasy-content-generator",
     "name": "Fantasy Content Generator",
     "author": "Gregory-Jagermeister",
-    "description": "A Fantasy Content Generator for Obsidian for All Your TTRPG / World Building Needs",
+    "description": "A Fantasy Content Generator for Obsidian for All Your TTRPG / World Building Needs.",
     "repo": "Gregory-Jagermeister/Fantasy-Content-Generator"
   },
   {
     "id": "tasks-calendar-wrapper",
     "name": "Tasks Calendar Wrapper",
     "author": "zhuwenq",
-    "description": "This is a simple wrapper for Obsidian-Tasks-Calendar (https://github.com/702573N/Obsidian-Tasks-Calendar) and Obsidian-Tasks-Timeline (https://github.com/702573N/Obsidian-Tasks-Timeline).",
+    "description": "This is a simple wrapper for Obsidian Tasks Calendar and Obsidian Tasks Timeline.",
     "repo": "Leonezz/obsidian-tasks-calendar-wrapper"
   },
   {
     "id": "awesome-brain-manager",
     "name": "Awesome Brain Manager",
-    "description": "A toolkit tries to solve all the trivial problems most people usually encountered in obsidian.",
+    "description": "A toolkit tries to solve all the trivial problems most people usually encountered in Obsidian.",
     "author": "Juck",
     "repo": "JuckZ/awesome-brain-manager"
   },
@@ -6253,7 +6253,7 @@
   {
     "id": "file-publisher",
     "name": "File Publisher",
-    "description": "Publishes a file to a given POST api.",
+    "description": "Publishes a file to a given POST API.",
     "author": "Devin Sackett",
     "repo": "yiglas/obsidian-file-publisher"
   },
@@ -6261,13 +6261,13 @@
     "id": "global-search-and-replace",
     "name": "Global Search and Replace",
     "author": "Mahmoud Fawzy Khalil",
-    "description": "Search and replace in all vault files",
+    "description": "Search and replace in all vault files.",
     "repo": "MahmoudFawzyKhalil/obsidian-global-search-and-replace"
   },
   {
     "id": "image-upload-toolkit",
     "name": "Image Upload Toolkit",
-    "description": "An obsidian plugin for uploading local images embedded in markdown to remote store and export markdown for publishing to static site. Currently, it supports Imgur and Aliyun OSS.",
+    "description": "An Obsidian plugin for uploading local images embedded in Markdown to remote store and export Markdown for publishing to static site. Currently, it supports Imgur and Aliyun OSS.",
     "author": "Addo Zhang",
     "repo": "addozhang/obsidian-image-upload-toolkit"
   },
@@ -6281,14 +6281,14 @@
   {
     "id": "latex-to-unicode",
     "name": "LaTeX to unicode converter",
-    "description": "Convert LaTeX commands into unicode sqeuences",
+    "description": "Convert LaTeX commands into unicode sqeuences.",
     "author": "fjdu",
     "repo": "fjdu/obsidian-latex-unicode"
   },
   {
     "id": "nl-syntax-highlighting",
     "name": "Natural Language Syntax Highlighting",
-    "description": "Highlight adjectives, nouns, adverbs, verbs, and conjunctions in the editor",
+    "description": "Highlight adjectives, nouns, adverbs, verbs, and conjunctions in the editor.",
     "author": "artisticat",
     "repo": "artisticat1/nl-syntax-highlighting"
   },
@@ -6309,7 +6309,7 @@
   {
     "id": "brainframe",
     "name": "Brainframe",
-    "description": "Tools to make Obsidian more into our second brains",
+    "description": "Tools to make Obsidian more into our second brains.",
     "author": "pedersen",
     "repo": "pedersen/obsidian-brainframe"
   },
@@ -6352,7 +6352,7 @@
     "id": "reveal-file-in-explorer",
     "name": "Reveal file in explorer",
     "author": "1C0D",
-    "description": "Clicking header title reveal active file in explorer and (option) when opening file + option to fold other directories",
+    "description": "Clicking header title reveal active file in explorer and (option) when opening file + option to fold other directories.",
     "repo": "1C0D/Obsidian-Reveal-File-in-explorer"
   },
   {
@@ -6380,13 +6380,13 @@
     "id": "page-properties",
     "name": "Page Properties",
     "author": "Anton Bualkh",
-    "description": "Add page properties similar to Logseq",
+    "description": "Add page properties similar to Logseq.",
     "repo": "necauqua/obsidian-page-properties"
   },
   {
     "id": "testing-vault",
     "name": "Testing Vault",
-    "description": "Randomized vault generator with links between notes, front matter, tags, orphan and leaf notes.",
+    "description": "Randomized vault generator with links between notes, frontmatter, tags, orphan and leaf notes.",
     "author": "Michael Pedersen",
     "repo": "pedersen/obsidian-testing-vault"
   },
@@ -6414,7 +6414,7 @@
   {
     "id": "oz-calendar",
     "name": "OZ Calendar",
-    "description": "View your notes in Calendar using any YAML key with a date",
+    "description": "View your notes in Calendar using any YAML key with a date.",
     "author": "Ozan Tellioglu",
     "repo": "ozntel/oz-calendar"
   },
@@ -6436,7 +6436,7 @@
     "id": "pseudocode-in-obs",
     "name": "Pseudocode",
     "author": "Yaotian Liu",
-    "description": "This is an obsidian plugin that helps to render a LaTeX-style pseudocode inside a code block.",
+    "description": "This is an Obsidian plugin that helps to render a LaTeX-style pseudocode inside a code block.",
     "repo": "Yaotian-Liu/obsidian-pseudocode"
   },
   {
@@ -6464,7 +6464,7 @@
     "id": "companion",
     "name": "Companion",
     "author": "rizerphe",
-    "description": "A github copilot-like interface for obsidian that can use ChatGPT under the hood.",
+    "description": "A github copilot-like interface for Obsidian that can use ChatGPT under the hood.",
     "repo": "rizerphe/obsidian-companion"
   },
   {
@@ -6478,13 +6478,13 @@
     "id": "frontmatter-alias-display",
     "name": "Frontmatter Alias Display",
     "author": "muhammadv-i",
-    "description": "A plugin for Obsidian to show front-matter aliases as display names in the File Explorer.",
+    "description": "A plugin for Obsidian to show frontmatter aliases as display names in the File Explorer.",
     "repo": "muhammadv-i/obsidian-frontmatter-alias-display"
   },
   {
     "id": "character-insertion",
     "name": "Character Insertion",
-    "description": "Plugin to insert a specified symbol under the cursor",
+    "description": "Plugin to insert a specified symbol under the cursor.",
     "author": "TakamiChie",
     "repo": "TakamiChie/Obsidian_CharacterInsertionPlugin"
   },
@@ -6492,7 +6492,7 @@
     "id": "whisper",
     "name": "Whisper",
     "author": "Nik Danilov",
-    "description": "Hands-Free Note-Taking for Obsidian with Whisper",
+    "description": "Hands-free note-taking for Obsidian with Whisper.",
     "repo": "nikdanilov/whisper-obsidian-plugin"
   },
   {
@@ -6506,14 +6506,14 @@
     "id": "code-files",
     "name": "Code Files",
     "author": "Lukas Bach",
-    "description": "Edit Code Files in Obsidian with VSCode's powerful Monaco Editor",
+    "description": "Edit Code Files in Obsidian with VS Code's powerful Monaco Editor.",
     "repo": "lukasbach/obsidian-code-files"
   },
   {
     "id": "flashcard-learning",
     "name": "Flashcard Learning",
     "author": "Gaétan Muck",
-    "description": "Improved flashcard learning system",
+    "description": "Improved flashcard learning system.",
     "repo": "gaetanmuck/obsidian-flashcard-learning"
   },
   {
@@ -6533,44 +6533,44 @@
   {
     "id": "file-order",
     "name": "File Order",
-    "description": "Use number-prefixes in your file names to define a custom order, and drag-and-drop the files to update that order",
+    "description": "Use number-prefixes in your file names to define a custom order, and drag-and-drop the files to update that order.",
     "author": "lukasbach",
     "repo": "lukasbach/obsidian-file-order"
   },
   {
-      "id": "no-tabs",
-      "name": "No Tabs",
-      "author": "Tobias Schuster",
-      "description": "Replaces the previous tab when creating a new note",
-      "repo": "TS-Tobias/obsidian-no-tabs"
+    "id": "no-tabs",
+    "name": "No Tabs",
+    "author": "Tobias Schuster",
+    "description": "Replaces the previous tab when creating a new note.",
+    "repo": "TS-Tobias/obsidian-no-tabs"
   },
   {
-      "id": "tab-rotator",
-      "name": "Tab Rotator",
-      "author": "Steven Jin",
-      "description": "This plugin rotates opened files to the left or right with a specified interval.",
-      "repo": "autohub7/obsidian-tab-rotator"
+    "id": "tab-rotator",
+    "name": "Tab Rotator",
+    "author": "Steven Jin",
+    "description": "This plugin rotates opened files to the left or right with a specified interval.",
+    "repo": "autohub7/obsidian-tab-rotator"
   },
   {
-      "id": "bulkopen-selected-links",
-      "name": "Bulk open selected links",
-      "author": "Steven Jin",
-      "description": "This plugin allows users to easily open all selected links in edit mode.",
-      "repo": "autohub7/obsidian-open-selected-links"
+    "id": "bulkopen-selected-links",
+    "name": "Bulk open selected links",
+    "author": "Steven Jin",
+    "description": "This plugin allows users to easily open all selected links in edit mode.",
+    "repo": "autohub7/obsidian-open-selected-links"
   },
   {
-      "id": "bbawj-semantic-search",
-      "name": "Semantic Search",
-      "author": "bbawj",
-      "description": "Semantic search for files using OpenAI's text embeddings",
-      "repo": "bbawj/obsidian-semantic-search"
+    "id": "bbawj-semantic-search",
+    "name": "Semantic Search",
+    "author": "bbawj",
+    "description": "Semantic search for files using OpenAI's text embeddings.",
+    "repo": "bbawj/obsidian-semantic-search"
   },
   {
-      "id": "select-current-line",
-      "name": "Select current line",
-      "author": "Gokul",
-      "description": "Selects the current line where the cursor is placed. Press 'ESC' button to select.",
-      "repo": "gokulk16/select-current-line-plugin"
+    "id": "select-current-line",
+    "name": "Select current line",
+    "author": "Gokul",
+    "description": "Selects the current line where the cursor is placed. Press 'ESC' key to select.",
+    "repo": "gokulk16/select-current-line-plugin"
   },
   {
     "id": "wikipedia-search",
@@ -6596,7 +6596,7 @@
   {
     "id": "marp-slides",
     "name": "Marp Slides",
-    "description": "Create Marp presentations in Obsidian",
+    "description": "Create Marp presentations in Obsidian.",
     "author": "Samuele Cozzi",
     "repo": "samuele-cozzi/obsidian-marp-slides"
   },
@@ -6611,14 +6611,14 @@
     "id": "tolino-notes-import",
     "name": "Tolino notes Importer",
     "author": "juergenbr",
-    "description": "This is a plugin for Obsidian to import notes from a Tolino E-Reader",
+    "description": "This is a plugin for Obsidian to import notes from a Tolino E-Reader.",
     "repo": "juergenbr/obsidian-tolino-notes-import"
   },
   {
     "id": "codeblock-customizer",
     "name": "Codeblock Customizer",
     "author": "mugiwara",
-    "description": "This Obsidian plugin lets you customize your codeblocks in editing, and reading mode as well.",
+    "description": "This Obsidian plugin lets you customize your code blocks in editing, and reading mode as well.",
     "repo": "mugiwara85/CodeblockCustomizer"
   },
   {
@@ -6632,21 +6632,21 @@
     "id": "ai-assistant",
     "name": "AI Assistant",
     "author": "Quentin Grail",
-    "description": "AI Assistant plugin for Obsidian",
+    "description": "AI Assistant plugin for Obsidian.",
     "repo": "qgrail/obsidian-ai-assistant"
   },
   {
     "id": "cron",
     "name": "Cron",
     "author": "Callum Loh",
-    "description": "Simple CRON / schedular plugin to regularly run user scripts or Obsidian commands.",
+    "description": "Simple CRON / scheduler plugin to regularly run user scripts or Obsidian commands.",
     "repo": "cdloh/obsidian-cron"
   },
   {
     "id": "tray",
     "name": "Tray",
     "author": "dragonwocky",
-    "description": "Run Obsidian from the system tray for customisable window management & global quick notes",
+    "description": "Run Obsidian from the system tray for customisable window management & global quick notes.",
     "repo": "dragonwocky/obsidian-tray"
   },
   {
@@ -6660,15 +6660,15 @@
     "id": "obsidian-soomda",
     "name": "Soomda",
     "author": "Michael Lee",
-    "description": "Quickly hide your sidebars",
+    "description": "Quickly hide your sidebars.",
     "repo": "michaellee/soomda"
   },
   {
-      "id": "vault-name-status-bar",
-      "name": "Vault name in status bar",
-      "author": "1C0D",
-      "description": "See your vault name in the status bar and click on it ot reduce it",
-      "repo": "1C0D/Obsidian-Vault-Name-in-Status-Bar"
+    "id": "vault-name-status-bar",
+    "name": "Vault name in status bar",
+    "author": "1C0D",
+    "description": "See your vault name in the status bar and click on it ot reduce it.",
+    "repo": "1C0D/Obsidian-Vault-Name-in-Status-Bar"
   },
   {
     "id": "quickly",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -150,7 +150,7 @@
     "id": "obsidian-day-planner",
     "name": "Day Planner",
     "author": "James Lynch",
-    "description": "An Obsidian plugin for day planning and managing pomodoro timers from a task list in a Markdown note.",
+    "description": "Day planning and managing pomodoro timers from a task list in a Markdown note.",
     "repo": "lynchjames/obsidian-day-planner"
   },
   {
@@ -646,7 +646,7 @@
   {
     "id": "obsidian-filename-heading-sync",
     "name": "Filename Heading Sync",
-    "description": "Obsidian plugin for keeping the filename with the first heading of a file in sync.",
+    "description": "Keep the filename with the first heading of a file in sync.",
     "author": "dvcrn",
     "repo": "dvcrn/obsidian-filename-heading-sync"
   },
@@ -654,7 +654,7 @@
     "id": "obsidian-orthography",
     "name": "Obsidian Orthography",
     "author": "denisoed",
-    "description": "Obsidian plugin to check & fix orthography errors in text.",
+    "description": "Check & fix orthography errors in text.",
     "repo": "denisoed/obsidian-orthography"
   },
   {
@@ -1165,7 +1165,7 @@
     "id": "obsidian-excalidraw-plugin",
     "name": "Excalidraw",
     "author": "Zsolt Viczian",
-    "description": "An Obsidian plugin to edit and view Excalidraw drawings.",
+    "description": "Edit and view Excalidraw drawings.",
     "repo": "zsviczian/obsidian-excalidraw-plugin"
   },
   {
@@ -1332,7 +1332,7 @@
   {
     "id": "obsidian-related-notes-finder",
     "name": "Related Notes Finder",
-    "description": "An Obsidian plugin that adds extra features for finding related notes.",
+    "description": "Adds extra features for finding related notes.",
     "author": "Joshua Michalik",
     "repo": "lifegems/obsidian-related-notes-finder"
   },
@@ -1458,7 +1458,7 @@
   {
     "id": "obsidian-sidebar-expand-on-hover",
     "name": "Sidebar Expand on Hover",
-    "description": "This Obsidian plugin expands or collapses the sidebar based on mouse hovering on the left ribbon.",
+    "description": "Expands or collapses the sidebar based on mouse hovering on the left ribbon.",
     "author": "Tousif Iqbal Anik (toiq)",
     "repo": "toiq/obsidian-sidebar-expand-on-hover"
   },
@@ -1620,7 +1620,7 @@
     "id": "obsidian-timeline",
     "name": "Timeline",
     "author": "George Butco",
-    "description": "Used to build great timelines",
+    "description": "Build great timelines",
     "repo": "George-debug/obsidian-timeline"
   },
   {
@@ -1738,7 +1738,7 @@
   {
     "id": "cmenu-plugin",
     "name": "cMenu",
-    "description": "An Obsidian plugin that adds a minimal text editor modal for a smoother writing/editing experience.",
+    "description": "Adds a minimal text editor modal for a smoother writing/editing experience.",
     "author": "Chetachi",
     "repo": "chetachiezikeuzor/cMenu-Plugin"
   },
@@ -1942,7 +1942,7 @@
     "id": "ObsidianAnkiSync",
     "name": "Obsidian Anki Sync",
     "author": "debanjandhar12",
-    "description": "Obsidian plugin to make flashcards and sync them to Anki.",
+    "description": "Make flashcards and sync them to Anki.",
     "repo": "debanjandhar12/Obsidian-Anki-Sync"
   },
   {
@@ -2138,7 +2138,7 @@
     "id": "obsidian-dynamic-toc",
     "name": "Dynamic Table of Contents",
     "author": "aidurber",
-    "description": "An Obsidian plugin to generate Tables of Contents that stay up to date with your document outline.",
+    "description": "Generate Tables of Contents that stay up to date with your document outline.",
     "repo": "aidurber/obsidian-plugin-dynamic-toc"
   },
   {
@@ -2235,7 +2235,7 @@
   {
     "id": "marginnote-companion",
     "name": "MarginNote Companion",
-    "description": "An Obsidian plugin to bridge MarginNote 3 and Obsidian.",
+    "description": "Bridge MarginNote 3 and Obsidian.",
     "author": "AidenLx",
     "repo": "aidenlx/marginnote-companion"
   },
@@ -2599,7 +2599,7 @@
   {
     "id": "obsidian-crypto-lookup",
     "name": "Crypto Lookup for Obsidian",
-    "description": "Uses the Cryptonator API to pull prices for crypto in a target currency.",
+    "description": "Use the Cryptonator API to pull prices for crypto in a target currency.",
     "author": "Andrew Lombardi",
     "repo": "kinabalu/obsidian-crypto-lookup"
   },
@@ -2620,7 +2620,7 @@
   {
     "id": "obsidian-word-sprint",
     "name": "Word Sprint for Obsidian",
-    "description": "Word Sprint for Obsidian plugin for your writing projects like NaNoWriMo.",
+    "description": "Word Sprint for your writing projects like NaNoWriMo.",
     "author": "Andrew Lombardi",
     "repo": "kinabalu/obsidian-word-sprint"
   },
@@ -2655,7 +2655,7 @@
   {
     "id": "language-translator",
     "name": "Language Translator",
-    "description": "An Obsidian plugin to translate selected text in the desired language.",
+    "description": "Translate selected text in the desired language.",
     "author": "Florin Bobis",
     "repo": "twentytwokhz/language-translator"
   },
@@ -2922,7 +2922,7 @@
     "id": "obsidian-tomorrows-daily-note",
     "name": "Tomorrow's Daily Note",
     "author": "Will Olson",
-    "description": "An Obsidian plugin that creates tomorrow's daily note for preemtive planning.",
+    "description": "Creates tomorrow's daily note for preemtive planning.",
     "repo": "frankolson/obsidian-tomorrows-daily-note"
   },
   {
@@ -3195,7 +3195,7 @@
     "id": "obsidian-excel-to-markdown-table",
     "name": "Excel to Markdown Table",
     "author": "Ganessh Kumar R P",
-    "description": "An Obsidian plugin to paste data from Microsoft Excel, Google Sheets, Apple Numbers and LibreOffice Calc as Markdown tables in Obsidian editor.",
+    "description": "Paste data from Microsoft Excel, Google Sheets, Apple Numbers and LibreOffice Calc as Markdown tables in Obsidian editor.",
     "repo": "ganesshkumar/obsidian-excel-to-markdown-table"
   },
   {
@@ -3265,7 +3265,7 @@
     "id": "todoist-text",
     "name": "Todoist Text",
     "author": "Wes Moncrief",
-    "description": "This Obsidian plugin integrates your Todoist tasks with Markdown checkboxes.",
+    "description": "Integrate your Todoist tasks with Markdown checkboxes.",
     "repo": "wesmoncrief/obsidian-todoist-text"
   },
   {
@@ -3433,7 +3433,7 @@
     "id": "markdown-table-editor",
     "name": "Markdown Table Editor",
     "author": "Ganessh Kumar R P",
-    "description": "An Obsidian plugin to provide an editor for Markdown tables. It can open CSV, Microsoft Excel/Google Sheets data as Markdown tables from Obsidian Markdown editor.",
+    "description": "Provides an editor for Markdown tables. It can open CSV, Microsoft Excel/Google Sheets data as Markdown tables from Obsidian Markdown editor.",
     "repo": "ganesshkumar/obsidian-table-editor"
   },
   {
@@ -3643,7 +3643,7 @@
     "id": "obsidian-list-modified",
     "name": "List Modified",
     "author": "Francis Kafieh",
-    "description": "A simple Obsidian plugin that links all modified files meeting certain criteria to a daily note.",
+    "description": "Link all modified files meeting certain criteria to a daily note.",
     "repo": "franciskafieh/obsidian-list-modified"
   },
   {
@@ -4126,7 +4126,7 @@
     "id": "zotero-bridge",
     "name": "Zotero Bridge",
     "author": "Shmavon Gazanchyan",
-    "description": "Obsidian plugin to integrate with Zotero through ZotServer",
+    "description": "Integrate with Zotero through ZotServer",
     "repo": "vanakat/zotero-bridge"
   },
   {
@@ -4217,7 +4217,7 @@
     "id": "zotero-link",
     "name": "Zotero Link",
     "author": "Shmavon Gazanchyan",
-    "description": "Obsidian plugin to insert link to Zotero item ",
+    "description": "Insert link to a Zotero item.",
     "repo": "vanakat/zotero-link"
   },
   {
@@ -4447,7 +4447,7 @@
   {
     "id": "literate-haskell",
     "name": "Literate Haskell",
-    "description": "An Obsidian plugin for integrating .lhs files into your PKM.",
+    "description": "Integrate .lhs files into your PKM.",
     "author": "James Jensen",
     "repo": "jajaperson/obsidian-literate-haskell"
   },
@@ -4525,7 +4525,7 @@
     "id": "obsidian-day-and-night",
     "name": "Day and Night",
     "author": "Kevin Patel",
-    "description": "An Obsidian plugin to automatically toggle themes between day theme and night theme on a set time schedule.",
+    "description": "Automatically toggle themes between day theme and night theme on a set time schedule.",
     "repo": "CyberT17/obsidian-day-and-night"
   },
   {
@@ -5000,7 +5000,7 @@
   {
     "id": "obsidian-old-note-admonitor",
     "name": "Old Note Admonitor",
-    "description": "This Obsidian plugin shows warnings if the note has not been updated for over specific days.",
+    "description": "Show warnings if the note has not been updated for over specific days.",
     "author": "tadashi-aikawa",
     "repo": "tadashi-aikawa/obsidian-old-note-admonitor"
   },
@@ -5323,7 +5323,7 @@
     "id": "obsidian-stylist",
     "name": "Obsidian Stylist",
     "author": "ixth",
-    "description": "Obsidian plugin that allows to add classes and styles on Markdown blocks.",
+    "description": "Allows you to add classes and styles on Markdown blocks.",
     "repo": "ixth/obsidian-stylist"
   },
   {
@@ -5554,7 +5554,7 @@
     "id": "obsidian-file-color",
     "name": "File Color",
     "author": "ecustic",
-    "description": "An Obsidian plugin for setting colors on folders and files in the file tree.",
+    "description": "Set colors on folders and files in the file tree.",
     "repo": "ecustic/obsidian-file-color"
   },
   {
@@ -5610,7 +5610,7 @@
     "id": "spoiler-block-obsidian",
     "name": "Spoiler Block",
     "author": "AllJavi",
-    "description": "Just a simple Obsidian plugin to hide information until you want to reveal it.",
+    "description": "Hide information until you want to reveal it.",
     "repo": "AllJavi/spoiler-block-obsidian"
   },
   {
@@ -5673,7 +5673,7 @@
     "id": "s3-attachments-storage",
     "name": "S3 attachments storage",
     "author": "TechTheAwesome",
-    "description": "An Obsidian plugin for storage and retrieval of media attachments on S3 compatible services.",
+    "description": "Storage and retrieval of media attachments on S3 compatible services.",
     "repo": "TechTheAwesome/obsidian-s3"
   },
   {
@@ -5707,7 +5707,7 @@
   {
     "id": "obsidian-gpt",
     "name": "GPT",
-    "description": "Obsidian plugin for getting language model completions from ChatGPT, GPT-3, and others.",
+    "description": "Get language model completions from ChatGPT, GPT-3, and others.",
     "author": "Jonathan Miller",
     "repo": "jmilldotdev/obsidian-gpt"
   },
@@ -5715,7 +5715,7 @@
     "id": "obsidian-pending-notes",
     "name": "Pending notes",
     "author": "Ulises Santana",
-    "description": "Obsidian plugin for searching links without notes in your vault.",
+    "description": "Search links without notes in your vault.",
     "repo": "ulisesantana/obsidian-pending-notes"
   },
   {
@@ -5729,7 +5729,7 @@
     "id": "code-emitter",
     "name": "Code Emitter",
     "author": "YISH",
-    "description": "An Obsidian plugin that allows code blocks executed interactively in sandbox like Jupyter notebooks. Supported language Rust, Kotlin, Python, JavaScript, TypeScript, etc.",
+    "description": "Allows code blocks to be executed interactively in a sandbox like Jupyter notebooks. Supported language Rust, Kotlin, Python, JavaScript, TypeScript, etc.",
     "repo": "mokeyish/obsidian-code-emitter"
   },
   {
@@ -5876,7 +5876,7 @@
     "id": "grappling-hook",
     "name": "🪝 Grappling Hook",
     "author": "pseudometa",
-    "description": "Obsidian Plugin for blazingly fast file switching to bookmarked files. For people for whom using the Quick Switcher still takes too much time.",
+    "description": "Blazingly fast file switching to bookmarked files. For people for whom using the Quick Switcher still takes too much time.",
     "repo": "chrisgrieser/grappling-hook"
   },
   {
@@ -6421,7 +6421,7 @@
   {
     "id": "tasks-to-omnifocus",
     "name": "Send Tasks to OmniFocus",
-    "description": "An Obsidian plugin will extract tasks from the current note and create them in OmniFocus.",
+    "description": "Extract tasks from the current note and create them in OmniFocus.",
     "author": "Henry Gustafson",
     "repo": "lizard-heart/obsidian-to-omnifocus"
   },
@@ -6618,7 +6618,7 @@
     "id": "codeblock-customizer",
     "name": "Codeblock Customizer",
     "author": "mugiwara",
-    "description": "This Obsidian plugin lets you customize your code blocks in editing, and reading mode as well.",
+    "description": "Customize your code blocks in editing, and reading mode as well.",
     "repo": "mugiwara85/CodeblockCustomizer"
   },
   {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2816,7 +2816,7 @@
   {
     "id": "get-info-plugin",
     "name": "Get Info",
-    "description": "Get Info is a plugin that tucks a menu inside your status bar and shows helpful information for your chosen file.",
+    "description": "Tuck a menu inside your status bar and show helpful information for your chosen file.",
     "author": "Chetachi",
     "repo": "chetachiezikeuzor/Get-Info-Plugin"
   },
@@ -3447,7 +3447,7 @@
     "id": "obsidian-extract-pdf-annotations",
     "name": "Extract PDF Annotations",
     "author": "Franz Achermann",
-    "description": "Extract PDF Annotations (Notes and Highlights) and sort them by topics.",
+    "description": "Extract PDF annotations (notes and highlights) and sort them by topic.",
     "repo": "munach/obsidian-extract-pdf-annotations"
   },
   {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -206,7 +206,7 @@
     "id": "convert-url-to-iframe",
     "name": "Convert url to preview (iframe)",
     "author": "FHachez",
-    "description": "Convert an url (e.g. YouTube) into an iframe (preview).",
+    "description": "Convert a URL (e.g. YouTube) into an iframe (preview).",
     "repo": "FHachez/obsidian-convert-url-to-iframe"
   },
   {
@@ -241,7 +241,7 @@
     "id": "obsidian-latex-environments",
     "name": "Latex Environments",
     "author": "Zach Raines",
-    "description": "Allows to quickly insert and change LaTeX environments within math environments.",
+    "description": "Allows you to quickly insert and change LaTeX environments within math environments.",
     "repo": "raineszm/obsidian-latex-environments"
   },
   {
@@ -282,7 +282,7 @@
   {
     "id": "extract-highlights-plugin",
     "name": "Extract Highlights",
-    "description": "Allows to extracts all ==highlights== in a note into your clipboard.",
+    "description": "Allows tyou o extracts all ==highlights== in a note into your clipboard.",
     "author": "Alexis Rondeau",
     "repo": "akaalias/extract-highlights-plugin"
   },
@@ -381,7 +381,7 @@
     "id": "footlinks",
     "name": "Footlinks",
     "author": "Daha",
-    "description": "Extracts urls from main text to footer.",
+    "description": "Extracts URLs from main text to footer.",
     "repo": "DahaWong/obsidian-footlinks"
   },
   {
@@ -423,14 +423,14 @@
     "id": "obsidian-rollover-daily-todos",
     "name": "Rollover Daily Todos",
     "author": "Matt Sessions",
-    "description": "This plugin will rollover any unchecked checkboxes from your last daily note into today's note.",
+    "description": "Rollover any unchecked checkboxes from your last daily note into today's note.",
     "repo": "shichongrui/obsidian-rollover-daily-todos"
   },
   {
     "id": "obsidian-reveal-active-file",
     "name": "Automatically Reveal Active File",
     "author": "Matt Sessions",
-    "description": "This plugin will automatically reveal the currently active file in the side navigation.",
+    "description": "Automatically reveal the currently active file in the side navigation.",
     "repo": "shichongrui/obsidian-reveal-active-file"
   },
   {
@@ -451,21 +451,21 @@
     "id": "obsidian-apple-reminders-plugin",
     "name": "Apple Reminders",
     "author": "Rishi Raval",
-    "description": "A plugin to attempt to bring Apple Reminders into Obsidian.",
+    "description": "Attempt to bring Apple Reminders into Obsidian.",
     "repo": "urishiraval/obsidian-apple-reminders-plugin"
   },
   {
     "id": "obsidian-contextual-typography",
     "name": "Contextual Typography",
     "author": "mgmeyers",
-    "description": "This plugin adds a data-tag-name attribute to all top-level divs in preview mode containing the child's tag name, allowing contextual typography styling.",
+    "description": "Adds a data-tag-name attribute to all top-level divs in preview mode containing the child's tag name, allowing contextual typography styling.",
     "repo": "mgmeyers/obsidian-contextual-typography"
   },
   {
     "id": "neo4j-graph-view",
     "name": "Neo4j Graph View",
     "author": "Emile van Krieken",
-    "description": "A plugin for advanced graph visualization and querying using Neo4j.",
+    "description": "Advanced graph visualization and querying using Neo4j.",
     "repo": "HEmile/obsidian-neo4j-graph-view"
   },
   {
@@ -479,7 +479,7 @@
     "id": "obsidian-temple",
     "name": "Temple",
     "author": "garyng",
-    "description": "A plugin for templating in Obsidian, powered by Nunjucks.",
+    "description": "Templating in Obsidian, powered by Nunjucks.",
     "repo": "garyng/obsidian-temple"
   },
   {
@@ -493,7 +493,7 @@
     "id": "obsidian-charts",
     "name": "Obsidian Charts",
     "author": "phibr0",
-    "description": "This Plugin lets you easily create Charts within Obsidian!",
+    "description": "Easily create Charts within Obsidian!",
     "repo": "phibr0/obsidian-charts"
   },
   {
@@ -507,7 +507,7 @@
     "id": "obsidian-autocomplete-plugin",
     "name": "Autocomplete",
     "author": "Yeboster",
-    "description": "This Plugin provides a text autocomplete feature to enhance typing speed.",
+    "description": "Provides a text autocomplete feature to enhance typing speed.",
     "repo": "yeboster/autocomplete-obsidian"
   },
   {
@@ -549,7 +549,7 @@
     "id": "obsidian-imgur-plugin",
     "name": "Imgur Plugin",
     "author": "Kirill Gavrilov",
-    "description": "This plugin uploads images from your clipboard to imgur.com and embeds uploaded image to your note.",
+    "description": "Uploads images from your clipboard to imgur.com and embeds uploaded image to your note.",
     "repo": "gavvvr/obsidian-imgur-plugin"
   },
   {
@@ -661,14 +661,14 @@
     "id": "obsidian-query-language",
     "name": "Obsidian Query Language",
     "author": "Joost Plattel",
-    "description": "This plugin allows you to query notes and represent data within Obsidian.",
+    "description": "Allows you to query notes and represent data within Obsidian.",
     "repo": "jplattel/obsidian-query-language"
   },
   {
     "id": "obsidian-markdown-formatting-assistant-plugin",
     "name": "Markdown Formatting Assistant",
     "author": "Reocin",
-    "description": "This Plugin provides a simple Editor for Markdown and in addition a command line interface. The command line interface facilitate a faster workflow.",
+    "description": "Provides a simple editor for Markdown and in addition a command line interface. The command line interface facilitate a faster workflow.",
     "repo": "Reocin/obsidian-markdown-formatting-assistant-plugin"
   },
   {
@@ -738,7 +738,7 @@
     "id": "various-complements",
     "name": "Various Complements",
     "author": "tadashi-aikawa",
-    "description": "This plugin enables you to complete words like the auto-completion of IDE.",
+    "description": "Enables you to complete words like the auto-completion of IDE.",
     "repo": "tadashi-aikawa/obsidian-various-complements-plugin"
   },
   {
@@ -772,28 +772,28 @@
   {
     "id": "obsidian-daily-stats",
     "name": "Daily Stats",
-    "description": "Track your daily word count",
+    "description": "Track your daily word count.",
     "author": "Dhruvik Parikh",
     "repo": "dhruvik7/obsidian-daily-stats"
   },
   {
     "id": "open-note-to-window-title",
     "name": "Active note to window title",
-    "description": "This plugin shows the current open note in the window title",
+    "description": "Shows the current open note in the window title.",
     "author": "Joost Plattel",
     "repo": "jplattel/open-note-to-window-title"
   },
   {
     "id": "meld-encrypt",
     "name": "Meld Encrypt",
-    "description": "Hide secrets in your notes",
+    "description": "Hide secrets in your notes.",
     "author": "meld-cp",
     "repo": "meld-cp/obsidian-encrypt"
   },
   {
     "id": "obsidian-vault-statistics-plugin",
     "name": "Vault Statistics",
-    "description": "Status bar item with vault statistics such as number of notes, files, attachments, and links",
+    "description": "Status bar item with vault statistics such as number of notes, files, attachments, and links.",
     "author": "Bryan Kyle",
     "repo": "bkyle/obsidian-vault-statistics-plugin"
   },
@@ -807,14 +807,14 @@
   {
     "id": "obsidian-hotkeys-for-specific-files",
     "name": "Hotkeys for specific files",
-    "description": "Add commands for specific files and open them with a hotkey",
+    "description": "Add commands for specific files and open them with a hotkey.",
     "author": "Vinzent",
     "repo": "Vinzent03/obsidian-hotkeys-for-specific-files"
   },
   {
     "id": "csv-obsidian",
     "name": "CSV Editor",
-    "description": "Edit CSV files in Obsidian",
+    "description": "Edit CSV files in Obsidian.",
     "author": "death_au",
     "repo": "deathau/csv-obsidian"
   },
@@ -828,7 +828,7 @@
   {
     "id": "mochi-cards-exporter",
     "name": "Mochi Cards Exporter",
-    "description": "Export Markdown notes to Mochi cards from within Obsidian",
+    "description": "Export Markdown notes to Mochi cards from within Obsidian.",
     "author": "kalbetre",
     "repo": "kalbetredev/mochi-cards-exporter"
   },
@@ -1017,7 +1017,7 @@
   {
     "id": "extract-url",
     "name": "Extract url content",
-    "description": "Extract url converting content into Markdown.",
+    "description": "Extract URL converting content into Markdown.",
     "author": "Stephen Solka",
     "repo": "trashhalo/obsidian-extract-url"
   },
@@ -1101,7 +1101,7 @@
   {
     "id": "obsidian-highlightpublicnotes-plugin",
     "name": "Highlight Public Notes",
-    "description": "This plugin warns that a note is public (based on a frontmatter attribute) by colorizing the note red.",
+    "description": "Warns that a note is public (based on a frontmatter attribute) by colorizing the note red.",
     "author": "dennis seidel",
     "repo": "dennisseidel/highlightpublicnotes-obsidian-plugin"
   },
@@ -1171,7 +1171,7 @@
   {
     "id": "obsidian-auto-link-title",
     "name": "Auto Link Title",
-    "description": "This plugin automatically fetches the titles of links from the web.",
+    "description": "Automatically fetches the titles of links from the web.",
     "author": "Matt Furden",
     "repo": "zolrath/obsidian-auto-link-title"
   },
@@ -1284,13 +1284,13 @@
     "id": "obsidian-2hop-links-plugin",
     "name": "2Hop Links Plugin",
     "author": "Tokuhiro Matsuno",
-    "description": "This plugin will display the page linked 2hop ahead.",
+    "description": "Display the page linked 2hop ahead.",
     "repo": "tokuhirom/obsidian-2hop-links-plugin"
   },
   {
     "id": "obsidian-image-auto-upload-plugin",
     "name": "Image auto upload Plugin",
-    "description": "This plugin uploads images from your clipboard by PicGo.",
+    "description": "Upload images from your clipboard by PicGo.",
     "author": "renmu123",
     "repo": "renmu123/obsidian-image-auto-upload-plugin"
   },
@@ -1374,7 +1374,7 @@
   {
     "id": "obsidian-pomodoro-plugin",
     "name": "Obsidian Pomodoro Plugin",
-    "description": "This is a simple pomodoro plugin for Obsidian.",
+    "description": "Simple pomodoro plugin for Obsidian.",
     "author": "Tokuhiro Matsuno",
     "repo": "tokuhirom/obsidian-pomodoro-plugin"
   },
@@ -1395,7 +1395,7 @@
   {
     "id": "obsidian-collapse-all-plugin",
     "name": "Collapse All",
-    "description": "This plugin adds a button to collapse all folders in the file explorer.",
+    "description": "Adds a button to collapse all folders in the file explorer.",
     "author": "OfficerHalf",
     "repo": "OfficerHalf/obsidian-collapse-all"
   },
@@ -1473,7 +1473,7 @@
     "id": "file-tree-alternative",
     "name": "File Tree Alternative Plugin",
     "author": "Ozan Tellioglu",
-    "description": "This plugin allows you to have an alternative file tree view.",
+    "description": "Allows you to have an alternative file tree view.",
     "repo": "ozntel/file-tree-alternative"
   },
   {
@@ -1521,7 +1521,7 @@
   {
     "id": "obsidian-gist",
     "name": "Gist",
-    "description": "This is a plugin to display the GitHub Gist.",
+    "description": "Display the GitHub Gist.",
     "author": "Jun Lin",
     "repo": "linjunpop/obsidian-gist"
   },
@@ -1542,7 +1542,7 @@
   {
     "id": "obsidian-advanced-new-file",
     "name": "Obsidian Advanced New File",
-    "description": "This is a plugin to create notes in chosen folder.",
+    "description": "Create notes in chosen folder.",
     "author": "Ivan Chernov",
     "repo": "vanadium23/obsidian-advanced-new-file"
   },
@@ -1577,7 +1577,7 @@
   {
     "id": "obsidian-pandoc",
     "name": "Obsidian Pandoc",
-    "description": "This is a Pandoc export plugin for Obsidian. It provides commands to export to formats like DOCX, ePub and PDF.",
+    "description": "Pandoc export plugin for Obsidian. It provides commands to export to formats like DOCX, ePub and PDF.",
     "author": "Oliver Balfour",
     "repo": "OliverBalfour/obsidian-pandoc"
   },
@@ -1591,7 +1591,7 @@
   {
     "id": "obsidian-habit-tracker",
     "name": "Habit Tracker",
-    "description": "This plugin for Obsidian creates a simple month view for visualizing your punch records.",
+    "description": "Creates a simple month view for visualizing your punch records.",
     "author": "duo",
     "repo": "duoani/obsidian-habit-tracker"
   },
@@ -1676,7 +1676,7 @@
     "id": "obsidian-image-uploader",
     "name": "Image Uploader",
     "author": "Creling",
-    "description": "This plugin can upload the image in your clipboard to any image hosting automatically when pasting.",
+    "description": "Upload the image in your clipboard to any image hosting automatically when pasting.",
     "repo": "Creling/obsidian-image-uploader"
   },
   {
@@ -1711,7 +1711,7 @@
     "id": "obsidian-embedded-code-title",
     "name": "Embedded Code Title",
     "author": "tadashi-aikawa",
-    "description": "This is an Obsidian plugin which can embeds title to code blocks.",
+    "description": "Embeds title to code blocks.",
     "repo": "tadashi-aikawa/obsidian-embedded-code-title"
   },
   {
@@ -1773,7 +1773,7 @@
   {
     "id": "obsidian-budget-wysiwyg",
     "name": "Budget WYSIWYG",
-    "description": "This is a plugin that automatically switches between preview mode and source mode based on if you are typing or not.",
+    "description": "Automatically switches between preview mode and source mode based on if you are typing or not.",
     "author": "OwnJoke",
     "repo": "OwnJoke/obsidian-budget-wysiwyg"
   },
@@ -1809,7 +1809,7 @@
     "id": "longform",
     "name": "Longform",
     "author": "Kevin Barrett",
-    "description": "A plugin for Obsidian that helps you write and edit novels, screenplays, and other long projects.",
+    "description": "Helps you write and edit novels, screenplays, and other long projects.",
     "repo": "kevboh/longform"
   },
   {
@@ -1864,7 +1864,7 @@
   {
     "id": "obsidian-view-mode-by-frontmatter",
     "name": "Force note view mode by frontmatter",
-    "description": "This plugin allows to force the view mode for a note by using frontmatter: YAML block with 'obsidian_ui_mode' as key.",
+    "description": "Allows you to force the view mode for a note by using frontmatter: YAML block with 'obsidian_ui_mode' as key.",
     "author": "Benny Wydooghe",
     "repo": "bwydoogh/obsidian-force-view-mode-of-note"
   },
@@ -1927,7 +1927,7 @@
   {
     "id": "obsidian-command-alias-plugin",
     "name": "Command Alias",
-    "description": "This plugin gives aliases to Obsidian commands.",
+    "description": "Gives aliases to Obsidian commands.",
     "author": "@Yajamon",
     "repo": "yajamon/obsidian-command-alias-plugin"
   },
@@ -1949,7 +1949,7 @@
     "id": "window-collapse",
     "name": "Window Collapse",
     "author": "Guilherme Quental",
-    "description": "This plugin provides an easy way to collapse the sidebars without going fullscreen.",
+    "description": "Provides an easy way to collapse the sidebars without going fullscreen.",
     "repo": "gquental/obsidian-window-collapse"
   },
   {
@@ -2046,7 +2046,7 @@
   {
     "id": "obsidian-annotator",
     "name": "Annotator",
-    "description": "A plugin for reading and annotating PDFs and EPUBs in Obsidian.",
+    "description": "Read and annotate PDFs and EPUBs in Obsidian.",
     "author": "Elias Sundqvist",
     "repo": "elias-sundqvist/obsidian-annotator"
   },
@@ -2060,14 +2060,14 @@
   {
     "id": "random-structural-diary-plugin",
     "name": "Random Structural Diary",
-    "description": "This is a plugin for picking random questions from a prepared question list. It allows you answer on different questions each time.",
+    "description": "Pick random questions from a prepared question list. It allows you answer on different questions each time.",
     "author": "Timur Sidoriuk",
     "repo": "ShockThunder/RandomStructuralDiary"
   },
   {
     "id": "obsidian-file-link",
     "name": "Better File Link",
-    "description": "A plugin to add better external file links to notes.",
+    "description": "Add better external file links to notes.",
     "author": "Marc Julian Schwarz",
     "repo": "marcjulianschwarz/obsidian-file-link"
   },
@@ -2096,7 +2096,7 @@
     "id": "obsidian-icon-folder",
     "name": "Obsidian Icon Folder",
     "author": "FlorianWoelki",
-    "description": "This plugin allows you to add icons to your folders.",
+    "description": "Allows you to add icons to your folders.",
     "repo": "FlorianWoelki/obsidian-icon-folder"
   },
   {
@@ -2376,7 +2376,7 @@
     "id": "obsidian-plotly",
     "name": "Plotly",
     "author": "Dmitriy Shulha",
-    "description": "With this plugin you can embed Plotly charts in your notes.",
+    "description": "Embed Plotly charts in your notes.",
     "repo": "Dmitriy-Shulha/obsidian-plotly"
   },
   {
@@ -2410,7 +2410,7 @@
   {
     "id": "mysnippets-plugin",
     "name": "MySnippets",
-    "description": "MySnippets is a plugin that adds a status bar menu allowing the user to quickly toggle their snippets on and off 🖌.",
+    "description": "Adds a status bar menu allowing the user to quickly toggle their snippets on and off.",
     "author": "Chetachi",
     "repo": "chetachiezikeuzor/MySnippets-Plugin"
   },
@@ -2425,7 +2425,7 @@
     "id": "obsidian-another-quick-switcher",
     "name": "Another Quick Switcher",
     "author": "tadashi-aikawa",
-    "description": "This is an Obsidian plugin which is another choice of Quick switcher.",
+    "description": "Another choice of Quick switcher.",
     "repo": "tadashi-aikawa/obsidian-another-quick-switcher"
   },
   {
@@ -2502,7 +2502,7 @@
     "id": "obsidian-link-archive",
     "name": "Link Archive",
     "author": "Tamás Deme",
-    "description": "This plugin archives links in your note so they're available to you even if the original site goes down or gets removed.",
+    "description": "Archive links in your note so they're available to you even if the original site goes down or gets removed.",
     "repo": "tomzorz/obsidian-link-archive"
   },
   {
@@ -2550,21 +2550,21 @@
   {
     "id": "obsidian-habitica-integration",
     "name": "Habitica Sync",
-    "description": "This plugin helps integrate Habitica user tasks and stats into Obsidian.",
+    "description": "Helps integrate Habitica user tasks and stats into Obsidian.",
     "author": "Leoh and Ran",
     "repo": "SuperChamp234/habitica-sync"
   },
   {
     "id": "obsidian-oura-plugin",
     "name": "Oura Plugin for Obsidian",
-    "description": "A plugin for importing oura ring data into a note.",
+    "description": "Import Oura Ring data into a note.",
     "author": "Andrew Lombardi",
     "repo": "kinabalu/obsidian-oura-plugin"
   },
   {
     "id": "obsidian-metacopy",
     "name": "Metacopy & URL",
-    "description": "Copy the value of a frontmatter key and allows to create link from it using various settings.",
+    "description": "Copy the value of a frontmatter key and allows you to create link from it using various settings.",
     "author": "Mara-Li",
     "repo": "Lisandra-dev/obsidian-metacopy"
   },
@@ -2599,7 +2599,7 @@
   {
     "id": "obsidian-crypto-lookup",
     "name": "Crypto Lookup for Obsidian",
-    "description": "A plugin for Obsidian which uses the Cryptonator API to pull back prices for crypto in a target currency.",
+    "description": "Uses the Cryptonator API to pull prices for crypto in a target currency.",
     "author": "Andrew Lombardi",
     "repo": "kinabalu/obsidian-crypto-lookup"
   },
@@ -2683,7 +2683,7 @@
   {
     "id": "mousewheel-image-zoom",
     "name": "Mousewheel Image zoom",
-    "description": "This plugin enables you to increase/decrease the size of an image by scrolling.",
+    "description": "Enables you to increase/decrease the size of an image by scrolling.",
     "author": "Nico Jeske",
     "repo": "nicojeske/mousewheel-image-zoom"
   },
@@ -2760,7 +2760,7 @@
   {
     "id": "obsidian-title-serial-number-plugin",
     "name": "Title Serial Number Plugin",
-    "description": "This plugin adds serial numbers to your Markdown title.",
+    "description": "Adds serial numbers to your Markdown title.",
     "author": "Domenic",
     "repo": "yalvhe2009/obsidian-title-serial-number-plugin"
   },
@@ -2837,7 +2837,7 @@
   {
     "id": "obsidian-wordpress",
     "name": "Publish to WordPress for Obsidian",
-    "description": "A plugin to publish your Obsidian documents to WordPress.",
+    "description": "Publish your Obsidian documents to WordPress.",
     "author": "devbean",
     "repo": "devbean/obsidian-wordpress"
   },
@@ -2978,7 +2978,7 @@
     "id": "obsidian-completr",
     "name": "Completr",
     "author": "tth05",
-    "description": "This plugin provides advanced auto-completion functionality for LaTeX, frontmatter and standard writing.",
+    "description": "Provides advanced auto-completion functionality for LaTeX, frontmatter and standard writing.",
     "repo": "tth05/obsidian-completr"
   },
   {
@@ -3019,14 +3019,14 @@
   {
     "id": "obsidian-memos",
     "name": "Obsidian Memos",
-    "description": "A plugin works perfect with your journal",
+    "description": "Works perfect with your journal",
     "author": "Boninall",
     "repo": "quorafind/obsidian-memos"
   },
   {
     "id": "para-shortcuts",
     "name": "PARA Shortcuts",
-    "description": "This plugin serves usefull commands to setup and manage your knowledge using the PARA method.",
+    "description": "Serves useful commands to setup and manage your knowledge using the PARA method.",
     "author": "gOAT",
     "repo": "gOATiful/para-shortcuts"
   },
@@ -3069,7 +3069,7 @@
     "id": "link-info-server",
     "name": "Link Server",
     "author": "moelody",
-    "description": "This plugin will open a reverse proxy server at port 3333 to get wikiLink information Obsidian API.",
+    "description": "Opens a reverse proxy server at port 3333 to get wikilink information from Obsidian API.",
     "repo": "moelody/link-to-obsidian"
   },
   {
@@ -3125,7 +3125,7 @@
     "id": "copy-as-html",
     "name": "Copy as HTML",
     "author": "Bailey Jennings",
-    "description": "This is a simple plugin that converts the selected Markdown to HTML and copies it to the clipboard.",
+    "description": "Converts the selected Markdown to HTML and copies it to the clipboard.",
     "repo": "jenningsb2/copy-as-html"
   },
   {
@@ -3257,7 +3257,7 @@
   {
     "id": "obsidian-chevereto-image-uploader",
     "name": "Chevereto Image Uploader for Obsidian",
-    "description": "This plugin uploads images in your clipboard to chevereto.",
+    "description": "Uploads images in your clipboard to chevereto.",
     "author": "kkzzhizhou",
     "repo": "kkzzhizhou/obsidian-chevereto-image-uploader"
   },
@@ -3355,7 +3355,7 @@
   {
     "id": "obsidian-advanced-new-folder",
     "name": "Obsidian Advanced New Folder",
-    "description": "This plugin lets you choose where to create a new folder.",
+    "description": "Lets you choose where to create a new folder.",
     "author": "Piotr Yordanov",
     "repo": "piotryordanov/obsidian-advanced-new-folder"
   },
@@ -3405,7 +3405,7 @@
     "id": "obsidian-steemit",
     "name": "Publish to Steemit",
     "author": "anpigon",
-    "description": "A plugin for publishing Obsidian documents to Steemit.",
+    "description": "Publish Obsidian documents to Steemit.",
     "repo": "anpigon/obsidian-steemit-plugin"
   },
   {
@@ -3475,7 +3475,7 @@
     "id": "heycalmdown-navigate-cursor-history",
     "name": "Navigate Cursor History",
     "author": "heycalmdown",
-    "description": "This plugin remembers the recent cursor positions history and allows you to jump to them back and forth like VS Code.",
+    "description": "Remembers the recent cursor positions history and allows you to jump to them back and forth like VS Code.",
     "repo": "heycalmdown/navigate-cursor-history"
   },
   {
@@ -3517,7 +3517,7 @@
     "id": "obsidian-format-code",
     "name": "Format code blocks of various languages",
     "author": "iVariable",
-    "description": "This plugin introduces commands to format code (internally uses prettier).",
+    "description": "Introduces commands to format code (internally uses prettier).",
     "repo": "iVariable/Obsidian-Format-Code"
   },
   {
@@ -3545,7 +3545,7 @@
     "id": "obsidian-custom-frames",
     "name": "Custom Frames",
     "author": "Ellpeck",
-    "description": "A plugin that turns web apps into panes using iframes with custom styling. Also comes with presets for Google Keep, Todoist and more.",
+    "description": "Turns web apps into panes using iframes with custom styling. Also comes with presets for Google Keep, Todoist and more.",
     "repo": "Ellpeck/ObsidianCustomFrames"
   },
   {
@@ -3615,14 +3615,14 @@
     "id": "obsidian-asciidoc-blocks",
     "name": "AsciiDoc Blocks Plugin",
     "author": "Juracy Filho",
-    "description": "A plugin to render asciidoc blocks in Obsidian, initially asciidoc tables.",
+    "description": "Render asciidoc blocks in Obsidian, initially asciidoc tables.",
     "repo": "juracy/obsidian-asciidoc-blocks"
   },
   {
     "id": "fleeting-notes-obsidian",
     "name": "Fleeting Notes Sync",
     "author": "Matthew Wong",
-    "description": "This is a plugin to sync Fleeting Notes with Obsidian.",
+    "description": "Sync Fleeting Notes with Obsidian.",
     "repo": "fleetingnotes/fleeting-notes-obsidian"
   },
   {
@@ -3671,7 +3671,7 @@
     "id": "typing-speed",
     "name": "Typing speed",
     "author": "supercyp",
-    "description": "A plugin for showing the current typing speed in the status bar.",
+    "description": "Show the current typing speed in the status bar.",
     "repo": "supercip971/obsidian-typing-speed"
   },
   {
@@ -3733,7 +3733,7 @@
   {
     "id": "obsidian-badge",
     "name": "Obsidian Badge",
-    "description": "This is a plugin to show badge for Obsidian.",
+    "description": "Show badge for Obsidian.",
     "author": "Jun Lin",
     "repo": "linjunpop/obsidian-badge"
   },
@@ -3741,7 +3741,7 @@
     "id": "kr-book-info-plugin",
     "name": "Korean Book Info Plugin",
     "author": "kmsk99",
-    "description": "A plugin that crawls Yes24 to get book information.",
+    "description": "Crawls Yes24 to get book information.",
     "repo": "kmsk99/kr-book-info-plugin"
   },
   {
@@ -3755,7 +3755,7 @@
     "id": "obsidian-link-embed",
     "name": "Link Embed",
     "author": "SErAphLi",
-    "description": "This plugin allow you to convert URLs in your notes into embeded previews.",
+    "description": "Allows you to convert URLs in your notes into embeded previews.",
     "repo": "Seraphli/obsidian-link-embed"
   },
   {
@@ -3783,7 +3783,7 @@
     "id": "obsidian-math-plus",
     "name": "Obsidian Math+",
     "author": "Oscar Capraro",
-    "description": "This is an Obsidian plugin for taking math notes using Excalidraw.",
+    "description": "Take math notes using Excalidraw.",
     "repo": "ocapraro/obsidian-math-plus"
   },
   {
@@ -3803,7 +3803,7 @@
   {
     "id": "obsidian-calibre-plugin",
     "name": "Calibre",
-    "description": "This plugin allows you to access your calibre libraries and read books directly in Obsidian.",
+    "description": "Allows you to access your calibre libraries and read books directly in Obsidian.",
     "author": "caronchen",
     "repo": "caronchen/obsidian-calibre-plugin"
   },
@@ -3818,14 +3818,14 @@
     "id": "plugins-galore",
     "name": "Plugins Galore",
     "author": "dylanpizzo",
-    "description": "This is an Obsidian plugin to allow easily sideloading other plugins.",
+    "description": "Allow easily sideloading other plugins.",
     "repo": "dylanpizzo/obsidian-plugins-galore"
   },
   {
     "id": "auto-card-link",
     "name": "Auto Card Link",
     "author": "Nekoshita Yuki",
-    "description": "Automatically fetches metadata from a url and makes it as a card-styled link.",
+    "description": "Automatically fetches metadata from a URL and makes it as a card-styled link.",
     "repo": "nekoshita/obsidian-auto-card-link"
   },
   {
@@ -3860,13 +3860,13 @@
     "id": "obsidian-filename-emoji-remover",
     "name": "Filename Emoji Remover",
     "author": "Yüksel Tolun",
-    "description": "This is a simple plugin to automatically remove emojis from filenames. Main purpose is to get rid of Dropbox sync issues for Readwise imported content.",
+    "description": "Automatically remove emojis from filenames. Main purpose is to get rid of Dropbox sync issues for Readwise imported content.",
     "repo": "YTolun/obsidian-filename-emoji-remover"
   },
   {
     "id": "obsidian-epub-plugin",
     "name": "ePub Reader",
-    "description": "This is an ePub reader plugin for Obsidian. Can open document with \".epub\" file extension.",
+    "description": "ePub reader plugin for Obsidian. Can open document with \".epub\" file extension.",
     "author": "caronchen",
     "repo": "caronchen/obsidian-epub-plugin"
   },
@@ -3972,14 +3972,14 @@
     "id": "obsidian-media-db-plugin",
     "name": "Media DB Plugin",
     "author": "Moritz Jung",
-    "description": "A plugin that can query multiple APIs for movies, series, anime, games, music releases and wiki articles, and import them into your vault.",
+    "description": "Query multiple APIs for movies, series, anime, games, music releases and wiki articles, and import them into your vault.",
     "repo": "mProjectsCode/obsidian-media-db-plugin"
   },
   {
     "id": "obsidian-sequence-hotkeys",
     "name": "Sequence Hotkeys",
     "author": "Ruan Moolman",
-    "description": "This plugin allows you to set hotkeys with key sequences instead of a single chord.",
+    "description": "Allows you to set hotkeys with key sequences instead of a single chord.",
     "repo": "moolmanruan/obsidian-sequence-hotkeys"
   },
   {
@@ -4000,7 +4000,7 @@
     "id": "obsidian-expand-bullet",
     "name": "Expand Bullet",
     "author": "Boninall",
-    "description": "A plugin for transforming bullet content into note.",
+    "description": "Transform bullet content into note.",
     "repo": "quorafind/Obsidian-Expand-Bullet"
   },
   {
@@ -4021,7 +4021,7 @@
     "id": "booksidian-plugin",
     "name": "Booksidian",
     "author": "Micha Brugger",
-    "description": "A plugin to connect your Goodreads shelves to your Obsidian vault.",
+    "description": "Connect your Goodreads shelves to your Obsidian vault.",
     "repo": "MichaBrugger/booksidian_plugin"
   },
   {
@@ -4070,7 +4070,7 @@
     "id": "obsidian-timestamp-notes",
     "name": "Timestamp Notes",
     "author": "Julian Grunauer",
-    "description": "This plugin allows side-by-side notetaking with videos. Annotate your notes with timestamps to directly control the video and remember where each note comes from.",
+    "description": "Allows side-by-side notetaking with videos. Annotate your notes with timestamps to directly control the video and remember where each note comes from.",
     "repo": "juliang22/ObsidianTimestampNotes"
   },
   {
@@ -4098,7 +4098,7 @@
     "id": "code-block-plugin",
     "name": "Code Block",
     "author": "Patrik Lindefors",
-    "description": "A plugin that converts text into code blocks with automatic language detection.",
+    "description": "Convert text into code blocks with automatic language detection.",
     "repo": "paddan/code-block-plugin"
   },
   {
@@ -4140,7 +4140,7 @@
     "id": "obsidian-to-notion",
     "name": "Obsidian shared to Notion",
     "author": "Easychris",
-    "description": "This plugin shares Obsidian files to Notion with the Notion API",
+    "description": "Shares Obsidian files to Notion with the Notion API",
     "repo": "Easychris/obsidian-to-notion"
   },
   {
@@ -4161,7 +4161,7 @@
     "id": "obsidian-table-to-csv-exporter",
     "name": "Table to CSV Exporter",
     "author": "Stefan Wolfrum",
-    "description": "This plugin allows for exporting tables from a pane in reading mode into CSV files.",
+    "description": "Allows you to export tables from a pane in reading mode into CSV files.",
     "repo": "metawops/obsidian-table-to-csv-export"
   },
   {
@@ -4175,14 +4175,14 @@
     "id": "scroll-speed",
     "name": "Scroll Speed",
     "author": "Florian Ludewig",
-    "description": "This plugin allows you to change the scroll speed inside Obsidian notes.",
+    "description": "Allows you to change the scroll speed in Obsidian notes.",
     "repo": "flolu/obsidian-scroll-speed"
   },
   {
     "id": "obsidian-translator",
     "name": "Translator",
     "author": "Haifeng Lu",
-    "description": "This is a plugin for Obsidian to translate selected text.",
+    "description": "Translate selected text.",
     "repo": "luhaifeng666/obsidian-translator"
   },
   {
@@ -4202,7 +4202,7 @@
   {
     "id": "obsidian-weread-plugin",
     "name": "Weread Plugin",
-    "description": "This is Obsidian plugin for Tencent weread.",
+    "description": "Sync Tencent Weread highlights and annotations.",
     "author": "hank zhao",
     "repo": "zhaohongxuan/obsidian-weread-plugin"
   },
@@ -4224,7 +4224,7 @@
     "id": "obsidian-golinks",
     "name": "Obsidian GoLinks",
     "author": "David Brownman (@xavdid)",
-    "description": "This is a plugin for Obsidian that renders go/links as clickable links.",
+    "description": "Render go/links as clickable links.",
     "repo": "xavdid/obsidian-golinks"
   },
   {
@@ -4308,14 +4308,14 @@
     "id": "obsidian-path-finder",
     "name": "Path Finder",
     "author": "jerrywcy",
-    "description": "A plugin that can find all paths between two notes and render them as graph or text.",
+    "description": "Find all paths between two notes and render them as graph or text.",
     "repo": "jerrywcy/obsidian-path-finder"
   },
   {
     "id": "obsidian-focus-plugin",
     "name": "Focus and Highlight",
     "author": "BO YI TSAI",
-    "description": "A plugin for Obsidian that will highlight and focus on the currently selected heading",
+    "description": "Highlight and focus on the currently selected heading.",
     "repo": "nagi1999a/obsidian-focus-plugin"
   },
   {
@@ -4511,7 +4511,7 @@
     "id": "script-launcher",
     "name": "Script Launcher",
     "author": "Alessandro Ruggiero",
-    "description": "This plugin allows you to launch scripts from the Obsidian app. You can add scripts shortcuts on your bottom bar and launch them with just one click!",
+    "description": "Allows you to launch scripts from the Obsidian app. You can add scripts shortcuts on your bottom bar and launch them with just one click!",
     "repo": "AlessandroRuggiero/script-launcher"
   },
   {
@@ -4595,7 +4595,7 @@
     "id": "obsidian-table-generator",
     "name": "Table Generator",
     "author": "Boninall",
-    "description": "A plugin for generate Markdown table quickly like Typora.",
+    "description": "Generate Markdown tables quickly like Typora.",
     "repo": "quorafind/obsidian-table-generator"
   },
   {
@@ -4609,7 +4609,7 @@
     "id": "obsidian-meta-bind-plugin",
     "name": "Meta Bind Plugin",
     "author": "Moritz Jung",
-    "description": "This plugin can create input fields inside your notes and bind them to metadata fields.",
+    "description": "Create input fields inside your notes and bind them to metadata fields.",
     "repo": "mProjectsCode/obsidian-meta-bind-plugin"
   },
   {
@@ -4636,7 +4636,7 @@
   {
     "id": "onyx-boox-extractor",
     "name": "Onyx Boox Annotation & Highlight Extractor",
-    "description": "This plugin extracts annotations and highlights files exported from Onyx Boox tablets, and converts them to reference, literature and permanent notes fitting to the Zettelkasten method.",
+    "description": "Extracts annotations and highlights files exported from Onyx Boox tablets, and converts them to reference, literature and permanent notes fitting to the Zettelkasten method.",
     "author": "Akos Balasko",
     "repo": "akosbalasko/Onyx-Boox-Annotation-Highlight-Extractor"
   },
@@ -4693,7 +4693,7 @@
     "id": "obsidian-html-plugin",
     "name": "HTML Reader",
     "author": "Nuthrash",
-    "description": "This is a HTML file reader plugin for Obsidian. Can open documents with .html and .htm file extensions.",
+    "description": "HTML file reader for Obsidian. Can open documents with .html and .htm file extensions.",
     "repo": "nuthrash/obsidian-html-plugin"
   },
   {
@@ -4714,21 +4714,21 @@
     "id": "note-synchronizer",
     "name": "Note Synchronizer",
     "author": "Songchen Tan",
-    "description": "This is a plugin for synchronizing Obsidian notes to other note-based softwares like Anki, following more strictly the principles of Zettelkasten and treating each Obsidian file as a note.",
+    "description": "Synchronize Obsidian notes to other note-based software like Anki, following more strictly the principles of Zettelkasten and treating each Obsidian file as a note.",
     "repo": "tansongchen/obsidian-note-synchronizer"
   },
   {
     "id": "url-namer",
     "name": "URL Namer",
     "author": "zfei",
-    "description": "This plugin retrieves the HTML titles to name the raw URL links.",
+    "description": "Retrieves the HTML titles to name the raw URL links.",
     "repo": "zfei/obsidian-url-namer"
   },
   {
     "id": "obsidian-douban-plugin",
     "name": "Douban",
     "author": "Wanxp",
-    "description": "This is a plugin that can import movies/books/musics/notes/games info data from Douban for Obsidian.",
+    "description": "Import movies/books/musics/notes/games info data from Douban for Obsidian.",
     "repo": "Wanxp/obsidian-douban"
   },
   {
@@ -4805,7 +4805,7 @@
     "id": "tag-summary-plugin",
     "name": "Tag Summary",
     "author": "J.D Gauchat",
-    "description": "This plugin creates summaries with paragraphs or blocks of text that share the same tag(s).",
+    "description": "Creates summaries with paragraphs or blocks of text that share the same tag(s).",
     "repo": "macrojd/tag-summary"
   },
   {
@@ -4840,14 +4840,14 @@
     "id": "symbols-prettifier",
     "name": "Symbols Prettifier",
     "author": "Florian Woelki",
-    "description": "This plugin allows you to prettify the symbols with actual symbols you commonly type, like arrows.",
+    "description": "Allows you to prettify the symbols with actual symbols you commonly type, like arrows.",
     "repo": "FlorianWoelki/obsidian-symbols-prettifier"
   },
   {
     "id": "obsidian-mtg",
     "name": "Obsidian MtG",
     "author": "omardelarosa",
-    "description": "A plugin for managing Magic: The Gathering decks and card lists as Obsidian notes.",
+    "description": "Manage Magic: The Gathering decks and card lists as Obsidian notes.",
     "repo": "omardelarosa/obsidian-mtg"
   },
   {
@@ -4889,7 +4889,7 @@
     "id": "qmd-as-md-obsidian",
     "name": "qmd as md",
     "author": "Daniel Borek",
-    "description": "This plugin provides an initial support for viewing files with .qmd extension. QMD files contain a combination of Markdown and executable code cells and are a format supported by Quarto open source publishing system.",
+    "description": "Provides an initial support for viewing files with .qmd extension. QMD files contain a combination of Markdown and executable code cells and are a format supported by Quarto open source publishing system.",
     "repo": "danieltomasz/qmd-as-md-obsidian"
   },
   {
@@ -4903,7 +4903,7 @@
     "id": "obsidian-things3-sync",
     "name": "Obsidian Things3 Sync",
     "author": "royx",
-    "description": "A plugin for syncing between Obsidian and Things3. Supporting multi-language, tags and dates.",
+    "description": "Sync between Obsidian and Things3. Supports multi-language, tags and dates.",
     "repo": "royxue/obsidian-things3-sync"
   },
   {
@@ -4994,7 +4994,7 @@
     "id": "obsidian-scroll-to-top-plugin",
     "name": "Scroll to Top Plugin",
     "author": "cloudhao1999",
-    "description": "This is a plugin for Obsidian that adds a button to scroll to the top of the current note.",
+    "description": "Adds a button to scroll to the top of the current note.",
     "repo": "cloudhao1999/obsidian-scroll-to-top-plugin"
   },
   {
@@ -5057,7 +5057,7 @@
     "id": "obsidian-handlebars",
     "name": "Obsidian Handlebars Template Plugin",
     "author": "Sean Quinlan",
-    "description": "This is a plugin for Obsidian that adds support for handlebars template blocks in notes.",
+    "description": "Adds support for handlebars template blocks in notes.",
     "repo": "sbquinlan/obsidian-handlebars"
   },
   {
@@ -5105,7 +5105,7 @@
   {
     "id": "sigma",
     "name": "Obsidian Sigma",
-    "description": "A plugin to enable using Obsidian notes as calculation sheets.",
+    "description": "Enable using Obsidian notes as calculation sheets.",
     "author": "monesga",
     "repo": "monesga/obsidian-sigma"
   },
@@ -5113,21 +5113,21 @@
     "id": "better-reading-mode",
     "name": "Better Reading Mode",
     "author": "Boninall",
-    "description": "A plugin to enable bionic reading mode in Live Preview mode of Obsidian.",
+    "description": "Enable bionic reading mode in Live Preview mode of Obsidian.",
     "repo": "quorafind/obsidian-better-reading-mode"
   },
   {
     "id": "obsidian-new-bullet-with-time",
     "name": "New Bullet With Time",
     "author": "Boninall",
-    "description": "A plugin allows you to auto add current time to new bullet line.",
+    "description": "Allows you to auto add current time to new bullet line.",
     "repo": "quorafind/obisidna-new-bullet-with-time"
   },
   {
     "id": "obsidian-md-to-jira",
     "name": "Markdown to Jira Converter",
     "author": "muckmuck",
-    "description": "A plugin for converting notes or selections to Jira markup and vice versa.",
+    "description": "Convert notes or selections to Jira markup and vice versa.",
     "repo": "muckmuck96/obsidian-md-to-jira"
   },
   {
@@ -5148,7 +5148,7 @@
     "id": "obsidian-toggle-meta-yaml-plugin",
     "name": "Toggle Meta Yaml",
     "author": "hua",
-    "description": "This is a simple plugin to toggle meta YAML.",
+    "description": "Toggle metadata YAML.",
     "repo": "hua03/obsidian-toggle-meta-yaml-plugin"
   },
   {
@@ -5162,14 +5162,14 @@
     "id": "daily-notes-editor",
     "name": "Daily Notes Editor",
     "author": "boninall",
-    "description": "A plugin for you to edit a bunch of daily notes in one page(inline), which works similar to Roam Research's default daily note view.",
+    "description": "Edit daily notes in one page (inline), which works similar to Roam Research's default daily note view.",
     "repo": "quorafind/obsidian-daily-notes-editor"
   },
   {
     "id": "bpmn-plugin",
     "name": "BPMN Plugin",
     "author": "joleaf",
-    "description": "This plugin enables viewing BPMN diagrams using bpmn-js.",
+    "description": "Enables viewing BPMN diagrams using bpmn-js.",
     "repo": "joleaf/obsidian-bpmn-plugin"
   },
   {
@@ -5190,7 +5190,7 @@
     "id": "double-click-tab",
     "name": "Double Click Tab",
     "author": "Boninall",
-    "description": "A plugin to modify the default behavior when you double click on the tab title, like close tab.",
+    "description": "Modify the default behavior when you double click on the tab title, like close tab.",
     "repo": "quorafind/Obsidian-Double-Click-Tab"
   },
   {
@@ -5245,7 +5245,7 @@
   {
     "id": "obsidian-markdown-export-plugin",
     "name": "Obsidian Markdown export",
-    "description": "This is a Markdown export plugin for Obsidian.",
+    "description": "Markdown export for Obsidian.",
     "author": "bingryan",
     "repo": "bingryan/obsidian-markdown-export-plugin"
   },
@@ -5253,7 +5253,7 @@
     "id": "sync-graph-settings",
     "name": "Sync Graph Settings",
     "author": "Xallt",
-    "description": "This is a plugin for syncing Global Graph settings (like color groups) to Local Graphs.",
+    "description": "Sync global graph settings (like color groups) to local graphs.",
     "repo": "Xallt/sync-graph-settings"
   },
   {
@@ -5274,7 +5274,7 @@
     "id": "obsidian-mindmap-nextgen",
     "name": "Obsidian Mindmap Nextgen",
     "author": "VeroCloud Pty Ltd (original by James Lynch)",
-    "description": "A plugin to preview notes as Markmap mind maps.",
+    "description": "Preview notes as Markmap mind maps.",
     "repo": "verocloud/obsidian-mindmap-nextgen"
   },
   {
@@ -5295,7 +5295,7 @@
     "id": "obsidian-clipper",
     "name": "Obsidian Clipper",
     "author": "John Christopher",
-    "description": "This plugin helps you capture highlights from the web.",
+    "description": "Helps you capture highlights from the web.",
     "repo": "jgchristopher/obsidian-clipper"
   },
   {
@@ -5309,14 +5309,14 @@
     "id": "obsidian-aggregator",
     "name": "Aggregator",
     "author": "SErAphLi",
-    "description": "This plugin helps you gather information from files, and make a summary in the file.",
+    "description": "Helps you gather information from files, and make a summary in the file.",
     "repo": "Seraphli/obsidian-aggregator"
   },
   {
     "id": "obsidian-autoscroll",
     "name": "Autoscroll",
     "author": "Petr Nazarov",
-    "description": "This plugin allows you to automatically scroll down the content with the provided speed.",
+    "description": "Allows you to automatically scroll down the content with the provided speed.",
     "repo": "petr-nazarov/obsidian-autoscroll"
   },
   {
@@ -5330,7 +5330,7 @@
     "id": "obsidian-dataset-aid",
     "name": "Text Dataset Aid Plugin",
     "author": "Conner Ohnesorge",
-    "description": "This plugin for Obsidian aids in the creation of fine-tuning datasets for language models.",
+    "description": "Aids in the creation of fine-tuning datasets for language models.",
     "repo": "conneroisu/Text-Dataset-Aid-Plugin"
   },
   {
@@ -5365,7 +5365,7 @@
     "id": "dmn-plugin",
     "name": "DMN Plugin",
     "author": "joleaf",
-    "description": "This plugin enables viewing DMNs using dmn-js.",
+    "description": "Enables viewing DMNs using dmn-js.",
     "repo": "joleaf/obsidian-dmn-plugin"
   },
   {
@@ -5407,7 +5407,7 @@
     "id": "obsidian-toggle-case",
     "name": "Toggle Case",
     "author": "automattech",
-    "description": "This plugin allows you to set a hotkey to toggle between `lowercase` `UPPERCASE` and `Title Case`.",
+    "description": "Allows you to set a hotkey to toggle between `lowercase` `UPPERCASE` and `Title Case`.",
     "repo": "MatthewAlner/obsidian-toggle-case"
   },
   {
@@ -5420,7 +5420,7 @@
   {
     "id": "canvas-presentation",
     "name": "Canvas Presentation",
-    "description": "A plugin to help you display cards based on sequence.",
+    "description": "Helps you display cards based on sequence.",
     "author": "Boninall",
     "repo": "quorafind/obsidian-canvas-presentation"
   },
@@ -5442,7 +5442,7 @@
     "id": "obsidian-basetag",
     "name": "Base Tag Renderer",
     "author": "Darren Kuro",
-    "description": "This plugin renders the basename of tags in preview mode.",
+    "description": "Renders the basename of tags in preview mode.",
     "repo": "darrenkuro/obsidian-basetag"
   },
   {
@@ -5470,7 +5470,7 @@
     "id": "obsidian-extlnkhelper-plugin",
     "name": "External Link Helper",
     "author": "Jhonghee Park",
-    "description": "This is a plugin for making inserting external links easier to your notes.",
+    "description": "Makie inserting external links easier to your notes.",
     "repo": "nakalsio/obsidian-danpung"
   },
   {
@@ -5505,7 +5505,7 @@
     "id": "obsidian-review-notes-plugin",
     "name": "Review Notes Plugin",
     "author": "tjandy98",
-    "description": "This plugin shows recently modified and newly created files.",
+    "description": "Shows recently modified and newly created files.",
     "repo": "tjandy98/obsidian-review-notes-plugin"
   },
   {
@@ -5596,7 +5596,7 @@
     "id": "quote-share",
     "name": "Quote Share",
     "author": "DuocNV",
-    "description": "This plugin allow your to easily generate beautiful gradient images from text and share them on social media.",
+    "description": "Allows you to easily generate beautiful gradient images from text and share them on social media.",
     "repo": "nguyenvanduocit/quote-share"
   },
   {
@@ -5623,7 +5623,7 @@
   {
     "id": "obsidian-contacts",
     "name": "Contacts",
-    "description": "Allows to manage and organize contacts.",
+    "description": "Allows you to manage and organize contacts.",
     "author": "vbeskrovnov",
     "repo": "vbeskrovnov/obsidian-contacts"
   },
@@ -5637,7 +5637,7 @@
   {
     "id": "link-nodes-in-canvas",
     "name": "Link Nodes in Canvas",
-    "description": "A plugin for you to add edges between notes in Canvas based on their links.",
+    "description": "Add edges between notes in Canvas based on their links.",
     "author": "Boninall",
     "repo": "quorafind/obsidian-link-nodes-in-canvas"
   },
@@ -5701,7 +5701,7 @@
     "id": "weekly-review",
     "name": "Weekly Review",
     "author": "Brandon Boswell",
-    "description": "This is opens all of the files you have created in the last week.",
+    "description": "Opens all of the files you have created in the last week.",
     "repo": "brandonkboswell/weekly-review"
   },
   {
@@ -5722,7 +5722,7 @@
     "id": "email-block-plugin",
     "name": "Email Block",
     "author": "joleaf",
-    "description": "This plugin renders an email code block.",
+    "description": "Renders an email code block.",
     "repo": "joleaf/obsidian-email-block-plugin"
   },
   {
@@ -5749,7 +5749,7 @@
   {
     "id": "obsidian-canvas-conversation",
     "name": "Canvas Conversation",
-    "description": "A plugin for Obsidian that allows you to create a canvas conversation using ChatGPT.",
+    "description": "Allows you to create a canvas conversation using ChatGPT.",
     "author": "André Baltazar",
     "repo": "AndreBaltazar8/obsidian-canvas-conversation"
   },
@@ -5785,7 +5785,7 @@
     "id": "obsidian-custom-file-extensions-plugin",
     "name": "Custom File Extensions and Types",
     "author": "MeepTech",
-    "description": "This plugin allows simple and modular control over what views open what file extensions from the app settings.",
+    "description": "Allows simple and modular control over what views open what file extensions from the app settings.",
     "repo": "MeepTech/obsidian-custom-file-extensions-plugin"
   },
   {
@@ -5799,7 +5799,7 @@
     "id": "canvas-mindmap",
     "name": "Canvas Mindmap",
     "author": "Boninall",
-    "description": "A plugin to make your canvas work like a mindmap.",
+    "description": "Make your canvas work like a mindmap.",
     "repo": "quorafind/obsidian-canvas-mindmap"
   },
   {
@@ -5813,7 +5813,7 @@
     "id": "cycle-in-sidebar",
     "name": "Cycle In Sidebar",
     "author": "Houcheng",
-    "description": "This a plugin provides hotkeys to cycle through tabs in the left or right sidebars.",
+    "description": "Provides hotkeys to cycle through tabs in the left or right sidebars.",
     "repo": "houcheng/obsidian-cycle-in-sidebar-plugin"
   },
   {
@@ -5833,7 +5833,7 @@
   {
     "id": "s3-image-uploader",
     "name": "S3 Image Uploader",
-    "description": "An image uploader for Obsidian that allows you to self host images on AWS S3.",
+    "description": "An image uploader for Obsidian that allows you to self-host images on AWS S3.",
     "author": "jvsteiner",
     "repo": "jvsteiner/s3-image-uploader"
   },
@@ -5841,14 +5841,14 @@
     "id": "canvas-filter",
     "name": "Canvas Filter",
     "author": "Ivan Koshelev",
-    "description": "This plugin lets you filter Canvas to only show items of specific color, tags or only connected to currently selected node.",
+    "description": "Lets you filter Canvas to only show items of specific color, tags or only connected to currently selected node.",
     "repo": "IKoshelev/Obsidian-Canvas-Filter"
   },
   {
     "id": "note-aliases",
     "name": "Note aliases",
     "author": "Pulsovi",
-    "description": "This plugin manages aliases of notes in Obsidian.",
+    "description": "Manage aliases of notes in Obsidian.",
     "repo": "pulsovi/obsidian-note-aliases"
   },
   {
@@ -5932,7 +5932,7 @@
     "id": "dmn-eval",
     "name": "DMN Eval",
     "author": "joleaf",
-    "description": "This plugin enables evaluating/executing DMNs.",
+    "description": "Enables evaluating/executing DMNs.",
     "repo": "joleaf/obsidian-dmn-eval-plugin"
   },
   {
@@ -5945,7 +5945,7 @@
   {
     "id": "obsidian-omnivore",
     "name": "Omnivore",
-    "description": "This is an Omnivore plugin for Obsidian.",
+    "description": "Omnivore plugin for Obsidian.",
     "author": "Omnivore",
     "repo": "omnivore-app/obsidian-omnivore"
   },
@@ -5988,7 +5988,7 @@
     "id": "material-symbols",
     "name": "Material Symbols",
     "author": "Cristoph Berane",
-    "description": "This plugin adds the material symbols (outlined) to Obsidian.",
+    "description": "Adds the material symbols (outlined) to Obsidian.",
     "repo": "cberane/obsidian-material-symbols"
   },
   {
@@ -6093,14 +6093,14 @@
     "id": "advanced-paste",
     "name": "Advanced Paste",
     "author": "kxxt",
-    "description": "This plugin provides advanced paste commands and enables you to create custom transforms for pasting.",
+    "description": "Provides advanced paste commands and enables you to create custom transforms for pasting.",
     "repo": "kxxt/obsidian-advanced-paste"
   },
   {
     "id": "aw-watcher-obsidian",
     "name": "Obsidian-compatible Watcher for ActivityWatch",
     "author": "Grimmauld",
-    "description": "This is a plugin bridging compatibility between ActivityWatch and Obsidian to allow detailed tracking od time spent in Obsidian.",
+    "description": "Bridges compatibility between ActivityWatch and Obsidian to allow detailed tracking of time spent in Obsidian.",
     "repo": "LordGrimmauld/aw-watcher-obsidian"
   },
   {
@@ -6114,7 +6114,7 @@
     "id": "vextab",
     "name": "Vextab",
     "author": "Luis Guzman",
-    "description": "An Obsidian plugin for rendering guitar tablature and music notation using Vextab.",
+    "description": "Render guitar tablature and music notation using Vextab.",
     "repo": "luigman/obsidian-vextab"
   },
   {
@@ -6149,7 +6149,7 @@
     "id": "optimize-canvas-connections",
     "name": "Optimize Canvas Connections",
     "author": "Félix Chénier",
-    "description": "A plugin that declutters a canvas by reconnecting notes using their nearest edges.",
+    "description": "Declutters a canvas by reconnecting notes using their nearest edges.",
     "repo": "felixchenier/obsidian-optimize-canvas-connections"
   },
   {
@@ -6169,14 +6169,14 @@
   {
     "id": "open-weather",
     "name": "OpenWeather",
-    "description": "This plugin returns the current weather from OpenWeather in a configurable string format.",
+    "description": "Returns the current weather from OpenWeather in a configurable string format.",
     "author": "willasm",
     "repo": "willasm/obsidian-open-weather"
   },
   {
     "id": "emoji-titler",
     "name": "Emoji Titler",
-    "description": "This plugin is emoji titler to easily insert an emoji in the title using a keyboard shortcut.",
+    "description": "Easily insert an emoji in the title using a keyboard shortcut.",
     "author": "Hyeonseo Nam",
     "repo": "HyeonseoNam/obsidian-emoji-titler"
   },
@@ -6212,7 +6212,7 @@
     "id": "nl-fast-image-cleaner",
     "name": "Fast Image Cleaner",
     "author": "Nathaniel",
-    "description": "This plugin allows you to quickly remove image attachment and referenced link from your documents in both LIVE , READ mode by right-click menu.",
+    "description": "Allows you to quickly remove image attachment and referenced link from your documents in both Live Preview and Read mode using the right-click menu.",
     "repo": "martinniee/Obsidian-fast-image-cleaner"
   },
   {
@@ -6226,7 +6226,7 @@
     "id": "tasks-calendar-wrapper",
     "name": "Tasks Calendar Wrapper",
     "author": "zhuwenq",
-    "description": "This is a simple wrapper for Obsidian Tasks Calendar and Obsidian Tasks Timeline.",
+    "description": "Simple wrapper for Obsidian Tasks Calendar and Obsidian Tasks Timeline.",
     "repo": "Leonezz/obsidian-tasks-calendar-wrapper"
   },
   {
@@ -6267,7 +6267,7 @@
   {
     "id": "image-upload-toolkit",
     "name": "Image Upload Toolkit",
-    "description": "An Obsidian plugin for uploading local images embedded in Markdown to remote store and export Markdown for publishing to static site. Currently, it supports Imgur and Aliyun OSS.",
+    "description": "Upload local images embedded in Markdown to remote store and export Markdown for publishing to static site. Currently, it supports Imgur and Aliyun OSS.",
     "author": "Addo Zhang",
     "repo": "addozhang/obsidian-image-upload-toolkit"
   },
@@ -6275,7 +6275,7 @@
     "id": "gene-ai",
     "name": "Gene 🧬",
     "author": "Matiss Jurevics",
-    "description": "A plugin for generating text using the OpenAI API.",
+    "description": "Generate text using the OpenAI API.",
     "repo": "MatissJurevics/Gene-AI"
   },
   {
@@ -6323,7 +6323,7 @@
   {
     "id": "source-code-note",
     "name": "Source Code Note",
-    "description": "This plugin can help you organize source code note easily.",
+    "description": "Helps you organize source code note easily.",
     "author": "Waiting",
     "repo": "waiting0324/obsidian-code-note"
   },
@@ -6359,7 +6359,7 @@
     "id": "float-search",
     "name": "Floating Search",
     "author": "Boninall",
-    "description": "A plugin for searching text by using Obsidian default search view.",
+    "description": "Search text by using Obsidian default search view.",
     "repo": "quorafind/obsidian-float-search"
   },
   {
@@ -6401,7 +6401,7 @@
     "id": "x86-flow-graphing",
     "name": "x86 Assembly Flow Graphing",
     "author": "icebear",
-    "description": "This plugin converts well formatted x86 assembly into appropriate flow graphs using Obsidian canvases.",
+    "description": "Converts well formatted x86 assembly into appropriate flow graphs using Obsidian canvases.",
     "repo": "dwolfe884/obsidian-x86-flow-graph"
   },
   {
@@ -6436,7 +6436,7 @@
     "id": "pseudocode-in-obs",
     "name": "Pseudocode",
     "author": "Yaotian Liu",
-    "description": "This is an Obsidian plugin that helps to render a LaTeX-style pseudocode inside a code block.",
+    "description": "Helps render LaTeX-style pseudocode inside a code block.",
     "repo": "Yaotian-Liu/obsidian-pseudocode"
   },
   {
@@ -6449,7 +6449,7 @@
   {
     "id": "unfilled-stats-highlighter",
     "name": "Unfilled Stats Highlighter",
-    "description": "This plugin is designed to streamline your stat/habit tracking process by automatically identifying and prefixing unfilled stats, making them easier to spot and fill out.",
+    "description": "Streamline your stat/habit tracking process by automatically identifying and prefixing unfilled stats, making them easier to spot and fill out.",
     "author": "Zachary Hynes",
     "repo": "White7292/obsidian-hd-unfilled-stats-highlighter"
   },
@@ -6470,7 +6470,7 @@
   {
     "id": "get-stock-information",
     "name": "Get Stock Information",
-    "description": "This plugin takes a stock symbol and returns a callout block with the latest stock information.",
+    "description": "Takes a stock symbol and returns a callout block with the latest stock information.",
     "author": "Mike Jongbloet",
     "repo": "mikejongbloet/obsidian-get-stock-information"
   },
@@ -6478,7 +6478,7 @@
     "id": "frontmatter-alias-display",
     "name": "Frontmatter Alias Display",
     "author": "muhammadv-i",
-    "description": "A plugin for Obsidian to show frontmatter aliases as display names in the File Explorer.",
+    "description": "Show frontmatter aliases as display names in the File Explorer.",
     "repo": "muhammadv-i/obsidian-frontmatter-alias-display"
   },
   {
@@ -6548,14 +6548,14 @@
     "id": "tab-rotator",
     "name": "Tab Rotator",
     "author": "Steven Jin",
-    "description": "This plugin rotates opened files to the left or right with a specified interval.",
+    "description": "Rotates opened files to the left or right with a specified interval.",
     "repo": "autohub7/obsidian-tab-rotator"
   },
   {
     "id": "bulkopen-selected-links",
     "name": "Bulk open selected links",
     "author": "Steven Jin",
-    "description": "This plugin allows users to easily open all selected links in edit mode.",
+    "description": "Allows you to easily open all selected links in edit mode.",
     "repo": "autohub7/obsidian-open-selected-links"
   },
   {
@@ -6590,7 +6590,7 @@
     "id": "draw-harada-method",
     "name": "Draw Harada Method",
     "author": "yildbs",
-    "description": "This plugin is used to draw the harada method. Create your own 1 goal, 8 plans, and 64 actions!",
+    "description": "Draw the harada method. Create your own 1 goal, 8 plans, and 64 actions!",
     "repo": "yildbs/obsidian-harada-method-plugin"
   },
   {
@@ -6611,7 +6611,7 @@
     "id": "tolino-notes-import",
     "name": "Tolino notes Importer",
     "author": "juergenbr",
-    "description": "This is a plugin for Obsidian to import notes from a Tolino E-Reader.",
+    "description": "Import notes from a Tolino E-Reader.",
     "repo": "juergenbr/obsidian-tolino-notes-import"
   },
   {
@@ -6625,7 +6625,7 @@
     "id": "auto-classifier",
     "name": "Auto Classifier",
     "author": "Hyeonseo Nam",
-    "description": "This plugin automatically classify tag from your notes using ChatGPT API. It analyze your note (It can be title, frontmatter, content or selected area) and automatically insert tag where you set.",
+    "description": "Automatically classify tag from your notes using ChatGPT API. It analyze your note (It can be title, frontmatter, content or selected area) and automatically insert tag where you set.",
     "repo": "hyeonseonam/auto-classifier"
   },
   {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -353,7 +353,7 @@
     "id": "maximise-active-pane-obsidian",
     "name": "Maximise Active Pane",
     "author": "death_au",
-    "description": "Simply fills the workspace with the active pane.",
+    "description": "Fills the workspace with the active pane.",
     "repo": "deathau/maximise-active-pane-obsidian"
   },
   {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -241,7 +241,7 @@
     "id": "obsidian-latex-environments",
     "name": "Latex Environments",
     "author": "Zach Raines",
-    "description": "Allows you to quickly insert and change LaTeX environments within math environments.",
+    "description": "Quickly insert and change LaTeX environments within math environments.",
     "repo": "raineszm/obsidian-latex-environments"
   },
   {
@@ -282,7 +282,7 @@
   {
     "id": "extract-highlights-plugin",
     "name": "Extract Highlights",
-    "description": "Allows tyou o extracts all ==highlights== in a note into your clipboard.",
+    "description": "Allows you to extract all ==highlights== in a note into your clipboard.",
     "author": "Alexis Rondeau",
     "repo": "akaalias/extract-highlights-plugin"
   },
@@ -661,7 +661,7 @@
     "id": "obsidian-query-language",
     "name": "Obsidian Query Language",
     "author": "Joost Plattel",
-    "description": "Allows you to query notes and represent data within Obsidian.",
+    "description": "Query notes and represent data within Obsidian.",
     "repo": "jplattel/obsidian-query-language"
   },
   {
@@ -1115,7 +1115,7 @@
   {
     "id": "obsidian-regex-pipeline",
     "name": "Regex Pipeline",
-    "description": "Allows users setup custom regex rules to automatically format notes.",
+    "description": "Set up custom regex rules to automatically format notes.",
     "author": "No3371",
     "repo": "No3371/obsidian-regex-pipeline"
   },
@@ -1864,7 +1864,7 @@
   {
     "id": "obsidian-view-mode-by-frontmatter",
     "name": "Force note view mode by frontmatter",
-    "description": "Allows you to force the view mode for a note by using frontmatter: YAML block with 'obsidian_ui_mode' as key.",
+    "description": "Force the view mode for a note by using frontmatter: YAML block with 'obsidian_ui_mode' as key.",
     "author": "Benny Wydooghe",
     "repo": "bwydoogh/obsidian-force-view-mode-of-note"
   },
@@ -1914,7 +1914,7 @@
     "id": "open-with",
     "name": "Open with",
     "author": "phibr0",
-    "description": "Allows you to add multiple other programs to open notes with.",
+    "description": "Add multiple other programs to open notes with.",
     "repo": "phibr0/obsidian-open-with"
   },
   {
@@ -2096,7 +2096,7 @@
     "id": "obsidian-icon-folder",
     "name": "Obsidian Icon Folder",
     "author": "FlorianWoelki",
-    "description": "Allows you to add icons to your folders.",
+    "description": "Add icons to your folders.",
     "repo": "FlorianWoelki/obsidian-icon-folder"
   },
   {
@@ -2201,7 +2201,7 @@
     "id": "customizable-menu",
     "name": "Customizable Menu",
     "author": "kzhovn",
-    "description": "Allows you to add any command to Obsidian's right-click menu.",
+    "description": "Add any command to Obsidian's right-click menu.",
     "repo": "kzhovn/obsidian-customizable-menu"
   },
   {
@@ -3300,7 +3300,7 @@
     "id": "markdown-shortcuts",
     "name": "Markdown shortcuts",
     "author": "Jules Guesnon",
-    "description": "Allows to write Markdown from shortcuts",
+    "description": "Write Markdown from shortcuts",
     "repo": "JulesGuesnon/obsidian-markdown-shortcuts"
   },
   {
@@ -3363,7 +3363,7 @@
     "id": "obsidian-mark-and-select",
     "name": "Mark and Select",
     "author": "anselmwang",
-    "description": "Allow users to set mark, move cursors freely and select from mark to cursor position.",
+    "description": "Set mark, move cursors freely and select from mark to cursor position.",
     "repo": "anselmwang/obsidian-mark-and-select"
   },
   {
@@ -3727,7 +3727,7 @@
     "id": "execute-code",
     "name": "Execute Code",
     "author": "twibiral",
-    "description": "Allows to execute code snippets within a note.",
+    "description": "Execute code snippets within a note.",
     "repo": "twibiral/obsidian-execute-code"
   },
   {
@@ -3755,14 +3755,14 @@
     "id": "obsidian-link-embed",
     "name": "Link Embed",
     "author": "SErAphLi",
-    "description": "Allows you to convert URLs in your notes into embeded previews.",
+    "description": "Convert URLs in your notes into embeded previews.",
     "repo": "Seraphli/obsidian-link-embed"
   },
   {
     "id": "obsidian-columns",
     "name": "Obsidian Columns",
     "author": "Trevor Nichols",
-    "description": "Allows you to create columns in Obsidian Markdown.",
+    "description": "Create columns in Obsidian Markdown.",
     "repo": "tnichols217/obsidian-columns"
   },
   {
@@ -3803,7 +3803,7 @@
   {
     "id": "obsidian-calibre-plugin",
     "name": "Calibre",
-    "description": "Allows you to access your calibre libraries and read books directly in Obsidian.",
+    "description": "Access your Calibre libraries and read books directly in Obsidian.",
     "author": "caronchen",
     "repo": "caronchen/obsidian-calibre-plugin"
   },
@@ -3818,7 +3818,7 @@
     "id": "plugins-galore",
     "name": "Plugins Galore",
     "author": "dylanpizzo",
-    "description": "Allow easily sideloading other plugins.",
+    "description": "Easily sideload other plugins.",
     "repo": "dylanpizzo/obsidian-plugins-galore"
   },
   {
@@ -3979,7 +3979,7 @@
     "id": "obsidian-sequence-hotkeys",
     "name": "Sequence Hotkeys",
     "author": "Ruan Moolman",
-    "description": "Allows you to set hotkeys with key sequences instead of a single chord.",
+    "description": "Set hotkeys with key sequences instead of a single chord.",
     "repo": "moolmanruan/obsidian-sequence-hotkeys"
   },
   {
@@ -4161,7 +4161,7 @@
     "id": "obsidian-table-to-csv-exporter",
     "name": "Table to CSV Exporter",
     "author": "Stefan Wolfrum",
-    "description": "Allows you to export tables from a pane in reading mode into CSV files.",
+    "description": "Export tables from a pane in reading mode into CSV files.",
     "repo": "metawops/obsidian-table-to-csv-export"
   },
   {
@@ -4175,7 +4175,7 @@
     "id": "scroll-speed",
     "name": "Scroll Speed",
     "author": "Florian Ludewig",
-    "description": "Allows you to change the scroll speed in Obsidian notes.",
+    "description": "Change the scroll speed in Obsidian notes.",
     "repo": "flolu/obsidian-scroll-speed"
   },
   {
@@ -4504,14 +4504,14 @@
     "id": "janitor",
     "name": "Janitor",
     "author": "Gabriele Cannata",
-    "description": "Performs cleanup tasks on the Obsidian vault.",
+    "description": "Perform cleanup tasks on the Obsidian vault.",
     "repo": "Canna71/obsidian-janitor"
   },
   {
     "id": "script-launcher",
     "name": "Script Launcher",
     "author": "Alessandro Ruggiero",
-    "description": "Allows you to launch scripts from the Obsidian app. You can add scripts shortcuts on your bottom bar and launch them with just one click!",
+    "description": "Launch scripts from the Obsidian app. You can add scripts shortcuts on your bottom bar and launch them with just one click!",
     "repo": "AlessandroRuggiero/script-launcher"
   },
   {
@@ -4840,7 +4840,7 @@
     "id": "symbols-prettifier",
     "name": "Symbols Prettifier",
     "author": "Florian Woelki",
-    "description": "Allows you to prettify the symbols with actual symbols you commonly type, like arrows.",
+    "description": "Prettify the symbols with actual symbols you commonly type, like arrows.",
     "repo": "FlorianWoelki/obsidian-symbols-prettifier"
   },
   {
@@ -4966,7 +4966,7 @@
     "id": "edit-gemini",
     "name": "Edit Gemini",
     "author": "Basil_Mori",
-    "description": "Allows the user to edit and create .gmi files.",
+    "description": "Edit and create .gmi files.",
     "repo": "Basil-Mori/obsidian-edit-gemini"
   },
   {
@@ -5092,7 +5092,7 @@
     "id": "deepl",
     "name": "DeepL",
     "author": "Till Friebe",
-    "description": "Allows translation of selected texts into more than 25 languages with DeepL.",
+    "description": "Translate selected text into more than 25 languages with DeepL.",
     "repo": "friebetill/obsidian-deepl"
   },
   {
@@ -5120,7 +5120,7 @@
     "id": "obsidian-new-bullet-with-time",
     "name": "New Bullet With Time",
     "author": "Boninall",
-    "description": "Allows you to auto add current time to new bullet line.",
+    "description": "Allows you to auto-add current time to new bullet lines.",
     "repo": "quorafind/obisidna-new-bullet-with-time"
   },
   {
@@ -5316,14 +5316,14 @@
     "id": "obsidian-autoscroll",
     "name": "Autoscroll",
     "author": "Petr Nazarov",
-    "description": "Allows you to automatically scroll down the content with the provided speed.",
+    "description": "Automatically scroll down the content with the provided speed.",
     "repo": "petr-nazarov/obsidian-autoscroll"
   },
   {
     "id": "obsidian-stylist",
     "name": "Obsidian Stylist",
     "author": "ixth",
-    "description": "Allows you to add classes and styles on Markdown blocks.",
+    "description": "Add classes and styles on Markdown blocks.",
     "repo": "ixth/obsidian-stylist"
   },
   {
@@ -5407,7 +5407,7 @@
     "id": "obsidian-toggle-case",
     "name": "Toggle Case",
     "author": "automattech",
-    "description": "Allows you to set a hotkey to toggle between `lowercase` `UPPERCASE` and `Title Case`.",
+    "description": "Set a hotkey to toggle between `lowercase` `UPPERCASE` and `Title Case`.",
     "repo": "MatthewAlner/obsidian-toggle-case"
   },
   {
@@ -5596,7 +5596,7 @@
     "id": "quote-share",
     "name": "Quote Share",
     "author": "DuocNV",
-    "description": "Allows you to easily generate beautiful gradient images from text and share them on social media.",
+    "description": "Easily generate beautiful gradient images from text and share them on social media.",
     "repo": "nguyenvanduocit/quote-share"
   },
   {
@@ -5623,7 +5623,7 @@
   {
     "id": "obsidian-contacts",
     "name": "Contacts",
-    "description": "Allows you to manage and organize contacts.",
+    "description": "Manage and organize contacts.",
     "author": "vbeskrovnov",
     "repo": "vbeskrovnov/obsidian-contacts"
   },
@@ -5749,7 +5749,7 @@
   {
     "id": "obsidian-canvas-conversation",
     "name": "Canvas Conversation",
-    "description": "Allows you to create a canvas conversation using ChatGPT.",
+    "description": "Create a canvas conversation using ChatGPT.",
     "author": "André Baltazar",
     "repo": "AndreBaltazar8/obsidian-canvas-conversation"
   },
@@ -5792,7 +5792,7 @@
     "id": "incremental-id",
     "name": "Incremental ID",
     "author": "Adrian Karwowski",
-    "description": "Allow to generate Jira like ids.",
+    "description": "Allow you to generate Jira-like IDs.",
     "repo": "adziok/obsidian-incremental-id"
   },
   {
@@ -6212,7 +6212,7 @@
     "id": "nl-fast-image-cleaner",
     "name": "Fast Image Cleaner",
     "author": "Nathaniel",
-    "description": "Allows you to quickly remove image attachment and referenced link from your documents in both Live Preview and Read mode using the right-click menu.",
+    "description": "Quickly remove image attachments and referenced links from your documents in both Live Preview and Read mode using the right-click menu.",
     "repo": "martinniee/Obsidian-fast-image-cleaner"
   },
   {
@@ -6555,7 +6555,7 @@
     "id": "bulkopen-selected-links",
     "name": "Bulk open selected links",
     "author": "Steven Jin",
-    "description": "Allows you to easily open all selected links in edit mode.",
+    "description": "Easily open all selected links in edit mode.",
     "repo": "autohub7/obsidian-open-selected-links"
   },
   {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5085,7 +5085,7 @@
     "id": "emo-uploader",
     "name": "Emo",
     "author": "yaleiyale",
-    "description": "Embed Markdown online file/image links. This plugin is for uploading images to hosting or files to github in Obsidian.",
+    "description": "Embed Markdown online file/image links. This plugin is for uploading images to hosting or files to GitHub in Obsidian.",
     "repo": "yaleiyale/obsidian-emo-uploader"
   },
   {
@@ -5253,7 +5253,7 @@
     "id": "sync-graph-settings",
     "name": "Sync Graph Settings",
     "author": "Xallt",
-    "description": "This is a plugin for syncing Global Graph settings (like Color Groups) to Local Graphs.",
+    "description": "This is a plugin for syncing Global Graph settings (like color groups) to Local Graphs.",
     "repo": "Xallt/sync-graph-settings"
   },
   {
@@ -6464,7 +6464,7 @@
     "id": "companion",
     "name": "Companion",
     "author": "rizerphe",
-    "description": "A github copilot-like interface for Obsidian that can use ChatGPT under the hood.",
+    "description": "A GitHub copilot-like interface for Obsidian that can use ChatGPT under the hood.",
     "repo": "rizerphe/obsidian-companion"
   },
   {


### PR DESCRIPTION
The following cleanup tasks were performed:

- Add a period at the end of descriptions
- Consistent capitalization for trademarks such as `Obsidian`
- Remove emoji from descriptions
- Fixed spelling and grammar errors
- Reduced redundant "This plugin" preface text
- Indentation inconsistencies