### PR TITLE
Add plugin: Quick Link Replace

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11975,5 +11975,12 @@
         "author": "Patrick Chiang",
         "description": "Show headings in the file explorer.",
         "repo": "patrickchiang/obsidian-headings-in-explorer"
+    },
+    {
+        "id": "quick-link-replace-plugin",
+        "name": "Quick Link Replace Plugin",
+        "author": "John Dolittle",
+        "description": "Insert quick links like &[number] or &[number]-[number] and click the button to replace them later. For example, replace &5 for [[file5.jpg]] ",
+        "repo": "DavidR86/obsidian-quick-link-replace"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11977,8 +11977,8 @@
         "repo": "patrickchiang/obsidian-headings-in-explorer"
     },
     {
-        "id": "quick-link-replace-plugin",
-        "name": "Quick Link Replace Plugin",
+        "id": "quick-link-replace",
+        "name": "Quick Link Replace",
         "author": "John Dolittle",
         "description": "Insert quick links like &[number] or &[number]-[number] and click the button to replace them later. For example, replace &5 for [[file5.jpg]] ",
         "repo": "DavidR86/obsidian-quick-link-replace"


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/DavidR86/obsidian-quick-link-replace

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
