### PR TITLE
Add Markdown Link Space Encoder plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7162,9 +7162,9 @@
   },
   {
     "id": "markdown-link-space-encoder",
-	  "name": "Markdown Link Space Encoder",
+    "name": "Markdown Link Space Encoder",
     "author": "Ron Kosova",
-  	"description": "Simple plugin to automatically encode spaces to %20 in Markdown-style links",
-  	"repo": "rkosova/obsidian-markdown-link-space-encoder"
+    "description": "Simple plugin to automatically encode spaces to %20 in Markdown-style links",
+    "repo": "rkosova/obsidian-markdown-link-space-encoder"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7159,5 +7159,12 @@
     "author": "Onur Ayçiçek",
     "description": "Search movies info and trailers.",
     "repo": "onuraycicek/obsidian-movie"
+  },
+  {
+    "id": "markdown-link-space-encoder",
+	  "name": "Markdown Link Space Encoder",
+    "author": "Ron Kosova",
+  	"description": "Simple plugin to automatically encode spaces to %20 in Markdown-style links",
+  	"repo": "rkosova/obsidian-markdown-link-space-encoder"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [rkosova/obsidian-markdown-link-space-encoder](https://github.com/rkosova/obsidian-markdown-link-space-encoder)

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [ x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x ] `main.js`
  - [ x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [ x] I have added a license in the LICENSE file.
- [ x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
