### PR TITLE
Remove invariant/obsidian-archivebox-plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5369,13 +5369,6 @@
         "repo": "slpbx/obsidian-plugin"
     },
     {
-        "id": "obsidian-archivebox-plugin",
-        "name": "ArchiveBox",
-        "description": "ArchiveBox.io support for external Obsidian links.",
-        "author": "invariant",
-        "repo": "invariant/obsidian-archivebox-plugin"
-    },
-    {
         "id": "quote-share",
         "name": "Quote Share",
         "author": "DuocNV",


### PR DESCRIPTION
I'm removing this plugin from the repository as I don't plan on maintaining it any longer and I'm deprecating this username, because I am constantly tagged in various Doc formats as an invariant which makes it too noisy to keep this account. The plugin has been archived.
