### PR TITLE
Add plugin: Import Attachments+

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12346,12 +12346,19 @@
         "author": "Karsten Finderup Pedersen",
         "description": "Interact with elements using keyboard shortcuts in the spirit of Vim.",
         "repo": "karstenpedersen/obsidian-vimium"
-        },
-        {
+    },
+    {
         "id": "checkbox-styling-helper",
         "name": "Checkbox styling helper",
         "author": "JaewonE",
         "description": "Helps you styling checkboxes in preview mode.",
         "repo": "jaewonE/checkbox-styling-helper"
+    },
+    {
+	    "id": "import-attachments-plus",
+	    "name": "Import Attachments+",
+	    "author": "Andrea Alberti",
+	    "description": "Import and manage attachments by enabling moving and linking",
+	    "repo": "alberti42/obsidian-import-attachments-plus"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12359,6 +12359,6 @@
 	    "name": "Import Attachments+",
 	    "author": "Andrea Alberti",
 	    "description": "Import and manage attachments by enabling moving and linking",
-	    "repo": "alberti42/obsidian-import-attachments-plus"
+	    "repo": "alberti42/obsidian-import-attachments-plus" 
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/alberti42/obsidian-import-attachments-plus

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
