### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9546,5 +9546,12 @@
     "author": "hideakitai",
     "description": "Obsidian plugin to switch Input Method when `InsertLeave` and `InsertEnter`. Supports macOS, Windows, and Linux.",
     "repo": "hideakitai/obsidian-vim-im-control"
+  },
+  {
+    "id": "obsidian-cubox-import",
+    "name": "Cubox Import",
+    "author": "HUANG Xiaojun",
+    "description": "Synchronize the archived collections in Cubox to Obsidian, allowing synchronization of the content on the first page at a time.",
+    "repo": "hxj8059/obsidian-cubox-import"
   }
 ]


### PR DESCRIPTION
Obsidian-Cubox-Import is an Obsidian plugin designed to enhance your note-taking experience. This plugin allows you to seamlessly download and extract data from Cubox and integrate it into your Obsidian vault.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [X]   macOS
  - [X]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X]  My GitHub release contains all required files
  - [X]  `main.js`
  - [X]  `manifest.json`
  - [X]  `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
