### PR TITLE
Update plugin description

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -10692,7 +10692,7 @@
         "id": "tab-selector",
         "name": "Tab Selector",
         "author": "namikaze-40p",
-        "description": "Switch to the desired tab in about two actions without leaving the home position on the keyboard.",
+        "description": "Quickly switch tab by 2 ways, one is general way in like other apps, the other is with keeping the keyboard home position.",
         "repo": "namikaze-40p/obsidian-tab-selector"
     },
     {
@@ -11392,7 +11392,7 @@
         "id": "bookmarks-caller",
         "name": "Bookmarks Caller",
         "author": "namikaze-40p",
-        "description": "Easily open bookmarks without leaving the keyboard home position.",
+        "description": "Easily open bookmarks with keeping the keyboard home position.",
         "repo": "namikaze-40p/obsidian-bookmarks-caller"
     },
     {


### PR DESCRIPTION
I want to change the description of my plugins below. Could you please review and merge?

- [Tab Selector](https://github.com/namikaze-40p/obsidian-tab-selector)
  - Reason for change: This plugin has been updated to add a new way of tab switching.
- [Bookmarks Caller](https://github.com/namikaze-40p/obsidian-bookmarks-caller)
  - Reason for change: To match the wording of the `Tab Selector` plugin description above.