### PR TITLE
Rename periodic para plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7358,9 +7358,9 @@
     },
     {
         "id": "periodic-para",
-        "name": "Periodic PARA",
+        "name": "LifeOS",
         "author": "YiBing Lin",
-        "description": "Assist in practicing the PARA method with periodic notes and usememos.",
+        "description": "Life management system based on Obsidian.",
         "repo": "quanru/obsidian-periodic-para"
     },
     {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7360,7 +7360,7 @@
         "id": "periodic-para",
         "name": "LifeOS",
         "author": "YiBing Lin",
-        "description": "Life management system based on Obsidian.",
+        "description": "Life management system.",
         "repo": "quanru/obsidian-periodic-para"
     },
     {


### PR DESCRIPTION
1. The current plugin name can no longer cover existing functions.
2. Prepare for adding more features later.
3. Fits with the existing official website: https://obsidian-life-os.netlify.app/
