### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9672,5 +9672,12 @@
     "author": "Mateus Molina",
     "description": "Add relevant git information of detected git repostitories to the file explorer",
     "repo": "MateusMolina/obsidian-git-file-explorer"
+  },
+  {
+    "id": "obsidian-full-screen-cross-platform-plugin",
+    "name": "Full Screen Toggle",
+    "author": "Donkey Pacific",
+    "description": "Fullscreen toggle plugin across all platforms.",
+    "repo": "DonkeyPacific/obsidian-full-screen-cross-platform-plugin"
   }
 ]


### PR DESCRIPTION
add a Full Screen Toggle plugin for Obsidian.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/DonkeyPacific/obsidian-full-screen-cross-platform-plugin/tree/1.0.0

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
