### PR TITLE
Add plugin: Note Splitter

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11359,5 +11359,12 @@
         "author": "Tom Parker-Shemilt",
         "description": "Generates random names.",
         "repo": "palfrey/obsidian-random-names"
+    },
+    {
+        "id": "note-splitter",
+        "name": "Note Splitter",
+        "author": "Trey Wallis",
+        "description": "Split a note into individual notes based on a delimiter.",
+        "repo": "trey-wallis/obsidian-note-splitter"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:
https://github.com/trey-wallis/obsidian-note-splitter

## Release Checklist
- [X] I have tested the plugin on
  - [ ]  Windows
  - [X]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
