### PR TITLE
Add Image Convert Contextmenu plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9182,5 +9182,12 @@
     "author": "Jose Elias Alvarez",
     "description": "Intelligently paste Markdown links.",
     "repo": "jose-elias-alvarez/obsidian-paste-link"
-  }
+  },
+  {
+    "id": "obsidian-image-convert-contextmenu",
+    "name": "Image Convert Contextmenu",
+    "author": "Chongmyung Park",
+    "description": "Contextmenu to change image format in reading view",
+    "repo": "byfun/obsidian-image-convert-contextmenu"
+  }  
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL
Link to my plugin: https://github.com/byfun/obsidian-image-convert-contextmenu

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
