### PR TITLE
Update LinkShelf to LinkStowr in community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7785,10 +7785,10 @@
   },
   {
     "id": "linkshelf",
-    "name": "LinkShelf",
+    "name": "LinkStowr",
     "description": "Save links from your browser directly into Obsidian.",
     "author": "Joel Sequeira",
-    "repo": "joelseq/obsidian-linkshelf"
+    "repo": "joelseq/obsidian-linkstowr"
   },
   {
     "id": "modules",


### PR DESCRIPTION
Due to a trademark issue I had to rename my Chrome extension from LinkShelf to LinkStowr. This PR updates the name and repo in the Community Plugins list to also reflect the name change. I left the id the same so that existing users can still receive updates.
