### PR TITLE
Add 2remarkable plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11912,5 +11912,12 @@
         "author": "Huajin",
         "description": "Create tabs in your notes.",
         "repo": "xhuajin/obsidian-tabs"
+    },
+    {
+        "id": "obsidian-to-remarkable",
+        "name": "Obsidian to Remarkable",
+        "author": "imimajin",
+        "description": "Automatically converts Markdown files from Obsidian to PDF and uploads them to a Remarkable tablet.",
+        "repo": "imimajin/obsidian-remarkable"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11914,8 +11914,8 @@
         "repo": "xhuajin/obsidian-tabs"
     },
     {
-      "id": "remarkable-sync",
-      "name": "Remarkable Sync",
+      "id": "2remarkable",
+      "name": "To Remarkable",
       "author": "imimajin",
       "description": "Automatically converts Markdown files from Obsidian to PDF and uploads them to a Remarkable tablet.",
       "repo": "imimajin/obsidian-remarkable"

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11914,10 +11914,11 @@
         "repo": "xhuajin/obsidian-tabs"
     },
     {
-        "id": "obsidian-to-remarkable",
-        "name": "Obsidian to Remarkable",
-        "author": "imimajin",
-        "description": "Automatically converts Markdown files from Obsidian to PDF and uploads them to a Remarkable tablet.",
-        "repo": "imimajin/obsidian-remarkable"
+      "id": "remarkable-sync",
+      "name": "Remarkable Sync",
+      "author": "imimajin",
+      "description": "Automatically converts Markdown files from Obsidian to PDF and uploads them to a Remarkable tablet.",
+      "repo": "imimajin/obsidian-remarkable"
     }
+
 ]


### PR DESCRIPTION
Add To Remarkable plugin entry

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/imimajin/obsidian-remarkable

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
