### PR TITLE
Add plugin: Auto-alias

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13109,6 +13109,13 @@
         "author": "ytisf",
         "description": "Enrich your notes with information from VirusTotal.",
         "repo": "ytisf/virustotal-enrich"
+     },
+     {
+        "id": "auto-alias",
+        "name": "Auto-alias",
+        "author": "Ptole_me",
+        "description": "Auto-creates aliases for different variations of your page titles (e.g. plurals, etc.) (Closed source)",
+        "repo": "ptolle-me/Auto-Alias-Plugin"
      }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: 
Public - https://github.com/ptolle-me/Auto-Alias-Plugin
Private (inviting @joethei)  - https://github.com/ptolle-me/Auto-Alias

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file. **[Unchecked, as observed with other closed-source plugins]**
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
