### PR TITLE
Add plugin: Paste as Embed

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12691,5 +12691,12 @@
         "author": "Nick Allison",
         "description": "Link your notes together.",
         "repo": "nickrallison/obsidian-note-linker-with-previewer"
+    },
+    {
+	"id": "obsidian-paste-as-embed",
+	"name": "Paste As Embed",
+	"author": "Matt Laporte",
+	"description": "Redirect pasted text into a separate note, and embed it.",
+	"repo": "mlprt/obsidian-paste-as-embed"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12693,10 +12693,10 @@
         "repo": "nickrallison/obsidian-note-linker-with-previewer"
     },
     {
-	"id": "obsidian-paste-as-embed",
-	"name": "Paste As Embed",
-	"author": "Matt Laporte",
-	"description": "Redirect pasted text into a separate note, and embed it.",
-	"repo": "mlprt/obsidian-paste-as-embed"
+    	"id": "paste-as-embed",
+    	"name": "Paste as Embed",
+    	"author": "Matt Laporte",
+    	"description": "Redirect pasted text into a separate note, and embed it.",
+    	"repo": "mlprt/obsidian-paste-as-embed"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/mlprt/obsidian-paste-as-embed

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
