### PR TITLE
Add theme: Dynamic Color

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1859,12 +1859,13 @@
     "author": "Anareaty",
     "repo": "anareaty/creme-brulee-obsidian-theme",
     "screenshot": "screenshot.png",
+    "modes": ["dark", "light"]
   },
   {
     "name": "Dynamic Color",
     "author": "Rody Davis",
     "repo": "rodydavis/obsidian-dynamic-color",
-    "screenshot": "screenshots/light-green.png",
+    "screenshot": "screenshots/light-purple.png",
     "modes": ["dark", "light"]
   }
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1863,7 +1863,7 @@
   {
     "name": "Dynamic Color",
     "author": "Rody Davis",
-    "repo": "rodydavis/obsidian-dynamic-theme",
+    "repo": "rodydavis/obsidian-dynamic-color",
     "screenshot": "screenshots/light-green.png",
     "modes": ["dark", "light"]
   }

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1859,6 +1859,12 @@
     "author": "Anareaty",
     "repo": "anareaty/creme-brulee-obsidian-theme",
     "screenshot": "screenshot.png",
+  },
+  {
+    "name": "Dynamic Theme",
+    "author": "Rody Davis",
+    "repo": "rodydavis/obsidian-dynamic-theme",
+    "screenshot": "screenshots/light-green.png",
     "modes": ["dark", "light"]
   }
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1861,7 +1861,7 @@
     "screenshot": "screenshot.png",
   },
   {
-    "name": "Dynamic Theme",
+    "name": "Dynamic Color",
     "author": "Rody Davis",
     "repo": "rodydavis/obsidian-dynamic-theme",
     "screenshot": "screenshots/light-green.png",


### PR DESCRIPTION
[Material Design](https://material.io) inspired theme that creates [dynamic color](https://codepen.io/Rody-Davis/pen/LYojpXB?editors=1111) palettes based on the current user selected [accent color](https://docs.obsidian.md/Reference/CSS+variables/Foundations/Colors#Accent+color).

Supports light and dark mode.

## Screenshots

![dark-blue](https://github.com/obsidianmd/obsidian-releases/assets/31253215/dcb8ce9b-94e0-4cb3-8128-d9cc75ff9a81)
![dark-green](https://github.com/obsidianmd/obsidian-releases/assets/31253215/c2495b8b-cc64-4d30-99f4-f14677260198)
![light-green](https://github.com/obsidianmd/obsidian-releases/assets/31253215/b4509023-c0a5-4f32-b26b-1b370e0fe2b3)
![light-purple](https://github.com/obsidianmd/obsidian-releases/assets/31253215/44ee92b1-8ed8-4f08-8d43-294acbfcda9d)
