### PR TITLE
Fix typo in the description of Quick Preview plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9418,7 +9418,7 @@
     "id": "quick-preview",
     "name": "Quick Preview",
     "author": "Ryota Ushio",
-    "description": "Quickly preview a suggestion before selecting it in link suggestions & quick swicher.",
+    "description": "Quickly preview a suggestion before selecting it in link suggestions & quick switcher.",
     "repo": "RyotaUshio/obsidian-quick-preview"
   },
   {


### PR DESCRIPTION
I found a typo in the description of my plugin [Quick Preview](https://github.com/RyotaUshio/obsidian-quick-preview), both in `manifest.json` and `community-plugins.json`.

I've already fixed `manifest.json` in my repository. https://github.com/RyotaUshio/obsidian-quick-preview/blob/main/manifest.json

Thank you!