### PR TITLE
Add plugin: Current File

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12962,5 +12962,12 @@
         "author": "Marius Svarverud",
         "description": "A file explorer for navigating hierarchical notes separated by '.'",
         "repo": "Rudtrack/structured-tree"
-    }
+    },
+    {
+        "id": "current-file",
+        "name": "Current File",
+        "author": "Mark Fowler",
+        "description": "Allows external applications to know what file the desktop app is currently viewing.",
+        "repo": "2shortplanks/current-file"
+    } 
 ]


### PR DESCRIPTION
Adds a plugin to write what file obsidian is currently looking at to an external file every time this changes

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/2shortplanks/current-file

## Release Checklist
- [X] I have tested the plugin on
  - [ ]  Windows
  - [X]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_. **NOT APPLICABLE - does not run on mobile, guarded by `isMobile`**
  - [ ]  iOS _(if applicable)_. **NOT APPLICABLE - does not run on mobile, guarded by `isMobile`**
- [x] My GitHub release contains all required files
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
