### PR TITLE
- Add obsidian-auto-image-remote-uploader plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8230,5 +8230,12 @@
     "author": "HiroMike",
     "description": "A simple time and date display.",
     "repo": "ms3056/Tokei"
-  }
+  },
+  {
+  "id": "obsidian-auto-image-remote-uploader",
+  "name": "Obsidian Auto Image Remote Uploader",
+  "author": "haierspi",
+  "description": "Added Obsidian remote image upload and save function, which can upload note images to your home NAS and synchronize to cloud storage (aliyun oss, aws S3, google ECS)",
+  "repo": "haierspi/obsidian-auto-image-remote-uploader"
+}
 ]


### PR DESCRIPTION
Added Obsidian remote image upload and save function, which can upload note images to your home NAS and synchronize to cloud storage (aliyun oss, aws S3, google ECS)

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
