### PR TITLE
Change name & repo of submitted plugin Remotely Secure to Remotely Sync

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8918,11 +8918,11 @@
         "repo": "jaschaephraim/obsidian-title-generator"
     },
     {
-        "id": "remotely-secure",
-        "name": "Remotely Secure",
+        "id": "remotely-sync",
+        "name": "Remotely Sync",
         "author": "sboesen",
         "description": "Security fixes for the remotely-save unofficial plugin allowing users to synchronize notes between local device and the cloud service. Not backwards compatible.",
-        "repo": "sboesen/remotely-secure"
+        "repo": "sboesen/remotely-sync"
     },
     {
         "id": "inline-encrypter",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8918,7 +8918,7 @@
         "repo": "jaschaephraim/obsidian-title-generator"
     },
     {
-        "id": "remotely-sync",
+        "id": "remotely-secure",
         "name": "Remotely Sync",
         "author": "sboesen",
         "description": "Security fixes for the remotely-save unofficial plugin allowing users to synchronize notes between local device and the cloud service. Not backwards compatible.",


### PR DESCRIPTION
Hello, my fork of the "Remotely Save" plugin was previously called Remotely Secure and merged in this pull request: https://github.com/obsidianmd/obsidian-releases/pull/2523

After [discussion](https://github.com/sboesen/remotely-sync/issues/32) the name "Remotely Sync" better describes its behavior. Specifically: the name "Remotely Secure" doesn't make it obvious what the plugin does, and as I've learned many of our users don't even use encryption which is where the security updates were. Please let me know if I can share any additional details, thank you!