### PR TITLE
Add theme: mono black (monochrome, charcoal)

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1699,5 +1699,12 @@
     "repo": "isax785/obsidian-sparkling-day",
     "screenshot": "img/sparkling_day_small.png",
     "modes": ["light"]
+  },
+  {
+    "name": "mono black (monochrome, charcoal)",
+    "author": "ZeChArtiahSaher",
+    "repo": "ZeChArtiahSaher/obsidian-mono-black",
+    "screenshot": "img/screen-1.png",
+    "modes": ["dark"]
   }
 ]


### PR DESCRIPTION
finally a fully black monochrome theme

## Repo URL

https://github.com/ZeChArtiahSaher/obsidian-mono-black

## Theme checklist

- [x] My repo contains all required files (please do not add them to this obsidian-releases repo).

    - [x] manifest.json
    - [x] theme.css
    - [x] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).

- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my theme's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Themes/App+themes/Theme+guidelines and have self-reviewed my theme to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my README.md.