### PR TITLE
archive "Smarter Markdown Hotkeys"

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2737,13 +2737,6 @@
         "repo": "lanice/obsidian-rant"
     },
     {
-        "id": "obsidian-smarter-md-hotkeys",
-        "name": "Smarter Markdown Hotkeys",
-        "description": "Hotkeys that select words and lines in a smart way before applying markup. Multiple cursors are supported as well.",
-        "author": "pseudometa",
-        "repo": "chrisgrieser/obsidian-smarter-md-hotkeys"
-    },
-    {
         "id": "obsidian-global-hotkeys",
         "name": "Global Hotkeys",
         "description": "Configurable system-wide hotkeys for running commands.",


### PR DESCRIPTION
Most of the plugin's features have been implemented by Obsidian core by now. The few features that are not part of core are available by via other plugins.

A deprecation notice has been there at the plugin's readme for a few months now.

Will archive the repo when this PR is merged.