### PR TITLE
Adding Tldraw to the Community Plugin List

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7362,5 +7362,12 @@
     "author": "Paul Treanor",
     "description": "Adds created on and last updated on dates of the active note to the status bar.",
     "repo": "paultreanor/notes-dater"
+  },
+  {
+    "id": "tldraw",
+    "name": "Tldraw",
+    "author": "Sam Alhaqab",
+    "description": "Integrates Tldraw into Obsidian, allowing users to draw and edit content on a virtual whiteboard.",
+    "repo": "holxsam/tldraw-in-obsidian"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [https://github.com/holxsam/tldraw-in-obsidian](https://github.com/holxsam/tldraw-in-obsidian)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
