### PR TITLE
Add hunchly plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9042,5 +9042,12 @@
     "author": "pseudometa",
     "description": "Adds a no-op command to disable hotkeys.",
     "repo": "chrisgrieser/obsidian-nothing"
+  },
+  {
+  	"id": "hunchly",
+  	"name": "Hunchly",
+    "author": "sapperlabs",
+  	"description": "Import notes and images from Hunchly.",
+  	"repo": "shadowoption/Hunchly-obsidian-plugin"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL


Link to my plugin: https://github.com/shadowoption/Hunchly-obsidian-plugin/

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
