### PR TITLE
Move obsidian-git plugin to Vinzent03

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17,7 +17,7 @@
         "id": "obsidian-git",
         "name": "Git",
         "author": "Vinzent, (Denis Olehov)",
-        "description": "Backup your vault with Git.",
+        "description": "Integrate Git version control with automatic backup and other advanced features.",
         "repo": "Vinzent03/obsidian-git"
     },
     {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18,7 +18,7 @@
         "name": "Git",
         "author": "Vinzent, (Denis Olehov)",
         "description": "Backup your vault with Git.",
-        "repo": "denolehov/obsidian-git"
+        "repo": "Vinzent03/obsidian-git"
     },
     {
         "id": "url-into-selection",


### PR DESCRIPTION
# I am renaming and relocating an existing Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
The plugin is currently here located: https://github.com/denolehov/obsidian-git

Since I'm maintaining that plugin for 3 years already, @denolehov will transfer the repo to my account. I haven't accepted the transfer yet, but will do so immediately after this pr is merged to prevent any issues with a missing repo. 