### PR TITLE
Add oBridge Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7726,5 +7726,12 @@
     "author": "sneaky-foxes",
     "description": "Lints filenames for invalid or troublesome characters",
     "repo": "sneaky-foxes/obsidian-safe-filename-linter"
+  },
+  {
+    "id": "obridge",
+    "name": "oBridge",
+    "author": "clock-worked",
+    "description": "A tool for effortlessly creating links between notes to bridge them together.",
+    "repo": "clock-worked/oBridge"
   }
 ]


### PR DESCRIPTION
A tool for effortlessly creating links between notes to bridge them together.

https://github.com/clock-worked/oBridge

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://github.com/obsidianmd/obsidian-releases/blob/master/plugin-review.md and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
