### PR TITLE
add the obsidian-gtd-no-next-step plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7523,5 +7523,12 @@
     "author": "ddalexb",
     "description": "Quickly fuzzysearch notes, cards and their content and shift focus to them within the currently opened canvas.",
     "repo": "ddalexb/obsidian-simple-canvasearch"
+  },
+  {
+    "id": "gtd-no-next-step",
+    "name": "GTD No Next Step",
+    "description": "Adds a badge to Getting Things Done (GTD) \"project\" files with no defined next step.",
+    "author": "Tobias Davis",
+    "repo": "saibotsivad/obsidian-gtd-no-next-step"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

Previously submitted as #2198 but had to close and reopen due to merge conflicts.

All comments in that PR have been addressed.

## Repo URL

Link to my plugin: https://github.com/saibotsivad/obsidian-gtd-no-next-step

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
