### PR TITLE
Rename Plugin: "Note to MP" -> "NoteToMP"

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12244,7 +12244,7 @@
     },
     {
         "id": "note-to-mp",
-        "name": "Note to MP",
+        "name": "NoteToMP",
         "author": "Sun Booshi",
         "description": "Send notes to WeChat MP drafts, or copy notes to WeChat MP editor, perfect preservation of note styles, support code highlighting, line numbers in code, and support local image uploads.",
         "repo": "sunbooshi/note-to-mp"


### PR DESCRIPTION
Rename Plugin: "Note to MP" -> "NoteToMP"

I found that when searching with the plugin name "Note to MP" there are many other plugins in the search results. Therefore, I want to change the plugin name to "NoteToMP" which should make it easier to find.

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
