### PR TITLE
Add plugin: Mapbox Location Image

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11439,9 +11439,16 @@
     },
     {
         "id": "link-magic",
-	   "name": "LinkMagic",
+        "name": "LinkMagic",
         "author": "AndyReifman",
-	   "description": "Automatically adds links to defined regex.",
-	   "repo": "AndyReifman/LinkMagic"
+        "description": "Automatically adds links to defined regex.",
+        "repo": "AndyReifman/LinkMagic"
+    },
+    {
+      "id": "mapbox-location",
+      "name": "Mapbox Location Image",
+      "author": "Aaron Czichon",
+      "description": "Renders an mapbox location image based on given coordinates.",
+      "repo": "aaronczichon/obsidian-location-plugin"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/aaronczichon/obsidian-location-plugin

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.

---

Called the id `mapbox-location` instead of `mapbox-location-image` as future version should also include interactive map.