### PR TITLE
Add plugin: Heading Toggler

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12712,5 +12712,12 @@
         "author": "Inder Singh",
         "description": "Upload images to your GitHub secret Gists. Also, resize uploaded images on the fly.",
         "repo": "singh-inder/obsidian-images-to-gist"
+    },
+    {
+        "id": "heading-toggler-obsidian",
+        "name": "Heading Toggler",
+        "author": "Lord Turmoil",
+        "description": "Easily toggle heading levels in Markdown documents with shortcuts.",
+        "repo": "Lord-Turmoil/heading-toggler-obsidian"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12714,7 +12714,7 @@
         "repo": "singh-inder/obsidian-images-to-gist"
     },
     {
-        "id": "heading-toggler-obsidian",
+        "id": "heading-toggler",
         "name": "Heading Toggler",
         "author": "Lord Turmoil",
         "description": "Easily toggle heading levels in Markdown documents with shortcuts.",


### PR DESCRIPTION
Heading Toggler is a plugin that allows you to easily toggle heading levels in Markdown documents with shortcuts.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: <https://github.com/Lord-Turmoil/heading-toggler-obsidian>

## Release Checklist

> I only have a Windows PC so I'm not able to test it on other OS. But I see no possible incompatibility for it is simple enough.

- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
