### PR TITLE
Add plugin: Random names

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11366,5 +11366,12 @@
         "author": "KraXen72 and Chetachi Ezikeuzor",
         "description": "Paint text different colors.",
         "repo": "KraXen72/obsidian-painter"
+    },
+    {
+        "id": "random-names",
+        "name": "Random names",
+        "author": "Tom Parker-Shemilt",
+        "description": "Generates random names.",
+        "repo": "palfrey/obsidian-random-names"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/palfrey/obsidian-random-names

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
