### PR TITLE
Update community-plugins.json to include "open as md" plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9399,5 +9399,12 @@
       "author": "mmmykhailo",
       "description": "View calendar events in daily notes.",
       "repo": "mmmykhailo/obsidian-daily-icalendar"
+    },
+     {
+      "id": "open-as-md",
+      "name": "open-as-md",
+      "author": "kursad-k",
+      "description": "Edit non-md file types as markdown files.",
+      "repo": "kursad-k/obsidian-openasmd"
     }
 ]


### PR DESCRIPTION
This plugin lets you edit non-markdown files like .txt, .json etc using the Obsidian's internal editor.

# I am submitting a new Community Plugin
I made this plugin to be able to edit files that are not markdown. The user is able to set the file type in the plugin settings.

## Repo URL
https://github.com/kursad-k/obsidian-openasmd

<!--- Paste a link to your repo here for easy access -->
[Link to my plugin:](https://github.com/kursad-k/obsidian-openasmd)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
