### PR TITLE
Remove Emoji in 🔔 Chime theme.

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1130,7 +1130,7 @@
     "modes": ["dark", "light"]
   },
   {
-    "name": "🔔 Chime",
+    "name": "Chime",
     "author": "Ha'ani Whitlock",
     "repo": "Bluemoondragon07/chime-theme",
     "screenshot": "Chime.png",


### PR DESCRIPTION
Some people have issues syncing the theme with Dropbox because of the emoji in the title, so I was wondering if I could remove that stylization.