### PR TITLE
Add Vanilla AMOLED Color theme

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2020,5 +2020,12 @@
     "repo": "Spekulucius/obsidian-brainhack",
     "screenshot": "preview.png",
     "modes": ["light", "dark"]
+  },
+  {
+    "name": "Vanilla AMOLED Color",
+    "author": "sskki",
+    "repo": "https://github.com/Sskki-exe/vanilla-amoled-theme-color",
+    "screenshot": "sample-screenshot-sm.png",
+    "modes": ["dark"]
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Theme

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my theme: 


## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `manifest.json`
  - [x] `theme.css`
  - [x] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my theme's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Themes/App+themes/Theme+guidelines and have self-reviewed my theme to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.
