### PR TITLE
Add plugin: Folder Note Title Fixer

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9679,5 +9679,12 @@
     "author": "Mateus Molina",
     "description": "Add relevant git information of detected git repostitories to the file explorer",
     "repo": "MateusMolina/obsidian-git-file-explorer"
+  },
+  {
+    "id": "folder-note-title-fixer",
+    "name": "Folder Note Title Fixer",
+    "author": "Fynn Freyer",
+    "description": "Makes the tab title display the folder name when using AidenLx's Folder Note with index notes.",
+    "repo": "FynnFreyer/obsidian-folder-note-title-fixer"
   }
 ]


### PR DESCRIPTION
Makes the tab title display the folder name when using [AidenLx's Folder Note](https://github.com/aidenlx/alx-folder-note) with index notes.