### PR TITLE
Add plugin: Relative Timestamps

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11954,5 +11954,5 @@
         "author": "Charles Young",
         "description": "Track the time between log entries.",
         "repo": "agctute/relative-timestamps"
-  },
+  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11947,5 +11947,12 @@
         "author": "kndshein",
         "description": "Automatically creates a Markdown link for Pivotal Tracker stories.",
         "repo": "kndshein/obsidian-pt-url-helper"
-    }
+    },
+    {
+        "id": "relative-timestamps",
+        "name": "Relative Timestamps",
+        "author": "Charles Young",
+        "description": "Track the time between log entries.",
+        "repo": "agctute/relative-timestamps"
+  },
 ]


### PR DESCRIPTION
added plugin

# I am submitting a new Community Plugin

## Repo URL

Link to my plugin:
https://github.com/agctute/relative-timestamps

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_a
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
