### PR TITLE
Add TreeFocus plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8265,5 +8265,12 @@
     "author": "James Lynch (continued by Erin Schnabel)",
     "description": "Day planning from a simple task list in a Markdown note (bare bones, preserves the features and behavior of the original plugin)",
     "repo": "ebullient/obsidian-day-planner-og"
+  },
+  {
+    "id": "treefocus",
+    "name": "TreeFocus",
+    "author": "iOSonntag",
+    "description": "Highlight, dim & style your files & folders in the file explorer (navigation) based on predefined or custom rules.",
+    "repo": "iOSonntag/obsidian-plugin-treefocus"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

[TreeFocus - GitHub Repository](https://github.com/iOSonntag/obsidian-plugin-treefocus)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
