### PR TITLE
Add plugin: External Links

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -10913,19 +10913,6 @@
     "repo": "TarsLab/obsidian-ai-zhipu"
   },
   {
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-    "id": "external-links",
-    "name": "External Links",
-    "author": "Juan Vimberg",
-    "description": "List external links on the right side panel.",
-    "repo": "jivimberg/external-links"
-  },
-  {
->>>>>>> e50db9e (Fixing missing curly brace)
-=======
->>>>>>> bb73b82 (Moving new plugin to the end)
     "id": "new-tab-plus",
     "name": "New Tab +",
     "author": "Raphaël Le Carval",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -10913,6 +10913,16 @@
     "repo": "TarsLab/obsidian-ai-zhipu"
   },
   {
+<<<<<<< HEAD
+=======
+    "id": "external-links",
+    "name": "External Links",
+    "author": "Juan Vimberg",
+    "description": "List external links on the right side panel.",
+    "repo": "jivimberg/external-links"
+  },
+  {
+>>>>>>> e50db9e (Fixing missing curly brace)
     "id": "new-tab-plus",
     "name": "New Tab +",
     "author": "Raphaël Le Carval",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11135,5 +11135,12 @@
     "author": "Zhou Hua",
     "description": "Integrate vConsole for developers to facilitate the debugging of mobile plugins.",
     "repo": "zhouhua/obsidian-vconsole"
+  },
+  {
+    "id": "external-links",
+    "name": "External Links",
+    "author": "Juan Vimberg",
+    "description": "List external links on the right side panel.",
+    "repo": "jivimberg/external-links"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -10914,6 +10914,7 @@
   },
   {
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
     "id": "external-links",
     "name": "External Links",
@@ -10923,6 +10924,8 @@
   },
   {
 >>>>>>> e50db9e (Fixing missing curly brace)
+=======
+>>>>>>> bb73b82 (Moving new plugin to the end)
     "id": "new-tab-plus",
     "name": "New Tab +",
     "author": "Raphaël Le Carval",


### PR DESCRIPTION
Adding External Links plugin

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/jivimberg/external-links

## Release Checklist
- [X] I have tested the plugin on
  - [ ]  Windows
  - [X]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
