### PR TITLE
Add File Flex

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12024,5 +12024,12 @@
         "author": "acidghost",
         "description": "Automatically fill progress (as fraction or percentage) of check-lists.",
         "repo": "acidghost/obsidian-checklist-progress"
-    }
+    },
+    {
+        "id": "obsidian-file-flex",
+        "name": "File Flex",
+        "author": "Michael Baker",
+        "description": "Undo file and folder movement and name changes.",
+        "repo": "19msb/obsidian-file-flex"
+      }
 ]


### PR DESCRIPTION
Add File Flex

This pull request adds the File Flex plugin, which provides customisable undo functionality for file and folder movements and renames within Obsidian. Users can easily revert changes to their vault structure with a single click and/or hotkey.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/19msb/obsidian-file-flex

## Release Checklist
- [x ] I have tested the plugin on
  - [ ]  Windows
  - [x ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ x] My GitHub release contains all required files
  - [x ] `main.js`
  - [ x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [ x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
