### PR TITLE
Add plugin: Find Orphan Block Identifiers

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8055,5 +8055,12 @@
 	"author": "julix14",
 	"description": "Let your AI assistant ChatGPT define words and concepts for you.",
 	"repo": "julix14/chatGPT-Obsidian"
+  },
+  {
+    "id": "obsidian-find-orphan-block-identifiers",
+    "name": "Find Orphan Block Identifiers",
+    "author": "Alberto Leal",
+    "description": "Obsidian plugin to find orphaned block references and broken links.",
+    "repo": "dashed/obsidian-find-orphan-block-identifiers"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8057,10 +8057,10 @@
 	"repo": "julix14/chatGPT-Obsidian"
   },
   {
-    "id": "obsidian-find-orphan-block-identifiers",
+    "id": "find-orphan-block-identifiers",
     "name": "Find Orphan Block Identifiers",
     "author": "Alberto Leal",
-    "description": "Obsidian plugin to find orphaned block references and broken links.",
+    "description": "Find orphaned block references and broken links.",
     "repo": "dashed/obsidian-find-orphan-block-identifiers"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/dashed/obsidian-find-orphan-block-identifiers

Release: https://github.com/dashed/obsidian-find-orphan-block-identifiers/releases/tag/1.0.3

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
