### PR TITLE
Add plugin: Image Metadata

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12600,5 +12600,12 @@
         "author": "LuCrypto",
         "description": "Search and insert gifs in a note.",
         "repo": "LuCrypto/giphy-plugin"
+    },
+    {
+        "id": "image-metadata",
+        "name": "Image Metadata",
+        "author": "alexeiskachykhin",
+        "description": "Annotate photos with Exif and other metadata right from the image viewer screen.",
+        "repo": "alexeiskachykhin/obsidian-image-metadata-plugin"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/alexeiskachykhin/obsidian-image-metadata-plugin

## Release Checklist
- [x] I have tested the plugin on
  - [X]  Windows
  - [x]  macOS
  - [X]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
