### PR TITLE
Added weekly review notes linker plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1218,6 +1218,13 @@
         "repo": "renmu123/obsidian-image-auto-upload-plugin"
     },
     {
+        "id": "weekly-review-linker",
+        "name": "Weekly Review notes linker",
+	    "description": "This links all of the files you have created in the last week into a Weekly Review note.",
+	    "author": "Aditya Khowal and Brandon Boswell",
+         "repo": "https://github.com/AdityaKhowalGithub/weekly-review-notes-linker"
+    },
+    {
         "id": "obsidian-org-mode",
         "name": "Org Mode",
         "description": "Add Org Mode support.",


### PR DESCRIPTION
Weekly review notes linker plugin is a fork of the weekly review plugin. It alters the main functionality to make a weekly note that links all the notes created in a week into one file. This is helpful if you use periodic notes. For periodic notes set your naming scheme for weekly notes to: Weekly Review - 202x-xx-xx

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
