### PR TITLE
Add plugin: Azure DevOps Linker

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8666,13 +8666,6 @@
         "repo": "srz2/obsidian-jira-linker"
     },
     {
-        "id": "azure-linker",
-        "name": "Azure DevOps Linker",
-        "author": "Steven Zilberberg",
-        "description": "Quickly format an Azure DevOps issue tag as a link to you Azure DevOps instance.",
-        "repo": "srz2/obsidian-azure-devops-linker"
-    },
-    {
         "id": "remove-empty-folders",
         "name": "Remove Empty Folders",
         "author": "fnya",
@@ -11478,5 +11471,12 @@
         "author": "Brian Boucheron",
         "description": "Show draft status in the file explorer.",
         "repo": "beardicus/obsidian-draft-indicator-plugin"
+    },
+    {
+        "id": "azure-linker",
+        "name": "Azure DevOps Linker",
+        "author": "Steven Zilberberg",
+        "description": "Quickly format an Azure DevOps issue tag as a link to you Azure DevOps instance.",
+        "repo": "srz2/obsidian-azure-devops-linker"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8666,6 +8666,13 @@
         "repo": "srz2/obsidian-jira-linker"
     },
     {
+        "id": "azure-linker",
+        "name": "Azure DevOps Linker",
+        "author": "Steven Zilberberg",
+        "description": "Quickly format an Azure DevOps issue tag as a link to you Azure DevOps instance.",
+        "repo": "srz2/obsidian-azure-devops-linker"
+    },
+    {
         "id": "remove-empty-folders",
         "name": "Remove Empty Folders",
         "author": "fnya",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/srz2/obsidian-azure-devops-linker

## Release Checklist
- [X] I have tested the plugin on
  - [ ]  Windows
  - [X]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
