### PR TITLE
add Duplicate folder plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12024,5 +12024,12 @@
         "author": "acidghost",
         "description": "Automatically fill progress (as fraction or percentage) of check-lists.",
         "repo": "acidghost/obsidian-checklist-progress"
+    },
+    {
+        "id": "duplicate-folder",
+        "name": "Duplicate Folder",
+        "author": "Alex Pineda <github.com/alexpineda>",
+        "description": "A plugin to duplicate folders in your Obsidian vault. Copy nested folders as well.",
+        "repo": "alexpineda/copy-folder-obsidian"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL
(https://github.com/alexpineda/copy-folder-obsidian)
Link to my plugin:

## Release Checklist
- [ X ] I have tested the plugin on
  - [ X ]  Windows
  - [ X ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [ X ] `main.js`
  - [ X ] `manifest.json`
  - [ X ] `styles.css` _(optional)_
- [ X ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ X ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ X ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ X ] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [ X ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ X ] I have added a license in the LICENSE file.
- [ X ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
