### PR TITLE
Add Simple theme

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,13 @@
 [
   {
+    "name": "Simple",
+    "author": "Diego Eis",
+    "repo": "diegoeis/simple-obsidian",
+    "screenshot": "cover.png",
+    "description": "This is a topic for those who love to write with excellent legibility and design.",
+    "modes": ["dark", "light"]
+  },
+  {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",


### PR DESCRIPTION
New theme

The Simple is a theme for Obsidian that prioritizes reading and writing. 

It has minimal customizations and a simple design to avoid distractions and noise while taking notes and writing long-form texts.
