### PR TITLE
Add Yesterdays Tasks Cleanup plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11275,5 +11275,12 @@
         "author": "YunXiaoYi",
         "description": "Create notes with Mindmaps.",
         "repo": "OneCalmCloud/obsidian-mindmap"
-    }
+    },
+    {
+        "id": "yesterdays-tasks-cleanup",
+        "name": "Yesterdays Tasks Cleanup",
+        "author": "Christopher G. Roge",
+        "description": "Allows the user to easily convert tasks to simple bullet points because the task was rolled to the next daily note or is otherwise orphaned.",
+        "repo": "chrisroge/obsidian-yesterdays-tasks"
+}
 ]


### PR DESCRIPTION
Allows the user to easily convert tasks to simple bullet points because the task was rolled to the next daily note or is otherwise orphaned.
