### PR TITLE
Add plugin: Title Case Note Title

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9595,7 +9595,7 @@
     "author": "Pavel Frankov",
     "description": "Local GPT assistance for maximum privacy and offline access",
     "repo": "pfrankov/obsidian-local-gpt"
-  }
+  },
   {
     "id": "title-case-note-title",
     "name": "Title Case Note Title",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9596,4 +9596,11 @@
     "description": "Local GPT assistance for maximum privacy and offline access",
     "repo": "pfrankov/obsidian-local-gpt"
   }
+  {
+    "id": "title-case-note-title",
+    "name": "Title Case Note Title",
+    "author": "Chase Tramel",
+    "description": "Automatically renames note titles to MLA title case",
+    "repo": "ChaseTramel/obsidian-title-case-note-title"
+  }
 ]


### PR DESCRIPTION
When you rename a note in Obsidian with this plugin loaded, the new name is automatically converted to a close approximation of title case as defined by the MLA Handbook, 9th ed. This automatic title case works upon renaming, so this won't affect your old notes unless you manually rename them.

# I am submitting a new Community Plugin

## Repo URL
[Link to my plugin](https://github.com/ChaseTramel/obsidian-title-case-note-title)

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
