### PR TITLE
Add plugin: Highlight active folder section

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12962,5 +12962,13 @@
         "author": "Marius Svarverud",
         "description": "A file explorer for navigating hierarchical notes separated by '.'",
         "repo": "Rudtrack/structured-tree"
+    },
+    {
+	"id": "highlight active folder section",
+        "name": "Highlight active folder section",
+        "author": "Lukas Collier",
+        "description": "Highlight the active folder section and the title in the file explorer.",
+        "repo": "justanotherjurastudent/highlight-active-folder-section"
     }
+	
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12967,7 +12967,7 @@
 	"id": "highlight-active-folder-section",
         "name": "Highlight active folder section",
         "author": "Lukas Collier",
-        "description": "Highlight the active folder section and the title in the file explorer.",
+        "description": "Highlight the active folder section and the title in the file navigation.",
         "repo": "justanotherjurastudent/highlight-active-folder-section"
     }
 	

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12964,7 +12964,7 @@
         "repo": "Rudtrack/structured-tree"
     },
     {
-	"id": "highlight active folder section",
+	"id": "highlight-active-folder-section",
         "name": "Highlight active folder section",
         "author": "Lukas Collier",
         "description": "Highlight the active folder section and the title in the file explorer.",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12967,7 +12967,7 @@
 	"id": "highlight-active-folder-section",
         "name": "Highlight active folder section",
         "author": "Lukas Collier",
-        "description": "Highlight the active folder section and the title in the file navigation.",
+        "description": "Highlight the active folder section and the title in the obsidian file explorer.",
         "repo": "justanotherjurastudent/highlight-active-folder-section"
     }
 	

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12965,7 +12965,7 @@
     },
     {
 	"id": "highlight-active-folder-section",
-        "name": "Highlight active folder section",
+	"name": "Highlight active folder section",
         "author": "Lukas Collier",
         "description": "Highlight the active folder section and the title in the obsidian file explorer.",
         "repo": "justanotherjurastudent/highlight-active-folder-section"


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/justanotherjurastudent/highlight-active-folder-section
 
## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
