### PR TITLE
Add Permalink Opener, remove System Dark Mode

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -175,11 +175,11 @@
     "repo": "kepano/obsidian-minimal-settings"
   },
   {
-    "id": "obsidian-system-dark-mode",
-    "name": "System Dark Mode",
+    "id": "permalink-opener",
+    "name": "Permalink Opener",
     "author": "@kepano",
-    "description": "Automatically use the operating system's setting to switch between light and dark mode.",
-    "repo": "kepano/obsidian-system-dark-mode"
+    "description": "Open URLs based on a permalink or slug in the frontmatter properties. For use with Jekyll, Hugo, Eleventy and other publishing tools.",
+    "repo": "kepano/obsidian-permalink-opener"
   },
   {
     "id": "obsidian-discordrpc",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/kepano/obsidian-permalink-opener

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
