### PR TITLE
[Fix] remove "obsidian" from title.

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12164,5 +12164,12 @@
         "author": "Boninall",
         "description": "Automatically resize the node when the content changes.",
         "repo": "quorafind/obsidian-node-auto-resize"
+    },
+    {
+        "id": "checkbox-styling-helper",
+        "name": "Checkbox styling helper",
+        "author": "JaewonE",
+        "description": "Obsidian plugin that helps you styling checkboxes in preview mode.",
+        "repo": "jaewonE/obsidian-checkbox-styling-helper"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/jaewonE/obsidian-checkbox-styling-helper

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
