### PR TITLE
Fix inconsistent trailing slash for obsidian-material-flat-theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1188,7 +1188,7 @@
   {
     "name": "Material Flat",
     "author": "Threethan",
-    "repo": "threethan/obsidian-material-flat-theme/",
+    "repo": "threethan/obsidian-material-flat-theme",
     "screenshot": "screenshot.png",
     "modes": ["dark", "light"]
   },


### PR DESCRIPTION
This inconsistent slash tripped up my theme downloader - I'm hoping the inconsistency can be fixed here, to save me working around it in the code...

See https://github.com/claremacrae/obsidian-repos-downloader/issues/20

I checked there were no other occurrences.