### PR TITLE
Add plugin: Letterboxd Diary RSS Sync

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11296,5 +11296,12 @@
         "description": "Convert a complete Canvas to a long form document, integrating all cards, notes, images and other media content into a single markdown file.",
         "author": "slnsys",
         "repo": "slnsys/obsidian-canvas2document"
+    },
+    {
+        "id": "letterboxd-rss-sync",
+        "name": "Letterboxd Diary RSS Sync",
+        "author": "Nick Felker",
+        "description": "Syncs your public Letterboxd diary.",
+        "repo": "fleker/letterboxd-for-obsidian"
     }
 ]


### PR DESCRIPTION
I've created my first Obsidian plugin which works in a development vault and I'd like to submit it to the directory.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Fleker/letterboxd-for-obsidian

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [~] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
