### PR TITLE
Upgrade stale action to fix running out of operations

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v9
         with:
           stale-pr-message: "Hi there, as this PR has not seen any activity in the last 30 days, it will be closed in 15 days unless there are any updates."
           close-pr-message: "Hi there, to keep things tidy, we're closing PRs after one and a half months of inactivity.\nFeel free to create a new pull request when you're ready to continue. Thanks for your understanding!"


### PR DESCRIPTION
Not a plugin or theme PR. This upgrades the `stale` action to v9, because the action is [running out of operations](https://github.com/obsidianmd/obsidian-releases/actions/runs/8579626949/job/23514812480) and [v9 explicitly fixes this](https://github.com/actions/stale/releases/tag/v9.0.0)