### PR TITLE
Add plugin: Marker PDF to MD

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12803,8 +12803,8 @@
     	"repo" : "samuelrawrs/recent-tab-switcher"
     },
     {
-      	"id": "obsidian-marker",
-      	"name": "Obsidian Marker",
+      	"id": "marker-api",
+      	"name": "Marker PDF to MD",
       	"author": "L3N0X",
      	"description": "Convert PDFs to rich Markdown, including images and ocr using the marker api",
       	"repo": "l3-n0x/obsidian-marker"

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12801,5 +12801,12 @@
     	"description": "Switch to the most recently used tab.",
     	"author": "Samuel Ang",
     	"repo" : "samuelrawrs/recent-tab-switcher"
+    },
+    {
+      	"id": "obsidian-marker",
+      	"name": "Obsidian Marker",
+      	"author": "L3N0X",
+     	"description": "Convert PDFs to rich Markdown, including images and ocr using the marker api",
+      	"repo": "l3-n0x/obsidian-marker"
     }
 ]


### PR DESCRIPTION
Added my new plugin obsidian-marker which can convert PDFs to rich Markdown, embedding images and recognizing tables, headings and more! Also works on mobile!

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [obsidian-marker](https://github.com/L3-N0X/obsidian-marker)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
