### PR TITLE
Add plugin: Hash Pasted Image

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12423,5 +12423,12 @@
         "author": "mnaoumov",
         "description": "Allows to refresh preview mode without reopening the note",
         "repo": "mnaoumov/obsidian-refresh-preview"
+    },
+    {
+        "id": "hash-pasted-image",
+        "name": "Hash Pasted Image",
+        "author": "Minh Vương",
+        "description": "Auto rename pasted images added to the vault via hash algorithm SHA-512",
+        "repo": "hardingadonis/hash-pasted-image"
     }
 ]


### PR DESCRIPTION
# Note:

I re-create pull request again because after merge #3814, my plugin not included for release to community

---

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/hardingadonis/hash-pasted-image

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.