### PR TITLE
Add plugin: Angle Brackets Wrapper

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11915,11 +11915,10 @@
     },
     
     {
-    "id": "obsidian-no-angle-brackets",
-    "name": "No Angle Brackets",
+    "id": "angle-brackets-wrapper",
+    "name": "Angle Brackets Wrapper",
     "author": "data-jeong",
     "description": "Effortlessly wrap angle brackets with backticks in your Markdown text, excluding code blocks.",
     "repo": "data-jeong/obsidian-noanglebrackets",
-    "branch": "main"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11912,5 +11912,14 @@
         "author": "Huajin",
         "description": "Create tabs in your notes.",
         "repo": "xhuajin/obsidian-tabs"
-    }
+    },
+    
+    {
+    "id": "obsidian-no-angle-brackets",
+    "name": "No Angle Brackets",
+    "author": "data-jeong",
+    "description": "Effortlessly wrap angle brackets with backticks in your Markdown text, excluding code blocks.",
+    "repo": "data-jeong/obsidian-noanglebrackets",
+    "branch": "main"
+  }
 ]


### PR DESCRIPTION
# Obsidian Angle Brackets Wrapper Plugin
This plugin for Obsidian allows you to easily wrap angle brackets (<>) with backticks (`) in your Markdown text, excluding code blocks. With a simple button click, you can toggle the backticks around the angle brackets, making it convenient to format your text.

## Features

- Wrap angle brackets (<>) with backticks (`) in your Markdown text
- Exclude code blocks from the wrapping process
- Toggle the backticks with a simple button click
- Customize the plugin settings through the settings tab

## REPO URL 
---
Link to my plugin:
[](https://github.com/data-jeong/obsidian-noanglebrackets)

## Release Checklist
---
- [ ]  I have tested the plugin on:
    - [ ]  Windows
    - [x]  macOS
    - [ ]  Linux
    - [ ]  Android (if applicable)
    - [ ]  iOS (if applicable)
- [x]  My GitHub release contains all required files.

- [x]  GitHub release name matches the exact version number specified in my `manifest.json` (Note: Use the exact version number, don't include a prefix `v`).

- [x]  The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x]  My `README.md` describes the plugin's purpose and provides clear usage instructions.
- [x]  I have read the developer policies at [[Obsidian Developer Policies](https://docs.obsidian.md/Developer+policies)](https://docs.obsidian.md/Developer+policies), and have assessed my plugin's adherence to these policies.
- [x]  I have read the tips in [[Plugin Guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines)](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines) and have self-reviewed my plugin to avoid these common pitfalls.
- [x]  I have added a license in the `LICENSE` file.
- [x]  My project respects and is compatible with the original license of any code from other plugins that I'm using. I have given proper attribution to these other projects in my `README.md`.