### PR TITLE
Add plugin: Wechat Public Platform

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12234,5 +12234,12 @@
         "author": "triski",
         "description": "Page Up|Down|Top|Bottom",
         "repo": "chenshutian9610/obsidian-pagescroll-plugin"
+    },
+    {
+        "id": "wechat-public-platform",
+        "name": "Wechat Public Platform",
+        "description": "Release the article from your vault to WeChat, Baidu Baijiahao, or another article release platform.",
+        "author": "Blake Chan",
+        "repo": "ai-chen2050/obsidian-wechat-public-platform"
     }
 ]


### PR DESCRIPTION
new plugin

# I am submitting a new Community Plugin
Obsidian Wechat public Plugin  is a plugin to release article from your Obsidian Vault.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:  https://github.com/ai-chen2050/obsidian-wechat-public-platform

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
