### PR TITLE
Community themes: Renamed user Maldonacho to Carbonateb

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -908,7 +908,7 @@
   {
     "name": "Encore",
     "author": "Lucas Champagne",
-    "repo": "maldonacho/obsidian-encore-theme",
+    "repo": "carbonateb/obsidian-encore-theme",
     "screenshot": "images/promo-image.png",
     "modes": ["dark", "light"]
   },


### PR DESCRIPTION
I've changed my GitHub username to Carbonateb, this pr makes my theme (Encore) point to the canonical repository url instead of relying on GitHub's automatic redirect which is less reliable by nature.