### PR TITLE
remove System Theme plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -4438,13 +4438,6 @@
     "repo": "czottmann/obsidian-blockquote-levels"
   },
   {
-    "id": "obsidian-system-theme",
-    "name": "System Theme",
-    "author": "jgauth",
-    "description": "Plugin to automatically update to system theme.",
-    "repo": "jgauth/obsidian-system-theme"
-  },
-  {
     "id": "custom-sort",
     "name": "Custom File Explorer sorting",
     "author": "SebastianMC",


### PR DESCRIPTION
PR to remove my plugin.

My plugin was a workaround for an issue which has been fixed in obsidian 1.0.1. 