### PR TITLE
Add plugin: Map GPX

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9309,5 +9309,12 @@
     "author": "Git-Sum",
     "description": "Get your TickTicks!",
     "repo": "Git-Sum/obsidian-tckr"
+  },
+  {
+    "id": "map-gpx",
+    "name": "Map Gpx", 
+    "author": "Denis Doroshenko",
+    "description": "Plugin for visualizing gpx tracks ",
+    "repo": "dordenis/obsidian-map-gpx-plugin"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/dordenis/obsidian-map-gpx-plugin

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x]  `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
