### PR TITLE
Update community-plugins.json - new plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12892,5 +12892,12 @@
         "author": "Technerium",
         "description": "Graph of the Number of Files in the Vault.",
         "repo": "technerium/obsidian-vault-size-history"
+    },
+    {
+	"id": "wikipedia-link-preview",
+	"name": "Wikipedia Link Preview",
+	"author": "Fayssal Fertakh",
+	"description": "Displays linked Wikipedia article preview as a popup when hovering over wikipedia links.",
+	"repo": "szvest/obsidian-wikipedia-link-preview"
     }
 ]


### PR DESCRIPTION
Displays a preview of linked Wikipedia articles as a popup when hovering over Wikipedia links, showing the article's title, description, and featured image.

* [Community Plugin](?template=plugin.md)
