### PR TITLE
Update plugin description

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -10560,7 +10560,7 @@
     "id": "yesterday",
     "name": "Yesterday",
     "author": "Dominik Mayer",
-    "description": "Transforms Obsidian into a visually stunning diary.",
+    "description": "Transform your notes into a visually stunning diary, integrating dialogs, chat logs, and media content blocks for a seamless journaling experience.",
     "repo": "dominikmayer/obsidian-yesterday"
   },
   {


### PR DESCRIPTION
This plugin was merged as part of #3149.

Unfortunately I was not aware of the fact, that the plugin description was hard-coded in `community-plugins.json` and is not updated from the plugin's `manifest.json`.

The merged description does not incorporate the review comments. I have updated it now.

Sorry for the extra work.