### PR TITLE
Update description for Waypoint plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3286,7 +3286,7 @@
         "id": "waypoint",
         "name": "Waypoint",
         "author": "Idrees Hassan",
-        "description": "Easily generate dynamic MOCs in your folder notes. Enables folders to show up in the graph view and removes the need for messy tags!",
+        "description": "Easily generate dynamic MOCs in your folder notes using waypoints. Enables folders to show up in the graph view and removes the need for messy tags!",
         "repo": "IdreesInc/Waypoint"
     },
     {


### PR DESCRIPTION
Updated the plugin description to include the term "waypoints" after discovering that many people have searched for the plural of waypoint in the plugin explorer and not found it listed. Note that waypoints refers to the maps of content that you can use to link files in a folder together.