### PR TITLE
Add "Share Note" plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8055,5 +8055,12 @@
 	"author": "julix14",
 	"description": "Let your AI assistant ChatGPT define words and concepts for you.",
 	"repo": "julix14/chatGPT-Obsidian"
+  },
+  {
+    "id": "share-note",
+    "name": "Share Note",
+    "author": "Alan Grainger",
+    "description": "Share a note publicly with full styling. Data is stored encrypted on the server and only you have the key.",
+    "repo": "alangrainger/obsidian-share"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/alangrainger/obsidian-share

## 👉 Notes for Obsidian Team

This plugin is different from the two existing plugins QuickShare and OzanShare. QuickShare does not support the theme of your note, nor images. OzanShare is a paid service.

Regarding the code, I will be very interested to get your feedback. What I've done works perfectly, but I'm not sure how "best practice" my methods are, for example how I get the pixel-perfect rendered HTML here: https://github.com/alangrainger/obsidian-share/blob/2195942681f768075e82a91960a61225f9b5246d/src/note.ts#L46

Keen to hear feedback. Maybe you'll like how I did it!

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
- [x] I have given proper attribution to these other projects in my `README.md`.
