### PR TITLE
Add plugin: Get File Info

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11849,5 +11849,12 @@
         "author": "Alberto Sesiliano (aygjiay)",
         "description": "From a bible reference selected creates a markdown link to a configured bible site.",
         "repo": "aygjiay/obsidian-link-to-verse"
+    },
+    {
+        "id": "get-file-info",
+        "name": "Get File Info",
+        "author": "Vivek",
+        "description": "Get File Info is a plugin that tucks a menu inside your status bar and shows helpful information for your chosen file",
+        "repo": "VPS07/Get-File-Info-Plugin"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL
Link to my plugin: [Get-File-Info-Plugin](https://github.com/VPS07/Get-File-Info-Plugin)

## Release Checklist

- [x] I have tested the plugin on
	- [ ] 	 Windows
	- [ ] 	 macOS
	- [x] 	 Linux
	- [ ] 	 Android (if applicable)
	- [ ] 	 iOS (if applicable)

- [x]  My GitHub release contains all required files
	- [x]  main.js
	- [x]  manifest.json
	- [x]  styles.css (optional)

- [x] GitHub release name matches the exact version number specified in my manifest.json (Note: Use the exact version number, don't include a prefix `v`)

- [x] The `id` in my `manifest.json` matches the id in the `community-plugins.json` file.

- [x]  My README.md describes the plugin's purpose and provides clear usage instructions.

- [x]  I have read the developer policies at [docs.obsidian.md/Developer+policies](https://docs.obsidian.md/Developer+policies), and have assessed my plugins's adherence to these policies.

- [x]  I have read the tips in [docs.obsidian.md/Plugins/Releasing/Plugin+guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines) and have self-reviewed my plugin to avoid these common pitfalls.

- [x]  I have added a license in the LICENSE file.

- [x]  My project respects and is compatible with the original license of any code from other plugins that I'm using.

- [x] I have given proper attribution to these other projects in my `README.md`.
