### PR TITLE
Add Safe Filename Linter Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7537,5 +7537,13 @@
     "author": "ddalexb",
     "description": "Quickly fuzzysearch notes, cards and their content and shift focus to them within the currently opened canvas.",
     "repo": "ddalexb/obsidian-simple-canvasearch"
+  },
+  {
+    "id": "safe-filename-linter",
+    "name": "Safe Filename Linter",
+    "author": "sneaky-foxes",
+    "description": "Lints filenames for invalid or troublesome characters",
+    "repo": "sneaky-foxes/obsidian-safe-filename-linter",
+    "branch": "main"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/sneaky-foxes/obsidian-safe-filename-linter

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android
  - [x]  iOS
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  -  ~~`styles.css` _(optional)_~~
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
