### PR TITLE
Add Handwritten Notes to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7444,6 +7444,6 @@
     "name": "Hand Written Notes",
     "author": "FBarrca",
 	"description": " Please read the README on github! This plugin allows you to write notes by hand using a stylus.",
-    "repo": "https://github.com/FBarrca"
+    "repo": "FBarrca/obsidian-handwritten-notes"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7440,7 +7440,7 @@
     "description": "Generates study index notes using a spaced repetition algorithm (SM-2).",
     "repo": "nwindian/Memorization-Plugin"
   }, {
-	"id": "obsidian-handwritten-notes",
+    "id": "obsidian-handwritten-notes",
     "name": "Hand Written Notes",
     "author": "FBarrca",
 	"description": " Please read the README on github! This plugin allows you to write notes by hand using a stylus.",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7441,7 +7441,7 @@
     "repo": "nwindian/Memorization-Plugin"
   }, {
     "id": "obsidian-handwritten-notes",
-    "name": "Hand Written Notes",
+    "name": "Handwritten Notes",
     "author": "FBarrca",
     "description": " Please read the README on github! This plugin allows you to write notes by hand using a stylus.",
     "repo": "FBarrca/obsidian-handwritten-notes"

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7443,7 +7443,7 @@
     "id": "obsidian-handwritten-notes",
     "name": "Hand Written Notes",
     "author": "FBarrca",
-	"description": " Please read the README on github! This plugin allows you to write notes by hand using a stylus.",
+    "description": " Please read the README on github! This plugin allows you to write notes by hand using a stylus.",
     "repo": "FBarrca/obsidian-handwritten-notes"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7439,5 +7439,11 @@
     "author": "Joseph Cochran",
     "description": "Generates study index notes using a spaced repetition algorithm (SM-2).",
     "repo": "nwindian/Memorization-Plugin"
-  }
+  }, {
+	"id": "obsidian-handwritten-notes",
+    "name": "Hand Written Notes",
+    "author": "FBarrca",
+	"description": " Please read the README on github! This plugin allows you to write notes by hand using a stylus.",
+    "repo": "https://github.com/FBarrca"
+}
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin:
https://github.com/FBarrca/obsidian-handwritten-notes

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
