### PR TITLE
Add Card Navigator plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13110,5 +13110,12 @@
         "description": "Enrich your notes with information from VirusTotal.",
         "repo": "ytisf/virustotal-enrich"
      }
+    {
+        "id": "card-navigator-plugin",
+        "name": "Card Navigator",
+        "author": "wakeyi",
+        "description": "Navigate your notes visually with card-based interface",
+        "repo": "wakeyi-git/obsidian-card-navigator-plugin"
+     }
 ]
 


### PR DESCRIPTION
Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)


Card Navigator is a plugin for Obsidian that allows you to view and navigate your notes in a card-based interface. It provides an intuitive way to browse, sort, and manage your notes, enhancing your productivity and note-taking experience.