### PR TITLE
Remove Obsidian No Tabs Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6370,13 +6370,6 @@
     "repo": "lukasbach/obsidian-file-order"
   },
   {
-    "id": "no-tabs",
-    "name": "No Tabs",
-    "author": "Tobias Schuster",
-    "description": "Replaces the previous tab when creating a new note.",
-    "repo": "TS-Tobias/obsidian-no-tabs"
-  },
-  {
     "id": "tab-rotator",
     "name": "Tab Rotator",
     "author": "Steven Jin",


### PR DESCRIPTION
# I am removing my community plugin that is no longer maintained.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/TS-Tobias/obsidian-no-tabs