### PR TITLE
Added new community plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12892,5 +12892,12 @@
         "author": "Technerium",
         "description": "Graph of the Number of Files in the Vault.",
         "repo": "technerium/obsidian-vault-size-history"
+    },
+    {
+        "id": "obsidian-wikipedia-link-preview",
+        "name": "Wikipedia Link Preview",
+        "author": "Fayssal Fertakh",
+        "description": "Displays linked Wikipedia article preview as a popup when hovering over wikipedia links in Obsidian notes.",
+        "repo": "szvest/obsidian-wikipedia-link-preview"
     }
 ]


### PR DESCRIPTION
A new community plugin that displays linked Wikipedia article preview as a popup when hovering over wikipedia links in your notes.

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
