### PR TITLE
Add plugin: Lazy Plugin Loader

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13088,6 +13088,13 @@
 	  "author": "Henri Jamet",
 	  "description": "Explore your vault by iteratively adding or ignoring linked notes, ultimately generating a customizable canvas that visually represents the preserved notes and their connections.",
 	  "repo": "hjamet/Canvas-Explorer"
-	}
+    },
+	{
+        "id": "lazy-plugins",
+        "name": "Lazy Plugin Loader",
+        "author": "Alan Grainger",
+        "description": "Load plugins with a delay on startup, so that you can get your app startup down into the sub-second loading time.",
+        "repo": "alangrainger/obsidian-lazy-plugins"
+    }	
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/alangrainger/obsidian-lazy-plugins

This plugin is similar to `obsidian-plugin-groups` in the store, however [that plugin is no longer under development](https://github.com/Mocca101/obsidian-plugin-groups/issues/41#issuecomment-1907752889), as confirmed by the plugin owner.

This plugin is also significantly more simple, and should be compatible with Obsidian long into the future.

It has [some good feedback on Reddit](https://www.reddit.com/r/ObsidianMD/comments/1ekea52/install_this_plugin_loader_to_make_your_obsidian/) already.

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
.