### PR TITLE
Add plugin: Simple Youtube Referencer

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11478,5 +11478,12 @@
         "author": "Steven Zilberberg",
         "description": "Quickly format an Azure DevOps issue tag as a link to you Azure DevOps instance.",
         "repo": "srz2/obsidian-azure-devops-linker"
+    },
+    {
+        "id": "simple-youtube-referencer",
+	    "name": "Simple Youtube Referencer",
+        "author": "ohlai",
+        "description": "Adds metadata from link youtube video to frontmatter of a document.",
+        "repo": "ohlai/simple-youtube-referencer"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
