### PR TITLE
Rename Plugin: "Spotify Links" -> "Song Links"

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9178,10 +9178,10 @@
     },
     {
         "id": "spotify-links",
-        "name": "Spotify Links",
+        "name": "Song Links",
         "author": "Dillon Cutaiar",
         "description": "Insert a link to the song currently playing on your Spotify.",
-        "repo": "cutaiar/obsidian-spotify-links"
+        "repo": "cutaiar/obsidian-song-links"
     },
     {
         "id": "hunchly",


### PR DESCRIPTION
# I am submitting a name change to my Community Plugin

https://github.com/Cutaiar/obsidian-song-links

I recently had to change the name of "Spotify Links" to "Song Links" to make my plugin comply with the Spotify Brand Guidelines. I've kept the id the same as not to break any connections, but the display name mustn't mention "Spotify".

