### PR TITLE
Add plugin: Syrinscape Online Player

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12220,5 +12220,12 @@
         "author": "Evan Moscoso",
         "description": "Create personalized and intelligent analysis, brainstorms, summaries, and more for audio recordings that can be imported or spoken directly into a note",
         "repo": "Mossy1022/smart-transcriptions"
+    },
+    {
+        "id": "syrinscape-player-control",
+        "name": "Syrinscape Online Player",
+        "author": "Stephen Cooper",
+        "description": "Control Syrinscape Online Player from inside of notes.",
+        "repo": "scooper4711/obsidian-syrinscape"
     }
 ]


### PR DESCRIPTION
Syrinscape is a TTRPG tool for ambient sounds. This plugin will allow GMs to control the Syrinscape online player from inside of notes, triggering moods and one-shot sounds.

# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/scooper4711/obsidian-syrinscape

## Release Checklist
- [X] I have tested the plugin on
  - [ ]  Windows
  - [X]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [X]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
