### PR TITLE
Add plugin `show-dotfiles`

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6851,5 +6851,12 @@
     "author": "Numeroflip",
     "description": "Automatically prompt for a template, when creating a note.",
     "repo": "numeroflip/obsidian-auto-template-prompt"
+  },
+  {
+    "id": "show-dotfiles",
+    "name": "Show Dotfiles",
+    "author": "polyipseity",
+    "description": "Show dotfiles in Obsidian.",
+    "repo": "polyipseity/obsidian-show-dotfiles"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

(Side note, there are many trailing whitespaces and other types of inconsistent formatting in `community-plugins.json` that you may want to fix.)

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/polyipseity/obsidian-show-dotfiles

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
