### PR TITLE
Add [Sort Frontmatter] plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8629,5 +8629,12 @@
     "author": "@kepano",
     "description": "Open URLs based on a permalink or slug in the note properties. Useful with static site generator such as Jekyll, Hugo, Eleventy, etc.",
     "repo": "kepano/obsidian-permalink-opener"
-  }
+  },
+	{
+		"id": "obsidian-sort-frontmatter",
+		"name": "Sort Frontmatter",
+		"author": "Kanzi",
+		"description": "Sort frontmatter recursively",
+		"repo": "mariomui/obsidian-sort-frontmatter"
+  }	
 ]


### PR DESCRIPTION
Sorts frontmatter alphabetically and recursively

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/mariomui/obsidian-sort-frontmatter

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
