### PR TITLE
ADD Regex Order List plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11914,10 +11914,10 @@
         "repo": "xhuajin/obsidian-tabs"
     },
     {
-        "id": "regex-order-plugin",
-	    "name": "Regex Order List",
-        "description": "A plugin to order lists based on regex patterns.",
-	    "author": "toakezg",
-        "repo": "https://github.com/toakezg/Regex-Order-List"
+	"id": "regex-order-plugin",
+	"name": "Regex Order List",
+	"author": "toakezg",
+	"description": "A plugin to order lists based on regex patterns.",
+	"repo": "https://github.com/toakezg/Regex-Order-List"
     },
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11912,5 +11912,12 @@
         "author": "Huajin",
         "description": "Create tabs in your notes.",
         "repo": "xhuajin/obsidian-tabs"
-    }
+    },
+    {
+        "id": "regex-order-plugin",
+	    "name": "Regex Order List",
+        "description": "A plugin to order lists based on regex patterns.",
+	    "author": "toakezg",
+        "repo": "https://github.com/toakezg/Regex-Order-List"
+    },
 ]


### PR DESCRIPTION
A plugin to order lists based on regex patterns. 

Features:
We've covered most of the common types of sorting needs, including:

1. **Numerical Sorting**: Single and multiple numbers.
2. **Alphabetical Sorting**: Purely alphabetical strings.
3. **Alphanumeric Sorting**: Mixed letters and numbers.
4. **Date Sorting**: Both international and standard formats.
5. **Version Number Sorting**: Numbers separated by delimiters (like hyphens).

My first attempt of doing a plugin, and one of my first coding projects. Apologies in advance for any mishaps, thanks a bunch!

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
