### PR TITLE
Add popmonth plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9679,5 +9679,12 @@
     "author": "Mateus Molina",
     "description": "Add relevant git information of detected git repostitories to the file explorer",
     "repo": "MateusMolina/obsidian-git-file-explorer"
+  },
+   {
+    "id": "popmonth",
+    "name": "Populate Month",
+    "author": "Tom Flanders",
+    "description": "Populates a month of calendar files with checkboxed tasks",
+    "repo": "tomflanders/popmonth"
   }
 ]


### PR DESCRIPTION
Added popmonth plugin

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [ ] `main.js`
  - [ ] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ ] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [ ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
