### PR TITLE
Add TodoTxt plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6256,7 +6256,7 @@
     "author": "1C0D",
     "description": "toggle both sidebars (double middle mouse click or own shortcut) or each sidebar clicking middle mouse button and moving mouse towards the corresponding sidebar.",
     "repo": "1C0D/obsidian-easy-toggle-sidebars"
-  },  
+  },
   {
     "id": "x86-flow-graphing",
     "name": "x86 Assembly Flow Graphing",
@@ -6439,10 +6439,10 @@
     "description": "Search for Wikipedia articles and link them.",
     "repo": "StrangeGirlMurph/obsidian-wikipedia-search"
   },
-  { 
+  {
     "id": "vim-toggle",
     "name": "Vim Toggle",
-    "description": "(It toggles vim on/off) Allows for the the toggling and customization of said toggling within settings.", 
+    "description": "(It toggles vim on/off) Allows for the the toggling and customization of said toggling within settings.",
     "author": "Conner Ohnesorge",
     "repo": "conneroisu/vim-toggle"
   },
@@ -6571,27 +6571,27 @@
     "author": "Daniele Susino",
     "description": "Speedup latex matrices writing.",
     "repo": "Deltekk/Obsidian-Latex-Matrices"
- },
- {
+  },
+  {
     "id": "smart-rename",
     "name": "Smart Rename",
     "author": "mnaoumov",
     "description": "Renames notes keeping previous title in existing links",
     "repo": "mnaoumov/obsidian-smart-rename"
   },
- {
+  {
     "id": "folder-notes",
     "name": "Folder notes",
     "description": "Create notes within folders that can be accessed without collapsing the folder, similar to the functionality offered in Notion.",
     "author": "Lost Paul",
     "repo": "LostPaul/obsidian-folder-notes"
- },
- {
-  "id": "pocketbook-cloud-highlight-importer",
-  "name": "Pocketbook Cloud Highlight Importer",
-  "author": "Lena Brüder",
-  "description": "Imports notes and highlights from your Pocketbook Cloud account into your vault.",
-  "repo": "lenalebt/obsidian-pocketbook-cloud-highlight-importer"
+  },
+  {
+    "id": "pocketbook-cloud-highlight-importer",
+    "name": "Pocketbook Cloud Highlight Importer",
+    "author": "Lena Brüder",
+    "description": "Imports notes and highlights from your Pocketbook Cloud account into your vault.",
+    "repo": "lenalebt/obsidian-pocketbook-cloud-highlight-importer"
   },
   {
     "id": "pivotal-tracker-integration",
@@ -6613,8 +6613,8 @@
     "author": "Mani Batra",
     "description": "This is an obsidian plugin that uses OpenAI to generate flashcards from text and add them to Anki.",
     "repo": "manibatra/obsidian-text2anki-openai"
- },
- {
+  },
+  {
     "id": "ultimate-todoist-sync",
     "name": "Ultimate Todoist Sync",
     "description": "This is the best Todoist task synchronization plugin for Obsidian so far.",
@@ -6627,8 +6627,8 @@
     "author": "Galacsh",
     "description": "Enhances reading view. Use arrow keys to fold/unfold elements.",
     "repo": "Galacsh/obsidian-reading-view-enhancer"
- },
- {
+  },
+  {
     "id": "crossbow",
     "name": "Crossbow",
     "description": "Find backlinks in your notes",
@@ -6648,8 +6648,8 @@
     "description": "Runs ocr on images and pastes result in description.",
     "author": "kaffarell",
     "repo": "kaffarell/obsidian-tesseract-ocr"
- },
- {
+  },
+  {
     "id": "gpt-liteinquirer",
     "name": "GPT-LiteInquirer",
     "description": "Experience OpenAI ChatGPT assistance directly within Obsidian, drafting content without interrupting your creative flow.",
@@ -6718,64 +6718,64 @@
     "description": "Meet your open source AI mentor in Obsidian. Ask questions, get answers, and learn new things.",
     "author": "clementpoiret",
     "repo": "clementpoiret/ai-mentor"
- },
- {
+  },
+  {
     "id": "game-search",
     "name": "Game Search",
     "description": "Help insert game metadata into game notes or journals",
     "author": "calvin",
     "repo": "CMorooney/obsidian-game-search-plugin"
- },
- {
+  },
+  {
     "id": "linked-data-vocabularies",
     "name": "Linked Data Vocabularies",
     "author": "kometenstaub",
     "description": "Add Library of Congress Subject Headings (LCSH) as metadata to your notes.",
     "repo": "kometenstaub/linked-data-vocabularies"
- },
- {
+  },
+  {
     "id": "linked-data-helper",
     "name": "Linked Data Helper",
     "author": "kometenstaub",
     "description": "Prepare data needed by Linked Data Vocabularies.",
     "repo": "kometenstaub/linked-data-helper"
- },
- {
+  },
+  {
     "id": "show-diff",
     "name": "Show Diff",
     "author": "Ivan Lednev",
     "description": "Render Git diffs in Obsidian files",
     "repo": "ivan-lednev/obsidian-automatic-changelog"
- },
- {
+  },
+  {
     "id": "markdoc",
     "name": "Markdoc",
     "author": "Maciej Jur",
     "description": "Basic support for Markdoc files.",
     "repo": "kamoshi/obsidian-markdoc"
   },
- {
+  {
     "id": "colored-text",
     "name": "Colored Text",
     "author": "Erinc Ayaz",
     "description": "Color the selected texts.",
     "repo": "erincayaz/obsidian-colored-text"
- },
- {
+  },
+  {
     "id": "slide-note",
     "name": "Slide Note",
     "author": "Jinyan Xu",
     "description": "Conveniently take notes on PDF course slides :P",
     "repo": "Phantom1003/obsidian-slide-note"
- },
- {
+  },
+  {
     "id": "chem",
     "name": "Chem",
     "author": "Acylation",
     "description": "Providing chemistry supports. Rendering SMILES strings into chemistry structures.",
     "repo": "Acylation/obsidian-chem"
- },
- {
+  },
+  {
     "id": "last-modified-timestamp-in-status-bar",
     "name": "Last Modified Timestamp in Status Bar",
     "author": "Yustynn",
@@ -6817,7 +6817,7 @@
     "description": "Automatically prompt for a template, when creating a note.",
     "repo": "numeroflip/obsidian-auto-template-prompt"
   },
-  {  
+  {
     "id": "ketcher",
     "name": "Ketcher",
     "author": "Yulei Chen",
@@ -6868,10 +6868,10 @@
   },
   {
     "id": "plugin-manager",
-	  "name": "Plugin Manager",
-	  "description": "Extends plugin management of Obsidian.",
-	  "author": "ohm-en",
-	  "repo": "ohm-en/obsidian-plugin-manager"
+    "name": "Plugin Manager",
+    "description": "Extends plugin management of Obsidian.",
+    "author": "ohm-en",
+    "repo": "ohm-en/obsidian-plugin-manager"
   },
   {
     "id": "better-mathjax",
@@ -6984,5 +6984,12 @@
     "author": "HamsterBase",
     "description": "Official HamsterBase -> Obsidian integration",
     "repo": "hamsterbase/obsidian-hamsterbase"
+  },
+  {
+    "id": "todotxt",
+    "name": "TodoTxt",
+    "author": "Mark Grimes",
+    "description": "Manage Todo.txt files.",
+    "repo": "mvgrimes/obsidian-todotxt-plugin"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [mvgrimes/obsidian-todotxt-plugin](https://github.com/mvgrimes/obsidian-todotxt-plugin)

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
