### PR TITLE
Add plugin: File Preview

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11765,5 +11765,12 @@
         "author": "Isaia Riva",
         "description": "Create select that change the markdown on change adding an action button to the ribbon (left sidebar)",
         "repo": "IsaiaScope/smart-html-select-plugin"
+    },
+    {
+        "id": "file-preview",
+        "name": "File Preview",
+        "author": "Huajin",
+        "description": "Add file preview contents under file in file explorer.",
+        "repo": "xhuajin/obsidian-file-preview"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/xhuajin/obsidian-file-preview

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
