### PR TITLE
Update community-plugins.json after repo owner changed

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -142,9 +142,9 @@
   {
     "id": "obsidian-day-planner",
     "name": "Day Planner",
-    "author": "James Lynch",
-    "description": "Day planning and managing pomodoro timers from a task list in a Markdown note.",
-    "repo": "lynchjames/obsidian-day-planner"
+    "author": "James Lynch (continued by Ivan Lednev)",
+    "description": "Day planning from a task list in a Markdown note.",
+    "repo": "ivan-lednev/obsidian-day-planner"
   },
   {
     "id": "cm-editor-syntax-highlight-obsidian",


### PR DESCRIPTION
The creator of `obsidian-day-planner` showed up after a long break. He noticed that I'd been working on a fork, so he transferred the original repo to me, so that there is only one updated version of the plugin in the list.

This is a tiny change to fix the error when trying to download the plugin from the community plugins list.
Here is a link to the same plugin repo by the new address: https://github.com/ivan-lednev/obsidian-day-planner