### PR TITLE
Add plugin: Publish to DEV

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12296,6 +12296,6 @@
         "name": "Publish to DEV",
         "author": "Peter Strøiman",
         "description": "Publish and update notes as articles on DEV (https://dev.to)",
-        "repo": "https://github.com/stroiman/obsidian-dev-publish"
+        "repo": "stroiman/obsidian-dev-publish"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12290,5 +12290,12 @@
         "author": "LighthouseDino",
         "description": "Automatically manages and updates 'created' and 'modified' timestamps in the frontmatter of your notes.",
         "repo": "lighthousedino/obsidian-front-matter-timestamps"
+    },
+    {
+        "id": "publish-to-dev",
+        "name": "Publish to DEV",
+        "author": "Peter Strøiman",
+        "description": "Publish and update notes as articles on DEV (https://dev.to)",
+        "repo": "https://github.com/stroiman/obsidian-dev-publish"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/stroiman/obsidian-dev-publish

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
