### PR TITLE
Update repo stat for Pseudocode plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6325,7 +6325,7 @@
     "name": "Pseudocode",
     "author": "Yaotian Liu",
     "description": "Helps render LaTeX-style pseudocode inside a code block.",
-    "repo": "Yaotian-Liu/obsidian-pseudocode"
+    "repo": "ytliu74/obsidian-pseudocode"
   },
   {
     "id": "advanced-merger",


### PR DESCRIPTION
# I am NOT submitting a new Community Plugin

Sorry for the confusion, I recently changed my account name and have noticed that this has caused issues with the plugin stat auto-update. Therefore, I am submitting a pull request to update my repository URL to reflect the new account name.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/ytliu74/obsidian-pseudocode

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
