### PR TITLE
Add Plugin: spotify-links

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9042,5 +9042,12 @@
     "author": "pseudometa",
     "description": "Adds a no-op command to disable hotkeys.",
     "repo": "chrisgrieser/obsidian-nothing"
+  },
+  {
+    "id": "spotify-links",
+    "name": "Spotify Links",
+    "author": "Dillon Cutaiar",
+    "description": "Insert a link to the song currently playing on your Spotify",
+    "repo": "cutaiar/obsidian-spotify-links"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

https://github.com/Cutaiar/obsidian-spotify-links

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [x]  ~~Android~~ (desktop only)
  - [x]  ~~iOS~~ (desktop only)
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
- [x] I have given proper attribution to these other projects in my `README.md`.