### PR TITLE
remove jira cloud plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7483,13 +7483,6 @@
     "repo": "pfrankov/obsidian-colored-tags"
   },
   {
-    "id": "jira-cloud",
-    "name": "Jira Cloud",
-    "author": "OfficerHalf",
-    "description": "An unofficial integration to bring Jira Issues into your Obsidian notes.",
-    "repo": "OfficerHalf/obsidian-jira-cloud"
-  },
-  {
     "id": "markdown-sync-scroll",
     "name": "Markdown Sync Scroll",
     "author": "ProjectXero",


### PR DESCRIPTION
I'm not sure how I missed it, but there's already a plugin ([Obsidian Jira Issue](https://marc0l92.github.io/obsidian-jira-issue/)) that does what mine does and does it better. I'm just going to remove this from the registry before it gets any more users.