### PR TITLE
Add plugin: Toggle Readable line length

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12059,5 +12059,12 @@
         "author": "Tarslab",
         "description": "Use Kimi and other Chinese LLMs for text generation based on tag suggestions.",
         "repo": "TarsLab/obsidian-tars"
+    },
+    {
+        "id": "toggle-readable-line-length",
+        "name": "Toggle Readable line length",
+        "author": "Doug Richardson",
+        "description": "Add command to toggle Readable line length editor setting.",
+        "repo": "drichardson/obsidian-toggle-readable-line-length"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/drichardson/obsidian-toggle-readable-line-length

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
