### PR TITLE
Add Clean Slack Paste

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7732,6 +7732,6 @@
     "name": "Slack Paste Cleaner",
     "author": "Ariel Lothlorien",
     "description": "A plugin to clean up Slack message pastes/exports",
-    "repo": "eforen/obsidian-clean-slack-paste"
+    "repo": "Eforen/obsidian-clean-slack-paste"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7732,6 +7732,6 @@
     "name": "Slack Paste Cleaner",
     "author": "Ariel Lothlorien",
     "description": "A plugin to clean up Slack message pastes/exports",
-    "repo": "Eforen/obsidian-clean-slack-paste"
+    "repo": "eforen/obsidian-clean-slack-paste"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7726,5 +7726,12 @@
     "author": "sneaky-foxes",
     "description": "Lints filenames for invalid or troublesome characters",
     "repo": "sneaky-foxes/obsidian-safe-filename-linter"
+  },
+  {
+    "id": "slack-paste-cleaner",
+    "name": "Slack Paste Cleaner",
+    "author": "Ariel Lothlorien",
+    "description": "A plugin to clean up Slack message pastes/exports",
+    "repo": "Eforen/obsidian-clean-slack-paste"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/Eforen/obsidian-clean-slack-paste/

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
