### PR TITLE
Add plugin: Definition List

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12066,5 +12066,12 @@
         "author": "Doug Richardson",
         "description": "Add command to toggle Readable line length editor setting.",
         "repo": "drichardson/obsidian-toggle-readable-line-length"
+    },
+    {
+        "id": "definition-list",
+        "name": "Definition List",
+        "author": "shammond42",
+        "description": "Adds HTML definition list support.",
+        "repo": "shammond42/definition-list"
     }
 ]


### PR DESCRIPTION
Adds an entry in the community-plugins.json file for the Definition List plugin.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/shammond42/definition-list

## Release Checklist
- [X ] I have tested the plugin on
  - [ ]  Windows
  - [X]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
