### PR TITLE
Add plugin: Regex Mark

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9147,5 +9147,12 @@
     "author": "Tim Peters",
     "description": "Allows the user to edit and create .mdx files.",
     "repo": "timppeters/obsidian-edit-mdx"
+  },
+  {
+    "id": "regex-mark",
+    "name": "Regex Mark",
+    "author": "RieN7",
+    "description": "Add custom CSS classes to text based on regular expressions.",
+    "repo": "rien7/obsidian-regex-mark"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/rien7/obsidian-regex-mark

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
