### PR TITLE
Change wikipedia search description

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6149,7 +6149,7 @@
         "id": "wikipedia-search",
         "name": "Wikipedia Search",
         "author": "StrangeGirlMurph",
-        "description": "Search, link and open Wikipedia articles.",
+        "description": "Search, link and open Wikipedia/Wiki articles.",
         "repo": "StrangeGirlMurph/obsidian-wikipedia-search"
     },
     {


### PR DESCRIPTION
My plugin now also supports all sorts of other wikis and even though the plugin name suggest it only works with the Wikipedia I at least wanted to tweak the description a bit to communicate that it now also supports more.