### PR TITLE
Add "Quick Settings Switchs for Plugins"

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7775,5 +7775,12 @@
     "author": "williamechols",
     "description": "lightweight Python code snippet executor with runtime input support",
     "repo": "williamechols/obsidian-execute-python"
+  },
+  {
+    "id": "quick-settings-switchs",
+    "name": "Quick Settings Switchs for Plugins",
+    "author": "Hugo COLLIN",
+    "description": "Enable and disable your plugins quickly from the settings side menu.",
+    "repo": "Hugo-COLLIN/obsidian-quick-settings-switchs"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin : <br>Quick Settings Switchs for Plugins

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Hugo-COLLIN/obsidian-quick-settings-switchs

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
