### PR TITLE
Add plugin: Unused Notes Tracker

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9427,5 +9427,12 @@
     "author": "David Landry",
     "description": "A desk to see notes at a glance in Obsidian. Requires Dataview as a dependency.",
     "repo": "davidlandry93/obsidian-desk"
+  },
+    {
+    "id": "UnusedNotesTracker",
+    "name": "Unused Notes Tracker",
+    "author": "Nazar Novak",
+    "description": "Tracks unused notes more easily that you opened longer time ago.",
+    "repo": "nazarnovak/obsidian-unused-notes-plugin"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9429,7 +9429,7 @@
     "repo": "davidlandry93/obsidian-desk"
   },
     {
-    "id": "UnusedNotesTracker",
+    "id": "unused-notes-tracker",
     "name": "Unused Notes Tracker",
     "author": "Nazar Novak",
     "description": "Tracks unused notes more easily that you opened longer time ago.",


### PR DESCRIPTION
# I am submitting a new Community Plugin
## Repo URL 
Link to my plugin: https://github.com/nazarnovak/obsidian-unused-notes-plugin
## Release Checklist
- [ ] I have tested the plugin on
    - [x] Windows
    - [x] macOS
    - [ ] Linux
    - [ ] Android (if applicable)
    - [x] iOS (if applicable)
- [ ] My GitHub release contains all required files
    - [x] main.js
    - [x] manifest.json
    - [x] styles.css (optional)
- [x] GitHub release name matches the exact version number specified in my manifest.json (Note: Use the exact version number, don't include a prefix v)
- [x] The id in my manifest.json matches the id in the community-plugins.json file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
- [ ] I have given proper attribution to these other projects in my README.md.