### PR TITLE
Add plugin: Generate Hash

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11401,5 +11401,12 @@
         "author": "SystemSculpt.com",
         "description": "Enhance your data flow with AI-powered tools for note-taking, task management, templates, and so much more.",
         "repo": "systemsculpt/obsidian-systemsculpt-ai"
+    },
+    {
+        "id": "generate-hash",
+        "name": "Generate Hash",
+        "author": "zigahertz",
+        "description": "Generates a cryptographically strong pseudorandom hash.",
+        "repo": "zigahertz/obsidian-hash"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11408,5 +11408,12 @@
         "author": "zigahertz",
         "description": "Generates a cryptographically strong pseudorandom hash.",
         "repo": "zigahertz/obsidian-hash"
+    },
+    {
+        "id": "generate-hash",
+        "name": "Generate Hash",
+        "author": "zigahertz",
+        "description": "Generates a cryptographically strong pseudorandom hash.",
+        "repo": "zigahertz/obsidian-generate-hash"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11305,16 +11305,6 @@
         "repo": "ebullient/obsidian-slides-extended"
     },
     {
-<<<<<<< HEAD
-=======
-        "id": "generate-hash",
-        "name": "Generate Hash",
-        "author": "zigahertz",
-        "description": "Obsidian plugin for inserting a cryptographically strong pseudorandom hash.",
-        "repo": "zigahertz/obsidian-generate-hash"
-    },
-    {
->>>>>>> 7673f0b (Update community-plugins.json)
         "id": "my_anime_list_text_exporter",
         "name": "my anime list text exporter",
         "author": "XmoncocoX",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11305,6 +11305,16 @@
         "repo": "ebullient/obsidian-slides-extended"
     },
     {
+<<<<<<< HEAD
+=======
+        "id": "generate-hash",
+        "name": "Generate Hash",
+        "author": "zigahertz",
+        "description": "Obsidian plugin for inserting a cryptographically strong pseudorandom hash.",
+        "repo": "zigahertz/obsidian-generate-hash"
+    },
+    {
+>>>>>>> 7673f0b (Update community-plugins.json)
         "id": "my_anime_list_text_exporter",
         "name": "my anime list text exporter",
         "author": "XmoncocoX",
@@ -11408,12 +11418,5 @@
         "author": "zigahertz",
         "description": "Generates a cryptographically strong pseudorandom hash.",
         "repo": "zigahertz/obsidian-hash"
-    },
-    {
-        "id": "generate-hash",
-        "name": "Generate Hash",
-        "author": "zigahertz",
-        "description": "Generates a cryptographically strong pseudorandom hash.",
-        "repo": "zigahertz/obsidian-generate-hash"
     }
 ]


### PR DESCRIPTION
simple plugin to generate a pseudorandom hash

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/zigahertz/obsidian-generate-hash

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
