### PR TITLE
chore: update to Obsidian Plugin Docs guidelines link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/plugin.md
+++ b/.github/PULL_REQUEST_TEMPLATE/plugin.md
@@ -19,7 +19,7 @@ Link to my plugin:
 - [ ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
 - [ ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
 - [ ] My README.md describes the plugin's purpose and provides clear usage instructions.
-- [ ] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
+- [ ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
 - [ ] I have added a license in the LICENSE file.
 - [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
       I have given proper attribution to these other projects in my `README.md`.


### PR DESCRIPTION
When going through the Plugin PR Template checklist, there was a link to https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md, but it seems like those docs are out of date compared to https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines which was quoted during plugin review.

Just wanted to sync up the checklist with the most current guidelines to help streamline future plugin reviews.