### PR TITLE
Add Covert Obsidian Theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1441,8 +1441,7 @@
     "name": "Covert",
     "author": "Schrunchee",
     "repo": "schrunchee/obsidian-covert-theme",
-    "screenshot": "obsidian_covert_theme_sm2.jpg",
-    "modes": ["dark"],
-	"branch": "main"
+    "screenshot": "obsidian_covert_theme_sm3.jpg",
+    "modes": ["dark"]
 }
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1436,5 +1436,13 @@
     "repo": "zaklezaja/obsidian-oozy",
     "screenshot": "preview-cover.png",
     "modes": ["dark"]
-  }
+  },
+  {
+    "name": "Covert",
+    "author": "Schrunchee",
+    "repo": "https://github.com/schrunchee/obsidian-covert-theme/",
+    "screenshot": "obsidian_covert_theme_by_schrunchee.jpg",
+    "modes": ["dark"],
+	"branch": "main"
+}
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1440,8 +1440,8 @@
   {
     "name": "Covert",
     "author": "Schrunchee",
-    "repo": "https://github.com/schrunchee/obsidian-covert-theme/",
-    "screenshot": "obsidian_covert_theme_by_schrunchee.jpg",
+    "repo": "schrunchee/obsidian-covert-theme",
+    "screenshot": "obsidian_covert_theme_sm.jpg",
     "modes": ["dark"],
 	"branch": "main"
 }

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1441,7 +1441,7 @@
     "name": "Covert",
     "author": "Schrunchee",
     "repo": "schrunchee/obsidian-covert-theme",
-    "screenshot": "obsidian_covert_theme_sm.jpg",
+    "screenshot": "obsidian_covert_theme_sm2.jpg",
     "modes": ["dark"],
 	"branch": "main"
 }


### PR DESCRIPTION
A dark obsidian theme that is designed to make it hard for people to read over your shoulder.

<!--- Delete this section if submitting a plugin -->
# I am submitting a new Community Theme

## Repo URL

<!--- Paste a link to your repo here for easy access -->
[Link to my theme: ](https://github.com/schrunchee/obsidian-covert-theme)

## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [✓ ] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [✓ ] `manifest.json`
  - [✓ ] `theme.css`
  - [✓ ] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
- [✓ ] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [✓ ] I have added a license in the LICENSE file.
- [ ✓] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.
