### PR TITLE
Add plugin:obsidian-sync-db-os

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -297,7 +297,7 @@
         "id": "obsidian-dangling-links",
         "name": "Dangling links",
         "author": "Graydon Hoare",
-        "description": "Add a sidebar showing any dangling links in a vault. Dangling links are orphaned links that don't point to anything in the vault.",
+        "description": "Add a sidebar showing any dangling links in a vault. dangling links are orphaned links that don't point to anything in the vault.",
         "repo": "graydon/obsidian-dangling-links"
     },
     {
@@ -12362,8 +12362,8 @@
 	    "repo": "alberti42/obsidian-import-attachments-plus" 
     },
     {
-        "id": "obsidian-sync-db-os",
-        "name": "obsidian-sync-db-os",
+        "id": "sync-db-os",
+        "name": "sync-db-os",
         "author": "ketd",
         "description": "For synchronization between multiple platforms",
         "repo": "https://github.com/ketd/obsidian-sync-DB-OS"

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12366,7 +12366,7 @@
         "name": "sync-db-os",
         "author": "ketd",
         "description": "For synchronization between multiple platforms",
-        "repo": "https://github.com/ketd/obsidian-sync-DB-OS"
+        "repo": "ketd/obsidian-sync-DB-OS"
     }
 
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12360,5 +12360,13 @@
 	    "author": "Andrea Alberti",
 	    "description": "Import and manage attachments by enabling moving and linking",
 	    "repo": "alberti42/obsidian-import-attachments-plus" 
+    },
+    {
+        "id": "obsidian-sync-db-os",
+        "name": "obsidian-sync-db-os",
+        "author": "ketd",
+        "description": "For synchronization between multiple platforms",
+        "repo": "https://github.com/ketd/obsidian-sync-DB-OS"
     }
+
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:  https://github.com/ketd/obsidian-sync-DB-OS

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
