### PR TITLE
Add plugin: Heading Path

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12246,7 +12246,7 @@
         "id": "heading-path",
         "name": "Heading Path",
         "author": "Michael Baker",
-        "description": "Copy the path of the selected heading.",
+        "description": "Copy the heading path of the selected text.",
         "repo": "19msb/obsidian-heading-path"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12241,5 +12241,12 @@
         "author": "triski",
         "description": "Page Up|Down|Top|Bottom",
         "repo": "chenshutian9610/obsidian-pagescroll-plugin"
+    },
+    {
+        "id": "heading-path",
+        "name": "Heading Path",
+        "author": "Michael Baker",
+        "description": "Copy the path of the selected heading.",
+        "repo": "19msb/obsidian-heading-path"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12246,7 +12246,7 @@
         "id": "heading-path",
         "name": "Heading Path",
         "author": "Michael Baker",
-        "description": "Copy the heading path of the selected text.",
+        "description": "Copy the heading path of selected text.",
         "repo": "19msb/obsidian-heading-path"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/19msb/obsidian-heading-path

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
