### PR TITLE
Add plugin: Notes Sync Share

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8400,11 +8400,11 @@
     "repo": "PKM-er/obsidian-zotlit"
   },
   {
-		"id": "text-transform",
-		"name": "Text Transform",
-		"author": "ipshing",
-		"description": "This plugin adds options to transform text to different casings using keyboard shortcuts.",
-		"repo": "ipshing/obsidian-text-transform"
+    "id": "text-transform",
+    "name": "Text Transform",
+    "author": "ipshing",
+    "description": "This plugin adds options to transform text to different casings using keyboard shortcuts.",
+    "repo": "ipshing/obsidian-text-transform"
   },
   {
     "id": "copy-metadata",
@@ -8520,9 +8520,9 @@
   },
   {
     "id": "html-tabs",
-  	"name": "HTML Tabs",
-  	"author": "Patrick Tournet",
-  	"description": "Create and render Tabs and tab panels in your notes.",
+    "name": "HTML Tabs",
+    "author": "Patrick Tournet",
+    "description": "Create and render Tabs and tab panels in your notes.",
     "repo": "ptournet/obsidian-html-tabs"
   },
   {
@@ -8587,5 +8587,12 @@
     "author": "Alan Grainger",
     "description": "Instantly share a note, with the full theme and content exactly like you see in Reading View. Data is shared encrypted by default, and only you and the person you send it to have the key.",
     "repo": "alangrainger/obsidian-share"
+  },
+  {
+    "id": "notes-sync-share",
+    "name": "Notes Sync Share",
+    "author": "Alt-er",
+    "description": "Sync and share (publish) your notes in your own private service.",
+    "repo": "Alt-er/obsidian-sync-share"
   }
 ]


### PR DESCRIPTION
# Request to restore my plug-in, it has been modified as required

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:
https://github.com/Alt-er/obsidian-sync-share

## issues: 
https://github.com/Alt-er/obsidian-sync-share/issues/12#issue-1930458537

## fix
https://github.com/Alt-er/obsidian-sync-share/releases/tag/1.1.4

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [ ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
