### PR TITLE
Add Share to Cubox Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6844,5 +6844,12 @@
     "description": "Provide the function of fuzzy search using Chinese Pinyin.",
     "author": "lazyloong",
     "repo": "lazyloong/obsidian-fuzzy-chinese"
-  }
+  },
+  {
+    "id": "share-to-cubox",
+    "name": "Share to Cubox",
+    "description": "Share Obsidian notes to Cubox using the provided API.",
+    "author": "Redwinam",
+    "repo": "Redwinam/obsidian-cubox"
+  },
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6851,5 +6851,5 @@
     "description": "Share Obsidian notes to Cubox using the provided API.",
     "author": "Redwinam",
     "repo": "Redwinam/obsidian-cubox"
-  },
+  }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Redwinam/obsidian-cubox

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
