### PR TITLE
Rename Math Booster plugin to LaTeX-like Theorem & Equation Referencer

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8079,10 +8079,10 @@
     },
     {
         "id": "math-booster",
-        "name": "Math Booster",
+        "name": "LaTeX-like Theorem & Equation Referencer",
         "author": "Ryota Ushio",
-        "description": "Turn your Obsidian into LaTeX on steroids. Dynamically numbered theorem environments & equations, enhanced theorems/equations search & link auto-completion, and live-rendering of equations inside callouts & quotes.",
-        "repo": "RyotaUshio/obsidian-math-booster"
+        "description": "A powerful indexing & referencing system for theorems & equations in your vault. Bring LaTeX-like workflow into Obsidian with theorem environments, automatic equation numbering, and more.",
+        "repo": "RyotaUshio/obsidian-latex-theorem-equation-referencer"
     },
     {
         "id": "file-explorer-plus",


### PR DESCRIPTION
I want to rename [my plugin called "Math Booster"](https://github.com/RyotaUshio/obsidian-latex-theorem-equation-referencer) to "LaTeX-like Theorem & Equation Referencer" for better clarity and discoverability.

Backgrounds can be found here: https://github.com/RyotaUshio/obsidian-latex-theorem-equation-referencer/issues/210

Note that the [latest release](https://github.com/RyotaUshio/obsidian-latex-theorem-equation-referencer/releases/tag/2.2.0) already uses the [new manifest](https://github.com/RyotaUshio/obsidian-latex-theorem-equation-referencer/blob/a28ef21c5df044d5e9c31f274ba76102a88d3749/manifest.json).