### PR TITLE
update the repo link for obsidian-full-calendar

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3112,7 +3112,7 @@
         "name": "Full Calendar",
         "author": "Davis Haupt (@davish)",
         "description": "Keep events and manage your calendar alongside all your other notes in your vault.",
-        "repo": "davish/obsidian-full-calendar"
+        "repo": "obsidian-community/obsidian-full-calendar"
     },
     {
         "id": "heatmap-calendar",


### PR DESCRIPTION
this PR updates the link to the repo for obsidian-full-calendar to reflect that it has been moved to obsidian-community.