### PR TITLE
Update Tasks plugin authors

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1264,7 +1264,7 @@
     {
         "id": "obsidian-tasks-plugin",
         "name": "Tasks",
-        "author": "Martin Schenck and Clare Macrae",
+        "author": "Clare Macrae and Ilyas Landikov (created by Martin Schenck)",
         "description": "Track tasks across your vault. Supports due dates, recurring tasks, done dates, sub-set of checklist items, and filtering.",
         "repo": "obsidian-tasks-group/obsidian-tasks"
     },


### PR DESCRIPTION
This is being done with the agreement of:

- the original author, Martin Schenck (@schemar)
- co-maintainer Ilyas Landikov (@ilandikov)

Martin is retained as the third author, via `(created by Martin Schenck)`.

(I note that some other multi-owner plugins have used `original by`, but that seems to be for forks of an original, whereas Tasks is still the same plugin, with ownership just transferred to an organisation  in 2022 to permit onward maintenance...)