### PR TITLE
Update community-plugins.json with UseSemaLogic

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9406,5 +9406,12 @@
         "author": "Ryota Ushio",
         "description": "Automatically make all inline maths \\displaystyle.",
         "repo": "RyotaUshio/obsidian-auto-displaystyle-inline-math"
+    },
+    {
+        "id": "UseSemaLogic",
+        "name": "SemaLogic Obsidian Plugin",
+        "author": "SemaLogic UG",
+        "description": "Real-time use of the SemaLogic formal language",
+        "repo": "MM-GO/UseSemaLogicInObsidian"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

Link to my plugin: [https://github.com/MM-GO/UseSemaLogicInObsidian](https://github.com/MM-GO/UseSemaLogicInObsidian)

## Release Checklist

- [x]  I have tested the plugin on
    - [x]  Windows
    - [ ]  macOS
    - [x]  Linux
    - [x]  Android _(if applicable)_
    - [ ]  iOS _(if applicable)_

- [x]  My GitHub release contains all required files
    - [x]  `main.js`
    - [x]  `manifest.json`
    - [ ]  `styles.css` _(optional)_

- [x]  GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)

- [x]  The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.

- [x]  My README.md describes the plugin's purpose and provides clear usage instructions.

- [x]  I have read the developer policies at [https://docs.obsidian.md/Developer+policies](https://docs.obsidian.md/Developer+policies), and have assessed my plugins's adherence to these policies.

- [x]  I have read the tips in [https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines) and have self-reviewed my plugin to avoid these common pitfalls.

- [x]  I have added a license in the LICENSE file.

 My project respects and is compatible with the original license of any code from other plugins that I'm using.  
I have given proper attribution to these other projects in my `README.md`.