### PR TITLE
Update community-plugins.json - new plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12892,5 +12892,12 @@
         "author": "Technerium",
         "description": "Graph of the Number of Files in the Vault.",
         "repo": "technerium/obsidian-vault-size-history"
+    },
+    {
+	"id": "obsidian-wikipedia-preview",
+	"name": "Wikipedia Link Preview",
+	"author": "Fayssal Fertakh",
+	"description": "Displays linked Wikipedia article preview as a popup when hovering over wikipedia links.",
+	"repo": "szvest/obsidian-wikipedia-preview"
     }
 ]


### PR DESCRIPTION
### New Plugin: Wikipedia Preview

This pull request introduces a new plugin for Obsidian called **Obsidian Wikipedia Preview**. This plugin enhances the reading experience by providing previews for Wikipedia links directly within the note. This plugin is designed to make research and note-taking more efficient by allowing users to quickly access summaries and overviews of linked Wikipedia articles without leaving the note.
#### Features
- Automatic previews for Wikipedia links on hover.
- Image Support: Displays the featured image from the Wikipedia article, enhancing the visual context of the preview.

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
