### PR TITLE
Update: Shimmering Focus screenshot file

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -454,7 +454,7 @@
     "name": "Shimmering Focus",
     "author": "pseudometa",
     "repo": "chrisgrieser/shimmering-focus",
-    "screenshot": "assets/promo-screenshot.png",
+    "screenshot": "assets/promo-screenshot.webp",
     "modes": ["dark", "light"]
   },
   {


### PR DESCRIPTION
## Theme Update 
Link to my theme: https://github.com/chrisgrieser/shimmering-focus

Switch to use `webp` as image file format. Image filesize is more than halved, while the resolution/quality is the same.

(Might actually recommend themes to use webp screenshots in general, btw?)