### PR TITLE
Add `directory-files` to plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7245,5 +7245,12 @@
     "description": "Collect RSS articles into notes.",
     "author": "Monnierant",
     "repo": "monnierant/obsidian-simple-rss"
+  },
+  {
+    "id": "directory-files",
+    "name": "Directory Files",
+    "description": "Link to and view the contents of folders with auto-generated and auto-maintained directory files.",
+    "author": "Devin Droddy",
+    "repo": "ThePyroTF2/directory-files"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
