### PR TITLE
Rebrand Custom Sidebar Icons to Custom Icons

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11154,7 +11154,7 @@
         "id": "custom-sidebar-icons",
         "name": "Custom Icons",
         "author": "RavenHogWarts",
-        "description": "Customize sidebar workspace document and folder icons to personalize your Obsidian experience.",
+        "description": "Enhance your workspace with customizable icons for documents and folders.",
         "repo": "RavenHogWarts/obsidian-custom-sidebar-icons"
     },
     {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11155,7 +11155,7 @@
         "name": "Custom Icons",
         "author": "RavenHogWarts",
         "description": "Enhance your workspace with customizable icons for documents and folders.",
-        "repo": "RavenHogWarts/obsidian-custom-sidebar-icons"
+        "repo": "RavenHogWarts/obsidian-custom-icons"
     },
     {
         "id": "update-time-updater",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11152,9 +11152,9 @@
     },
     {
         "id": "custom-sidebar-icons",
-        "name": "Custom Sidebar Icons",
+        "name": "Custom Icons",
         "author": "RavenHogWarts",
-        "description": "Customize sidebar workspace document icons.",
+        "description": "Customize sidebar workspace document and folder icons to personalize your Obsidian experience.",
         "repo": "RavenHogWarts/obsidian-custom-sidebar-icons"
     },
     {


### PR DESCRIPTION
# Rebrand a plugin

## Repo URL

Link to my plugin: https://github.com/RavenHogWarts/obsidian-custom-icons

## Enhanced Functionality
I've expanded the plugin's capabilities, introducing customization options for folder icons alongside its original document icon customization feature.

## Rationale for Rebranding
The added functionality greatly broadens the plugin's applicability, making "Custom Icons" a more fitting name. It accurately reflects the plugin's enhanced utility in personalizing both documents and folders, offering a unified customization experience.

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [X]  macOS
  - [X]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
