### PR TITLE
Add Obsidian Autocorrect plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7,6 +7,13 @@
         "repo": "argenos/nldates-obsidian"
     },
     {
+	  "id": "obsidian-autocorrect",
+	  "name": "Obsidian Autocorrect",
+	  "author": "William Keating",
+	  "description": "Autocorrects spelling mistakes in Obsidian using a large language model.",
+	  "repo": "WilliamKeating/obsidian-autocorrect"
+    },
+    {
         "id": "hotkeysplus-obsidian",
         "name": "Hotkeys++",
         "author": "Argentina Ortega Sainz",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7,13 +7,6 @@
         "repo": "argenos/nldates-obsidian"
     },
     {
-	  "id": "obsidian-autocorrect",
-	  "name": "Obsidian Autocorrect",
-	  "author": "William Keating",
-	  "description": "Autocorrects spelling mistakes in Obsidian using a large language model.",
-	  "repo": "WilliamKeating/obsidian-autocorrect"
-    },
-    {
         "id": "hotkeysplus-obsidian",
         "name": "Hotkeys++",
         "author": "Argentina Ortega Sainz",
@@ -10099,5 +10092,12 @@
     "author": "Kacper Darowski",
     "description": "Rearrange and hide status bar elements.",
     "repo": "Opisek/obsidian-statusbar-organizer"
+  },
+  {
+	  "id": "obsidian-autocorrect",
+	  "name": "Obsidian Autocorrect",
+	  "author": "William Keating",
+	  "description": "Autocorrects spelling mistakes in Obsidian using a large language model.",
+	  "repo": "WilliamKeating/obsidian-autocorrect"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/WilliamKeating/obsidian-autocorrect/tree/v1.0.0

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
