### PR TITLE
Update Chat with bard plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8512,11 +8512,11 @@
         "repo": "Tatz884/RescueTime-Obsidian"
     },
     {
-        "id": "chat-with-bard",
-        "name": "Chat with Bard",
+        "id": "gemini-ai-assistant",
+        "name": "Gemini AI Assistant",
         "author": "Artel250",
-        "description": "Chat with the Google Bard Assistant.",
-        "repo": "Artel250/Obsidian-Talk-with-Bard"
+        "description": "Use Google Gemini directly in obsidian for free.",
+        "repo": "Artel250/Obsidian-Gemini-Assistant"
     },
     {
         "id": "tracker-plus",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8515,7 +8515,7 @@
         "id": "chat-with-bard",
         "name": "Gemini AI Assistant",
         "author": "Artel250",
-        "description": "Use Google Gemini directly in obsidian for free.",
+        "description": "A Google Gemini integration, completely for free.",
         "repo": "Artel250/Obsidian-Gemini-Assistant"
     },
     {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8512,7 +8512,7 @@
         "repo": "Tatz884/RescueTime-Obsidian"
     },
     {
-        "id": "gemini-ai-assistant",
+        "id": "chat-with-bard",
         "name": "Gemini AI Assistant",
         "author": "Artel250",
         "description": "Use Google Gemini directly in obsidian for free.",


### PR DESCRIPTION
The plugin was originally developed to enable users to use Google Bard in Obsidian. Google Bard has now been replaced with gemini and a completely different api, so the plugin has also been completely reworked to adapt to those changes.

This includes also a name change: from "Talk with Bard" to "Gemini AI Assistant"

Would it be possible to make the changes so that the plugin is updated in the obsidan community plugins, or should I create and submit a new plugin alltogether?