### PR TITLE
Accommodate abrupt policy/compliance changes for Obsidian_to_Anki plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -381,7 +381,7 @@
         "id": "obsidian-to-anki-plugin",
         "name": "Export to Anki",
         "author": "Pseudonium",
-        "description": "This is an Anki integration plugin! Designed for efficient bulk exporting.",
+        "description": "Previously known as Obsidian_to_Anki plugin. This is an Anki integration plugin! Designed for efficient bulk exporting.",
         "repo": "Pseudonium/Obsidian_to_Anki"
     },
     {


### PR DESCRIPTION
Update description to have previous plugin name so that its still searchable via Community Plugins -> Browse. 

Btw, I am a maintaner of the plugin Obsidian_to_Anki. Related to https://github.com/Pseudonium/Obsidian_to_Anki/issues/509.
