### PR TITLE
Rename Cycle Through Panes to Tab Switcher

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -297,7 +297,7 @@
     "id": "cycle-through-panes",
     "name": "Tab Switcher",
     "author": "Vinzent & phibr0",
-    "description": "Switch your tabs with `ctrl + Tab` in recently used order, just like in your browser!",
+    "description": "Switch your tabs with Ctrl + Tab in recently used order like in a browser.",
     "repo": "Vinzent03/tab-switcher"
   },
   {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -295,10 +295,10 @@
   },
   {
     "id": "cycle-through-panes",
-    "name": "Cycle through Panes",
-    "author": "Vinadon & phibr0",
-    "description": "Cycle through your open panes with `ctrl + Tab`, just like with tabs in your browser!",
-    "repo": "phibr0/cycle-through-panes"
+    "name": "Tab Switcher",
+    "author": "Vinzent & phibr0",
+    "description": "Switch your tabs with `ctrl + Tab` in recently used order, just like in your browser!",
+    "repo": "Vinzent03/tab-switcher"
   },
   {
     "id": "music-code-blocks",


### PR DESCRIPTION
# I am renaming and relocating an existing Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
The plugin is currently here located: https://github.com/phibr0/cycle-through-panes

Because I'm now mainly maintaining that plugin, @phibr0 transfers the repo to my account. In addition, I'm renaming it. I haven't accepted the transfer yet, but will do so immediately after this pr is merged to prevent any issues with a missing repo. 