### PR TITLE
Add plugin: Sync config folder to common folder

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11247,5 +11247,12 @@
     "author": "Dale de Silva",
     "description": "Hand write or draw with a stylus directly between paragraphs in your notes.",
     "repo": "daledesilva/obsidian_ink"
+  },
+  {
+    "id": "sync-config-folder-to-common-folder",
+    "name": "Sync config folder to common folder",
+    "author": "codeonquer",
+    "description": "Sync contents from config folder to common folder for backup or other purposes.",
+    "repo": "codeonquer/obsidian-sync-config-folder-to-common-folder"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/codeonquer/obsidian-sync-config-folder-to-common-folder

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.