### PR TITLE
Adding obsidian-enhanced-treemap

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6816,5 +6816,12 @@
     "author": "Yustynn",
     "description": "Dynamic display of file modification timestamp in the status bar.",
     "repo": "Yustynn/obsidian-last-modified-timestamp-in-status-bar"
+  },
+  {
+    "id": "obsidian-enhanced-treemap",
+    "name": "Obsidian Enhanced Treemap",
+    "author": "Erik Shelley",
+    "description": "This is an Obsidian (https://obsidian.md) plugin for creating enhanced treemaps.",
+    "repo": "erikshelley/obsidian-enhanced-treemap"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6821,7 +6821,7 @@
     "id": "enhanced-treemap",
     "name": "Enhanced Treemap",
     "author": "Erik Shelley",
-    "description": "This is an Obsidian (https://obsidian.md) plugin for creating enhanced treemaps.",
+    "description": "Create enhanced treemaps.",
     "repo": "erikshelley/obsidian-enhanced-treemap"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6818,8 +6818,8 @@
     "repo": "Yustynn/obsidian-last-modified-timestamp-in-status-bar"
   },
   {
-    "id": "obsidian-enhanced-treemap",
-    "name": "Obsidian Enhanced Treemap",
+    "id": "enhanced-treemap",
+    "name": "Enhanced Treemap",
     "author": "Erik Shelley",
     "description": "This is an Obsidian (https://obsidian.md) plugin for creating enhanced treemaps.",
     "repo": "erikshelley/obsidian-enhanced-treemap"


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/erikshelley/obsidian-enhanced-treemap

## Release Checklist
- [ ] I have tested the plugin on
  - [X]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
