### PR TITLE
Change repo url for Mindmap Nextgen plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5002,7 +5002,7 @@
         "name": "Mindmap Nextgen",
         "author": "VeroCloud Pty Ltd (original by James Lynch)",
         "description": "Preview notes as Markmap mind maps.",
-        "repo": "verocloud/obsidian-mindmap-nextgen"
+        "repo": "james-tindal/obsidian-mindmap-nextgen"
     },
     {
         "id": "obsidian-link-opener",


### PR DESCRIPTION
The repo at [verocloud/obsidian-mindmap-nextgen](https://github.com/verocloud/obsidian-mindmap-nextgen) has moved to `james-tindal/obsidian-mindmap-nextgen`