### PR TITLE
[author]: Change Obsidian GitHub Publisher to Enveloppe

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3494,10 +3494,10 @@
     },
     {
         "id": "obsidian-mkdocs-publisher",
-        "name": "Github Publisher",
+        "name": "Enveloppe",
         "author": "Mara-Li",
         "description": "Publish your notes to a preconfigured GitHub repository.",
-        "repo": "ObsidianPublisher/obsidian-github-publisher"
+        "repo": "Enveloppe/obsidian-enveloppe"
     },
     {
         "id": "obsidian-notion-video",


### PR DESCRIPTION
The project was renamed to have a better understanding and difference between the Obsidian team and me, preventing confusion between publisher and publish project.

I hope it's okay!
Thanks.