### PR TITLE
Add light mode support to my theme Seamless View

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -1937,13 +1937,13 @@
     "screenshot": "Northern-Sky-small.png",
     "modes": ["light"]
   },
-	{
-	"name": "Seamless View",
-	"author": "Gustavo Salgado",
-	"repo": "GustavoSZ124/Obsidian-Theme-Seamless-View",
-	"screenshot": "assets/Seamless View.png",
-	"modes": ["dark"]
-	},
+  {
+  	"name": "Seamless View",
+  	"author": "Gustavo Salgado",
+  	"repo": "GustavoSZ124/Obsidian-Theme-Seamless-View",
+  	"screenshot": "assets/Seamless View.png",
+  	"modes": ["dark","light"]
+  },
 	{
     "name": "Gummy-Revived",
     "author": "WinnerWind",


### PR DESCRIPTION
Add light mode support

# I am updating my Community Theme Seamless View

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my theme: https://github.com/GustavoSZ124/Obsidian-Theme-Seamless-View


## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `manifest.json`
  - [x] `theme.css`
  - [x] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my theme's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Themes/App+themes/Theme+guidelines and have self-reviewed my theme to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.
