### PR TITLE
chore: add AI Research Assistant to Community Plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7214,7 +7214,7 @@
     "name": "Chemical Structure Renderer",
     "description": "Render chemical structures from SMILES strings into PNG or SVG format using Ketcher and Indigo Service.",
     "author": "xaya1001",
-    "repo": "xaya1001/obsidian-Chemical-Structure-Renderer" 
+    "repo": "xaya1001/obsidian-Chemical-Structure-Renderer"
   },
   {
     "id": "time-ruler",
@@ -7252,18 +7252,18 @@
     "repo": "iafisher/obsidian-quick-links"
   },
   {
-  	"id": "editor-width-slider",
-  	"name": "Editor Width Slider",
-  	"author": "@MugishoMp",
-  	"description": "Customize Obsidian's editor width with a slider for a tailored editing experience.",
-  	"repo": "MugishoMp/obsidian-editor-width-slider"
+    "id": "editor-width-slider",
+    "name": "Editor Width Slider",
+    "author": "@MugishoMp",
+    "description": "Customize Obsidian's editor width with a slider for a tailored editing experience.",
+    "repo": "MugishoMp/obsidian-editor-width-slider"
   },
   {
-   "id": "markdown-tree",
-   "name": "Markdown Tree",
-   "author": "carvah",
-   "description": "Create a beautiful and intuitive directory tree using Markdown-oriented code style using tabs, spaces and enters.",
-   "repo": "carvah/markdown-tree-plugin"
+    "id": "markdown-tree",
+    "name": "Markdown Tree",
+    "author": "carvah",
+    "description": "Create a beautiful and intuitive directory tree using Markdown-oriented code style using tabs, spaces and enters.",
+    "repo": "carvah/markdown-tree-plugin"
   },
   {
     "id": "auto-front-matter",
@@ -7336,7 +7336,7 @@
     "repo": "vzsky/apl-obsidian"
   },
   {
-     "id": "guid-front-matter",
+    "id": "guid-front-matter",
     "name": "Add an ID to the front matter",
     "author": "llimllib",
     "description": "Add a globally unique ID to every markdown document's front matter",
@@ -7362,5 +7362,12 @@
     "author": "Paul Treanor",
     "description": "Adds created on and last updated on dates of the active note to the status bar.",
     "repo": "paultreanor/notes-dater"
+  },
+  {
+    "id": "ai-research-assistant",
+    "name": "AI Research Assistant",
+    "author": "Interweb Alchemy",
+    "description": "A Prompt Engineering research utility for generative AI models like OpenAI's ChatGPT that facilitates archiving and searching conversations and live editing a conversation's context/memory.",
+    "repo": "InterwebAlchemy/obsidian-ai-research-assistant"
   }
 ]


### PR DESCRIPTION
Adds InterwebAlchemy/obsidian-ai-research-assistant to community-plugins.json

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/InterwebAlchemy/obsidian-ai-research-assistant

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux **Don't have Obsidian installed on a Linux machine**
  - [ ]  Android _(if applicable)_ **Not Applicable**
  - [ ]  iOS _(if applicable)_ **Not Applicable**
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
