### PR TITLE
chore: add ai-research-assistant to community-plugns.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7537,5 +7537,12 @@
     "author": "ddalexb",
     "description": "Quickly fuzzysearch notes, cards and their content and shift focus to them within the currently opened canvas.",
     "repo": "ddalexb/obsidian-simple-canvasearch"
+  },
+  {
+    "id": "ai-research-assistant",
+    "name": "AI Research Assistant",
+    "author": "Interweb Alchemy",
+    "description": "A Prompt Engineering research utility for generative AI models like OpenAI's ChatGPT that facilitates archiving and searching conversations and live editing a conversation's context/memory.",
+    "repo": "InterwebAlchemy/obsidian-ai-research-assistant"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/InterwebAlchemy/obsidian-ai-research-assistant

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux **Don't have Obsidian installed on a Linux machine**
  - [ ]  Android _(if applicable)_ **Desktop Only due to Electron SafeStorage requirement for API keys**
  - [ ]  iOS _(if applicable)_ **Desktop Only due to Electron SafeStorage requirement for API keys**
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
