### PR TITLE
Add plugin: AutoGraphed

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -10239,5 +10239,12 @@
     "author": "Timofey Koolin",
     "description": "Modify text from the clipboard by regexp rules",
     "repo": "rekby/obsidian-paste-transform"
+  },
+  {
+    "id": "auto-graphed",
+    "name": "AutoGraphed",
+    "author": "Vadini Agrawal",
+    "description": "Automatically generate tags between your notes",
+    "repo": "vadini-agrawal/auto-graphed"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

Proposing adding AutoGraphed to the Obsidian community plugins. This plugin allows you to auto-generate connections between your notes.

## Repo URL

Link to my plugin: https://github.com/vadini-agrawal/auto-graphed

## Release Checklist
- [X] I have tested the plugin on
  - [ ]  Windows
  - [X]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
