### PR TITLE
Add plugin: Vivaldi Notes Importer

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -10243,7 +10243,7 @@
   {
     "id":"vivaldi-importer",
     "name":"Vivaldi Notes Importer",
-    "description":"Import notes from Vivaldi browser.",
+    "description":"Import notes from Vivaldi Browser.",
     "author":"Arturo2r",
     "repo":"Arturo2r/obsidian-vivaldi-notes"
   }

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -10243,7 +10243,7 @@
   {
     "id":"vivaldi-importer",
     "name":"Vivaldi Notes Importer",
-    "description":"Import notes from Vivaldi Browser.",
+    "description":"Import notes from Vivaldi browser.",
     "author":"Arturo2r",
     "repo":"Arturo2r/obsidian-vivaldi-notes"
   }

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -10239,5 +10239,12 @@
     "author": "Timofey Koolin",
     "description": "Modify text from the clipboard by regexp rules",
     "repo": "rekby/obsidian-paste-transform"
+  },
+  {
+    "id":"obsidian-vivaldi-notes",
+    "name":"Vivaldi Notes Importer",
+    "description":"Import notes from Vivaldi browser.",
+    "author":"Arturo2r",
+    "repo":"Arturo2r/obsidian-vivaldi-notes"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -10241,7 +10241,7 @@
     "repo": "rekby/obsidian-paste-transform"
   },
   {
-    "id":"obsidian-vivaldi-notes",
+    "id":"vivaldi-importer",
     "name":"Vivaldi Notes Importer",
     "description":"Import notes from Vivaldi browser.",
     "author":"Arturo2r",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Arturo2r/obsidian-vivaldi-notes

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
