### PR TITLE
Add plugin: Double Capitalization Fix

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,12 +1,5 @@
 [
     {
-        "id": "double-capitalization-fix",
-        "name": "Double Capitalization Fix",
-        "author": "Ivan Babichuk",
-        "description": "Automatically detects and corrects words with two initial capital letters followed by lowercase letters.",
-        "repo": "/ibabichuk/double-capitalization-fix-obsidian"
-    }, 
-    {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
         "author": "Argentina Ortega Sainz",
@@ -12558,5 +12551,12 @@
         "author": "KaelLarkin",
         "description": "Nextcloud breaks Wiki-links. This fixes them.",
         "repo": "KFreon/nextcloud-link-fixer"
+    },
+    {
+        "id": "double-capitalization-fix",
+        "name": "Double Capitalization Fix",
+        "author": "Ivan Babichuk",
+        "description": "Automatically detects and corrects words with two initial capital letters followed by lowercase letters.",
+        "repo": "/ibabichuk/double-capitalization-fix-obsidian"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,12 @@
 [
     {
+        "id": "double-capitalization-fix",
+        "name": "Double Capitalization Fix",
+        "author": "Ivan Babichuk",
+        "description": "Automatically detects and corrects words with two initial capital letters followed by lowercase letters.",
+        "repo": "/ibabichuk/double-capitalization-fix-obsidian"
+    }, 
+    {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
         "author": "Argentina Ortega Sainz",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12557,6 +12557,6 @@
         "name": "Double Capitalization Fix",
         "author": "Ivan Babichuk",
         "description": "Automatically detects and corrects words with two initial capital letters followed by lowercase letters.",
-        "repo": "/ibabichuk/double-capitalization-fix-obsidian"
+        "repo": "ibabichuk/double-capitalization-fix-obsidian"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12556,7 +12556,7 @@
         "id": "double-capitalization-fix",
         "name": "Double Capitalization Fix",
         "author": "Ivan Babichuk",
-        "description": "Automatically detects and corrects words with two initial capital letters followed by lowercase letters.",
+        "description": "Automatically detects and corrects misstyped words with two initial capital letters followed by lowercase letters.",
         "repo": "ibabichuk/double-capitalization-fix-obsidian"
     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/ibabichuk/double-capitalization-fix-obsidian

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [ ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
