### PR TITLE
Add Day Planner (OG)

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -143,7 +143,7 @@
     "id": "obsidian-day-planner",
     "name": "Day Planner",
     "author": "James Lynch (continued by Ivan Lednev)",
-    "description": "Day planning from a task list in a Markdown note.",
+    "description": "Day planning from a task list in a Markdown note with enhanced time block functionality.",
     "repo": "ivan-lednev/obsidian-day-planner"
   },
   {
@@ -8258,5 +8258,12 @@
     "description": "Elevate your Obsidian workflow with customizable LLM actions.",
     "author": "Zekun Shen",
     "repo": "buszk/obsidian-ai-editor"
+  },
+  {
+    "id": "day-planner-og",
+    "name": "Day Planner (OG)",
+    "author": "James Lynch (continued by Erin Schnabel)",
+    "description": "Day planning from a simple task list in a Markdown note (bare bones, preserves the features and behavior of the original plugin)",
+    "repo": "ebullient/obsidian-day-planner-og"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

Add the alternate day-planner plugin, with some text modifications to disambiguate between the two (where one is adding new features and capabilities, and the other is hewing closer to the original behavior).

@ivan-lednev .. LMK what you think.

Note: They are now separated in the file, but I still have the proposed changes (with agreement below).

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/ebullient/obsidian-day-planner-og

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.



