### PR TITLE
Added obsidian-mochi-flashcards to communify-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8223,5 +8223,12 @@
     "author": "HiroMike",
     "description": "A simple time and date display.",
     "repo": "ms3056/Tokei"
-  }
+  },
+  {
+  "id": "obsidian-mochi-flashcards",
+  "name": "Obsidian + Mochi Flashcards",
+  "author": "Hristiyan Dimitrov",
+  "description": "A plugin that allows you to create yoru flashcards in Obsidian and use them in Mochi. It has the power to change your study workflow forever.",
+  "repo": "hrsdimitrov/obsidian-mochi-flashcards"
+}
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/hrsdimitrov/obsidian-mochi-flashcards

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
