### PR TITLE
Add light theme option

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1684,7 +1684,7 @@
     "author": "Dominik Meurer",
     "repo": "DMeurer/improved-potato",
     "screenshot": "images/image2.png",
-    "modes": ["dark"]
+    "modes": ["dark", "light"]
   },
   {
     "name": "Neovim",


### PR DESCRIPTION
# Updating my theme.

Adding the light theme that was implemented.




# I am submitting a new Community Theme

## Repo URL

<!--- Paste a link to your repo here for easy access -->
[Link to my theme](https://github.com/DMeurer/improved-potato)


## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [X] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [X] `manifest.json`
  - [X] `theme.css`
  - [X] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
- [X] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my theme's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Themes/App+themes/Theme+guidelines and have self-reviewed my theme to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.
