### PR TITLE
chore(plugininfo-update): update name, desc and link of plugin UNITADE

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7610,10 +7610,10 @@
   },
   {
     "id": "unitade",
-    "name": "Unitade",
+    "name": "UNITADE.md",
     "author": "Falcion",
-    "description": "Effortlessly treat any file extension as note, organize diverse file formats in your vault.",
-    "repo": "Falcion/UnitadeOBSIDIAN"
+    "description": "Effortlessly treat any file extension as note, organize diverse file formats in your vault and take advancements in control of extension system even with custom modals.",
+    "repo": "Falcion/UNITADE.md"
   },
   {
     "id": "python-scripter",


### PR DESCRIPTION
# I am submitting a new Community Plugin

I'm creating a PR to update UNITADE's manifest information (if it's possible).

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Falcion/UNITADE.md

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
