### PR TITLE
Update community-plugins.json with new name for "jTab" plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3466,7 +3466,7 @@
     },
     {
         "id": "obsidian-jtab",
-        "name": "jTab",
+        "name": "jTab Guitar Codeblocks",
         "author": "davfive",
         "description": "Add guitar chords and tabs to your notes with jTab code blocks.",
         "repo": "davfive/obsidian-jtab"


### PR DESCRIPTION
Per the Obsidian team's request, I am submitting a new name for my plugin. I have published a new version of my plugin with the name changed everywhere along with some bug fixes.

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
