### PR TITLE
Add Double Capitalization Fix plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,12 +1,5 @@
 [
     {
-        "id": "double-capitalization-fix",
-        "name": "Double Capitalization Fix",
-        "author": "Ivan Babichuk",
-        "description": "Automatically detects and corrects words with two initial capital letters followed by lowercase letters.",
-        "repo": "/ibabichuk/double-capitalization-fix-obsidian"
-    }, 
-    {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
         "author": "Argentina Ortega Sainz",
@@ -12558,5 +12551,12 @@
         "author": "KaelLarkin",
         "description": "Nextcloud breaks Wiki-links. This fixes them.",
         "repo": "KFreon/nextcloud-link-fixer"
+    },
+    {
+        "id": "double-capitalization-fix",
+        "name": "Double Capitalization Fix",
+        "author": "Ivan Babichuk",
+        "description": "Automatically detects and corrects words with two initial capital letters followed by lowercase letters.",
+        "repo": "/ibabichuk/double-capitalization-fix-obsidian"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,12 @@
 [
     {
+        "id": "double-capitalization-fix",
+        "name": "Double Capitalization Fix",
+        "author": "Ivan Babichuk",
+        "description": "Automatically detects and corrects words with two initial capital letters followed by lowercase letters.",
+        "repo": "/ibabichuk/double-capitalization-fix-obsidian"
+    }, 
+    {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
         "author": "Argentina Ortega Sainz",


### PR DESCRIPTION
THis Obsidian plugin automatically corrects words with double capitalization (I tent to do such mistypes all the TIme).
It detects and corrects words with exactly two initial capital letters followed by lowercase letters.
Works on Spacebar and Enter key presses.


* [Community Plugin](?template=plugin.md)

