### PR TITLE
Add NotSwift theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1492,5 +1492,12 @@
   "repo": "diegoeis/simple-obsidian",
   "screenshot": "cover.png",
   "modes": ["dark", "light"]
+},
+{
+  "name": "NotSwift",
+  "author": "David Roos",
+  "repo": "davidjroos/obsidian-notswift",
+  "screenshot": "screenie.png",
+  "modes": ["dark", "light"]
 }
 ]


### PR DESCRIPTION
# I am submitting a new Community Theme

## Repo URL

Link to my theme:  https://github.com/davidjroos/obsidian-notswift

## Theme checklist

- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `manifest.json`
  - [x] `theme.css`
  - [x] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading). FIXED!
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.
