### PR TITLE
Add plugin: Log Marker

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9672,5 +9672,12 @@
     "author": "Adi Ron",
     "description": "Copies the contents of files or selections within to the clipboard, without internal links",
     "repo": "adiron/obsidian-strip-internal-links"
+  },
+  {
+    "id": "log-marker",
+    "name": "Log Marker",
+    "author": "Whitman Schorn",
+    "description": "Adds a button to create a note and entry for the current date and time.",
+    "repo": "whitmanschorn/log-marker"
   }
 ]


### PR DESCRIPTION
This plugin enables my particular workflow with Obsidian.  It adds a button (and command) to create a note and entry for the current date and time. It also pulls focus to the relevant note, for times when I have too many tabs open. 

# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/whitmanschorn/log-marker

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_ (not used)
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
