### PR TITLE
remove mention of copy URL functionality, rename plugin and reword description

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1548,9 +1548,9 @@
     },
     {
         "id": "copy-url-in-preview",
-        "name": "Copy Image and URL context menu",
+        "name": "Image Context Menus",
         "author": "NomarCub",
-        "description": "Copy Image, Copy URL and Open PDF externally context menu in reading view.",
+        "description": "Copy, open in default app, show in system explorer, reveal in navigation context menu for images. Also Open PDF externally context menu.",
         "repo": "NomarCub/obsidian-copy-url-in-preview"
     },
     {


### PR DESCRIPTION
see: https://github.com/NomarCub/obsidian-copy-url-in-preview/releases/tag/1.6.0

The PR template didn't work for me, point me to what I need to do, if anyting.