### PR TITLE
Dark-Light Accent Color

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12927,5 +12927,13 @@
         "author": "yefengr",
         "description": "Count the number of words written each day and display it on a calendar.",
         "repo": "yefengr/obsidian-daily-statistics"
-    }
+    },
+	{
+  "id": "obsidian-accent-color-plugin",
+  "name": "Obsidian Accent Color Plugin",
+  "author": "Wilbur Salazar",
+  "description": "A plugin to set different accent colors for light and dark themes in Obsidian.",
+  "repo": "wilbursalazar/Obsidian-accent-color-dark-light",
+  "version": "1.0.0"
+}
 ]


### PR DESCRIPTION
This plugin, which lets you set different accent colors for light and dark themes in Obsidian. It provides a simple way to enhance visual customization by offering separate color codes for both dark and light themes.

Settings menu:
<img width="792" alt="Screen Shot 2024-08-17 at 8 09 45 PM" src="https://github.com/user-attachments/assets/6c579e37-0620-44f1-9c85-683f56836eb0">

You can set an accent for your light theme:
<img width="886" alt="Screen Shot 2024-08-17 at 8 14 09 PM" src="https://github.com/user-attachments/assets/ff557c86-2cad-4d5c-b923-f74a05491b5f">

And one for your dark theme:
<img width="376" alt="Screen Shot 2024-08-17 at 8 17 30 PM" src="https://github.com/user-attachments/assets/47e912d4-714a-4896-a16b-cbc90bfd7ced">

https://buymeacoffee.com/wilbursalazar

