### PR TITLE
Add plugin: Figma Embed

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13110,13 +13110,6 @@
         "description": "Upload images from your clipboard to ImgBB.",
         "repo": "jordanhandy/obsidian-imgbb-uploader"
     },
-	{
-        "id": "figma-embed",
-        "name": "Figma Embed",
-        "author": "Kyle Kochanek",
-        "description": "Embed Figma files as inline previews in Obsidian.",
-        "repo": "kocheck/obsidian-figma-viewer"
-    },
     {
         "id": "import-github-readme",
         "name": "Import GitHub Readme",
@@ -13403,5 +13396,12 @@
         "author": "ChenPengyuan",
         "description": "Add zoom and drag functionality to diagrams from Mermaid, Plantuml, Graphviz, Gravizo and so on",
         "repo": "gitcpy/diagram-zoom-drag"        
+    },
+	{
+        "id": "figma-embed",
+        "name": "Figma Embed",
+        "author": "Kyle Kochanek",
+        "description": "Embed Figma files as inline previews.",
+        "repo": "kocheck/obsidian-figma-viewer"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13110,6 +13110,13 @@
         "description": "Upload images from your clipboard to ImgBB.",
         "repo": "jordanhandy/obsidian-imgbb-uploader"
     },
+	{
+        "id": "figma-embed",
+        "name": "Figma Embed",
+        "author": "Kyle Kochanek",
+        "description": "Embed Figma files as inline previews in Obsidian.",
+        "repo": "kocheck/obsidian-figma-viewer"
+    },
     {
         "id": "import-github-readme",
         "name": "Import GitHub Readme",


### PR DESCRIPTION
Added kocheck/obsidian-figma-viewer plugin to community plugins.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [kocheck/obsidian-figma-viewer](https://github.com/kocheck/obsidian-figma-viewer)

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
