### PR TITLE
add gummy theme, fixed

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1457,5 +1457,11 @@
     "repo": "SalemElatar/salem-obsidian-theme",
     "screenshot": "screenshot.png",
     "modes": ["dark", "light"]
+ },
+     "name": "gummy",
+    "author": "kneecaps",
+    "repo": "7368697661/gummy",
+    "screenshot": "preview_thumb.png",
+    "modes": ["dark", "light"]
  }
 ]


### PR DESCRIPTION

# I am submitting a new Community Theme

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my theme: https://github.com/7368697661/gummy


## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `manifest.json`
  - [x] `theme.css`
  - [x] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.
