### PR TITLE
Add plugin: Copy Previous Day Note

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13123,6 +13123,13 @@
 		"author": "Erika Gozar",
 		"description": "Inserts user-defined CSS snippets into the selected text.",
 		"repo": "Erallie/css-inserter"
-	}
+	},
+    {
+        "id": "copy-previous-day-note",
+        "name": "Copy Previous Day Note",
+        "author": "José Feiteirinha",
+        "description": "Copies the previous day's note when creating a new daily note.",
+        "repo": "feiteira/obsidian-copy-previous-day-note"
+    }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12719,11 +12719,11 @@
         "repo": "Lord-Turmoil/heading-toggler-obsidian"
     },
     {
-        "id": "rollover-weekly-todo",
-        "name": "Rollover Weekly Todo",
-        "description": "Rollover unchecked todo items from the previous weekly note",
-        "author": "Shubham Sethi",
-        "repo" : "shsethi/obsidian-rollover-weekly-todos"
+    	"id": "rollover-weekly-todo",
+    	"name": "Rollover Weekly Todo",
+    	"description": "Rollover unchecked todo items from the previous weekly note",
+    	"author": "Shubham Sethi",
+    	"repo" : "shsethi/obsidian-rollover-weekly-todos"
     },
     {
         "id": "youtube-downloader",


### PR DESCRIPTION
# I am submitting a new Community Plugin
## Repo URL
Link to my plugin: https://github.com/feiteira/obsidian-copy-previous-day-note

## Release Checklist
* [ ]  I have tested the plugin on
  * [x]   Windows
  * [ ]   macOS
  * [ ]   Linux
  * [ ]   Android _(if applicable)_
  * [ ]   iOS _(if applicable)_
* [x]  My GitHub release contains all required files 
   * [x]  `main.js`
   * [x]  `manifest.json`
   * [ ]  `styles.css` _(optional)_
* [x]  GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
* [x]  The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
* [x]  My README.md describes the plugin's purpose and provides clear usage instructions.
* [x]  I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
* [x]  I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
* [x]  I have added a license in the LICENSE file.
* [x]  My project respects and is compatible with the original license of any code from other plugins that I'm using.
   I have given proper attribution to these other projects in my `README.md`.