### PR TITLE
Add plugin: 复制图文 (Copy Image Text)

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13746,6 +13746,6 @@
   		"name": "复制图文 (Copy Image Text)",
   		"author": "msgk",
   		"description": "Copy note content (including text and images) to clipboard. 复制笔记内容（包括文本和图片）到剪贴板。",
-  		"repo": "msgk/obsidian-copy-image-text"
-  }
+  		"repo": "msgk239/obsidian-copy-image-text"
+	}
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13742,7 +13742,7 @@
     "repo": "alythobani/obsidian-callout-toggles"
 	},
 	{
-  		"id": "obsidian-copy-image-text",
+  		"id": "copy-image-text",
   		"name": "复制图文 (Copy Image Text)",
   		"author": "msgk",
   		"description": "Copy note content (including text and images) to clipboard. 复制笔记内容（包括文本和图片）到剪贴板。",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13740,5 +13740,12 @@
     "author": "Aly Thobani",
     "description": "Quickly add, change, or remove callouts in your notes.",
     "repo": "alythobani/obsidian-callout-toggles"
+	},
+	{
+  		"id": "obsidian-copy-image-text",
+  		"name": "复制图文 (Copy Image Text)",
+  		"author": "msgk",
+  		"description": "Copy note content (including text and images) to clipboard. 复制笔记内容（包括文本和图片）到剪贴板。",
+  		"repo": "msgk/obsidian-copy-image-text"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL
<!--- Paste a link to your repo here for easy access -->
https://github.com/msgk239/obsidian-copy-image-text

## Release Checklist
- [ ] I have tested the plugin on
  - [ x ]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [ x ] `main.js`
  - [ x ] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ x ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ x ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ x ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ x ] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [ x ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ x ] I have added a license in the LICENSE file.
- [ x ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
