### PR TITLE
Update Math Booster plugin's description

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8102,7 +8102,7 @@
     "id": "math-booster",
     "name": "Math Booster",
     "author": "Ryota Ushio",
-    "description": "Turn your Obsidian into LaTeX on steroids. Dynamically numbered theorem environments & equations, theorems/equations live suggestion, showing backlinks to theorems/equations and live-rendering equations inside callouts & quotes.",
+    "description": "Turn your Obsidian into LaTeX on steroids. Dynamically numbered theorem environments & equations, enhanced theorems/equations search & link auto-completion, and live-rendering of equations inside callouts & quotes.",
     "repo": "RyotaUshio/obsidian-math-booster"
   },
   {


### PR DESCRIPTION
This PR is for matching `community-plugins.json` to the updated description in `manifest.json` in my repo.

https://github.com/RyotaUshio/obsidian-math-booster/blob/master/manifest.json