### PR TITLE
Improve description of files needed in releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/plugin.md
+++ b/.github/PULL_REQUEST_TEMPLATE/plugin.md
@@ -12,7 +12,7 @@ Link to my plugin:
   - [ ]  Linux
   - [ ]  Android _(if applicable)_
   - [ ]  iOS _(if applicable)_
-- [ ] My GitHub release contains all required files
+- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
   - [ ] `main.js`
   - [ ] `manifest.json`
   - [ ] `styles.css` _(optional)_


### PR DESCRIPTION
When I (Mark Fowler) did my initial release I didn't realize that that individual files needed to be released, not just included in the source tarball.

I'm suggesting this update to the pull request template to hopefully avoid someone else having the same problem.

