### PR TITLE
add plugin obsidian-copilot-plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7362,5 +7362,12 @@
     "author": "Paul Treanor",
     "description": "Adds created on and last updated on dates of the active note to the status bar.",
     "repo": "paultreanor/notes-dater"
+  },
+  {
+    "id": "obsidian-copilot-plugin",
+    "name": "Obsidian Copilot",
+    "author": "Jordi Smit",
+    "description": "Adds a highly configurable copilot-like auto-completion to Obsidian.",
+    "repo": "j0rd1smit/obsidian-copilot"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin
This plugin adds a copilot-like auto-completion to Obsidian. It uses the OpenAI API or Azure OpenAi API to generate text based on the n characters before and after your cursor. It will show the suggested completion in transparent text next to your cursor. You can then press Tab to insert the suggestion. Additionally, you can press Escape or move the cursor to ignore the suggestion.

Besides this default functionality, the plugin has been designed to be highly configurable, allowing people to play around with their own prompt engineering approaches. This will enable them to change the prediction to match their own style.

## Repo URL

Link to my plugin:
https://github.com/j0rd1smit/obsidian-copilot#obsidian-sample-plugin

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(not applicable)_
  - [ ]  iOS _(not applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
