### PR TITLE
Add Dacula Plus theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1436,5 +1436,12 @@
     "repo": "zaklezaja/obsidian-oozy",
     "screenshot": "preview-cover.png",
     "modes": ["dark"]
+  },
+  {
+    "name": "Dracula Plus",
+    "author": "saket",
+    "repo": "saket61195/Dracula_obsidian_theme",
+    "screenshot": "demo1.png",
+    "modes": ["dark"]
   }
 ]


### PR DESCRIPTION
> # I am submitting a new Community Theme
> Dracula inspired theme.
> 
> ## Repo URL
> Link to my theme: https://github.com/saket61195/Dracula_obsidian_theme
> 
> ## Theme checklist
> * [x]  My repo contains all required files (please _do not_ add them to this `obsidian-releases` repo).
>   
>   * [x]  `manifest.json`
>   * [x]  `theme.css`
>   * [x]  The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
> * [x]  I have indicated which modes (dark, light, or both) are compatible with my theme.
> * [x]  I have added a license in the LICENSE file.
> * [x]  My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.

