### PR TITLE
Add HelpMate plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9189,5 +9189,5 @@
     "description": "Integrating Help Systems into the Obsidian UI.",
     "author": "TfTHacker",
     "repo": "TfTHacker/obsidian42-HelpMate"
-  },
+  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9182,5 +9182,12 @@
     "author": "Jose Elias Alvarez",
     "description": "Intelligently paste Markdown links.",
     "repo": "jose-elias-alvarez/obsidian-paste-link"
-  }
+  },
+  {
+    "id": "obsidian42-helpmate",
+    "name": "Obsidian42 - HelpMate",
+    "description": "Integrating Help Systems into the Obsidian UI.",
+    "author": "TfTHacker",
+    "repo": "TfTHacker/obsidian42-HelpMate"
+  },
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/TfTHacker/obsidian42-HelpMate

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
