### PR TITLE
Rebrand Obsidian Icon Folder to Iconize

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2038,10 +2038,10 @@
   },
   {
     "id": "obsidian-icon-folder",
-    "name": "Icon Folder",
+    "name": "Iconize",
     "author": "FlorianWoelki",
-    "description": "Add icons to your folders.",
-    "repo": "FlorianWoelki/obsidian-icon-folder"
+    "description": "Add icons to anything you want in Obsidian.",
+    "repo": "FlorianWoelki/obsidian-iconize"
   },
   {
     "id": "ghost-fade-focus",
@@ -8162,9 +8162,9 @@
     "repo": "red0orange/obsidian-webdav-file-explorer"
   },
   {
-  	"id": "sheets",
-  	"name": "Sheets Extended",
-  	"author": "NicoNekoru",
+    "id": "sheets",
+    "name": "Sheets Extended",
+    "author": "NicoNekoru",
     "description": "Vertical headers, merged cells, and custom css tables with advanced table compatability",
     "repo": "NicoNekoru/obsidan-advanced-table-xt"
   },
@@ -8183,11 +8183,11 @@
     "repo": "x-Ai/obsidian-nifty-links"
   },
   {
-  	"id": "exercises",
-  	"name": "Exercises",
-  	"author": "AlexCCavaco",
-  	"description": "Create Interactive Exercises along side your Obsidian Notes",
-  	"repo": "AlexCCavaco/obsidian-exercises"
+    "id": "exercises",
+    "name": "Exercises",
+    "author": "AlexCCavaco",
+    "description": "Create Interactive Exercises along side your Obsidian Notes",
+    "repo": "AlexCCavaco/obsidian-exercises"
   },
   {
     "id": "math-booster",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2040,7 +2040,7 @@
     "id": "obsidian-icon-folder",
     "name": "Iconize",
     "author": "FlorianWoelki",
-    "description": "Add icons to anything you want in Obsidian.",
+    "description": "Add icons to anything you desire in Obsidian, including files, folders, and text.",
     "repo": "FlorianWoelki/obsidian-iconize"
   },
   {


### PR DESCRIPTION
# Rebrand a plugin

Hopefully, the formatting of the other lines is ok. If not I can undo this.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/FlorianWoelki/obsidian-iconize

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
