### PR TITLE
Add Code Block Search plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11533,8 +11533,7 @@
         "name": "Code Block Search",
         "author": "Locker1162",
         "description": "Search function returning only results inside code blocks.",
-        "repo": "Locker1162/code-block-search",
-        "branch": "master"
+        "repo": "Locker1162/code-block-search"
     }
       
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11529,7 +11529,7 @@
         "repo": "terrychenzw/obsidian-zettelkasten-navigation"
     },
     {
-        "id": "codeblock-search",
+        "id": "code-block-search",
         "name": "Code Block Search",
         "author": "Locker1162",
         "description": "Search function returning only results inside code blocks.",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11527,5 +11527,14 @@
         "author": "terrychenzw",
         "description": "Visualize a Luhmann-style zettelkasten.",
         "repo": "terrychenzw/obsidian-zettelkasten-navigation"
+    },
+    {
+        "id": "codeblock-search",
+        "name": "Code Block Search",
+        "author": "Locker1162",
+        "description": "Search function returning only results inside code blocks.",
+        "repo": "Locker1162/code-block-search",
+        "branch": "master"
     }
+      
 ]


### PR DESCRIPTION
Adds a custom search function to search for a string and return entire code blocks containing that string.
Opens copyable results in a new tab that clears when the app closes.

Press hotkey to open search prompt.

![Pasted image 20240505100124](https://github.com/obsidianmd/obsidian-releases/assets/59067376/6f0cbca8-bcc6-4663-894b-032745e212ad)

Open Code Block Search Results tab for all results. Tab contents clear on exiting the app.

![Pasted image 20240505100146](https://github.com/obsidianmd/obsidian-releases/assets/59067376/5df4abc3-a52d-44e5-aa49-42cd79afa714)

Can keep multiple searches open at once.

![Pasted image 20240505100523](https://github.com/obsidianmd/obsidian-releases/assets/59067376/7d4cc570-4278-416c-811c-f0af1c5af43d)
