### PR TITLE
Rename author and update repo for OfficerHalf plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1319,8 +1319,8 @@
         "id": "obsidian-collapse-all-plugin",
         "name": "Collapse All",
         "description": "Extend collapse/expand all with commands that can be bound to hotkeys.",
-        "author": "OfficerHalf",
-        "repo": "OfficerHalf/obsidian-collapse-all"
+        "author": "Nathonius",
+        "repo": "nathonius/obsidian-collapse-all"
     },
     {
         "id": "obsidian-chartsview-plugin",
@@ -1921,8 +1921,8 @@
         "id": "obsidian-trello",
         "name": "Trello",
         "description": "Connect Trello cards to Obsidian notes.",
-        "author": "OfficerHalf",
-        "repo": "OfficerHalf/obsidian-trello"
+        "author": "Nathonius",
+        "repo": "nathonius/obsidian-trello"
     },
     {
         "id": "obsidian-annotator",
@@ -2495,8 +2495,8 @@
         "id": "auto-class",
         "name": "Auto Class",
         "description": "Automatically apply CSS classes to Markdown views based on a note's path.",
-        "author": "OfficerHalf",
-        "repo": "OfficerHalf/obsidian-auto-class"
+        "author": "Nathonius",
+        "repo": "nathonius/obsidian-auto-class"
     },
     {
         "id": "obsidian-cloudinary-uploader",


### PR DESCRIPTION
I've renamed my github account and updated all my plugin readmes and manifests accordingly. Now doing the same for my previously released plugins here.