### PR TITLE
Add Generate-TOC plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11723,5 +11723,14 @@
         "author": "Dominic Let",
         "description": "Personal dictionary for your notes",
         "repo": "dominiclet/obsidian-note-definitions"
+    },
+	{
+        "id": "Generate-TOC",
+        "name": "Generate TOC(一键制作目录)",
+        "author": "adiyaojz",
+        "description": "双语版的一键制作一个可链接的目录,根据当前文档中的heading(等级标题)自动生成，如果已经生成，再次点击会进行更新，不会自动更新，防止占用线程到时变卡，配合admonition,效果更佳！，如果没配合admonition，可以勾选去掉代码框。",
+        "repo": "adiyaojz/obsdian-Generate-TOC"
     }
+	
+	
 ]


### PR DESCRIPTION
update community-plugins.json

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [adiyaojz/obsdian-Generate-TOC](https://github.com/adiyaojz/obsdian-Generate-TOC)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
