### PR TITLE
Add plugin: Minimize on Close

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13440,13 +13440,90 @@
         "repo": "Signynt/obsidian-editing-mode-hotkey"
     },
     {
-        "id": "hierarchy",
-        "name": "Hierarchy",
-        "author": "Kodai Nakamura",
-        "description": "Visualize the hierarchy of your link.",
-        "repo": "kdnk/obsidian-hierarchy"
+        "id": "canvas-task-importer",
+        "name": "Canvas LMS Task Importer",
+        "author": "jordaeday",
+        "description": "Import assignments from Canvas LMS.",
+        "repo": "jordaeday/canvas-task-importer"
     },
     {
+        "id": "tokenz",
+        "name": "Tokenz",
+        "author": "Ferenc Moricz",
+        "description": "Insert any type of short codes into your document. You can add smileys (:), ;), ...) or emojis (:smile:, :wink:, ...). More code maps will be added later. Even you, as a user can create your own.",
+        "repo": "ferenk/obsidian-tokenz"
+    },
+	{
+		"id": "diarian",
+		"name": "Diarian",
+		"author": "Erika Gozar",
+		"description": "All-in-one journaling toolkit.",
+		"repo": "Erallie/diarian"
+	},
+    {
+        "id": "nexus-ai-chat-importer",
+        "name": "Nexus AI Chat Importer",
+        "author": "Superkikim",
+        "description": "Import conversations from ChatGPT export files.",
+        "repo": "superkikim/nexus-ai-chat-importer"
+    },
+    {
+        "id": "auto-periodic-notes",
+        "name": "Auto Periodic Notes",
+        "author": "Jamie Hurst",
+        "description": "Creates new periodic notes automatically in the background and allows these to be pinned in your open tabs, requires the Periodic Notes plugin.",
+        "repo": "jamiefdhurst/obsidian-auto-periodic-notes"
+    },
+    {
+        "id": "mesh-ai",
+        "name": "Mesh AI",
+        "author": "Chasebank87",
+        "description": "Enables you to store AI prompts as patterns and run them seemlessly with most providers.",
+        "repo": "chasebank87/mesh-ai"
+    },
+	{
+        "id": "onto-tracker",
+        "name": "Onto Tracker",
+        "author": "Jacob Hart",
+        "description": "Manage projects according to an ontology.",
+        "repo": "jdchart/onto-tracker"
+    },
+    {
+        "id": "journaling",
+        "name": "Journaling",
+        "author": "Ordeeper",
+        "description": "View daily notes in a journal-like format, similar to Logseq. It enhances note organization and facilitates better reflection by consolidating daily notes into a continuous journaling view.",
+        "repo": "Ordeeper/obsidian-journaling-plugin"
+    },
+    {
+        "id": "shortcut-edit-mode",
+        "name": "Edit mode switch",
+        "author": "Mara-Li",
+        "description": "Add a button in the file header, in edit mode, to switch between source and live-preview.",
+        "repo": "Mara-Li/obsidian-edit-shortcut"
+     },
+     {
+         "id": "print",
+         "name": "Print",
+         "author": "Marijn Bent",
+         "description": "A simple plugin to add a print action.",
+         "repo": "marijnbent/obsidian-print"
+    },
+     {
+        "id": "morgen-tasks",
+        "name": "Morgen Tasks",
+        "author": "Morgen AG",
+        "description": "Plan, time block, and track tasks from your vault in any calendar using Morgen.",
+        "repo": "morgen-so/morgen-obsidian"
+     },
+     {
+        "id": "immich",
+        "name": "Immich",
+        "author": "Talal Abou Haiba",
+        "description": "Link your Immich images within your vault.",
+        "repo": "Talal-A/obsidian-immich"
+     },
+     {
         "id": "minimize-on-close",
         "name": "Minimize on Close",
         "author": "Andrea Alberti",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13440,94 +13440,17 @@
         "repo": "Signynt/obsidian-editing-mode-hotkey"
     },
     {
-        "id": "canvas-task-importer",
-        "name": "Canvas LMS Task Importer",
-        "author": "jordaeday",
-        "description": "Import assignments from Canvas LMS.",
-        "repo": "jordaeday/canvas-task-importer"
+        "id": "hierarchy",
+        "name": "Hierarchy",
+        "author": "Kodai Nakamura",
+        "description": "Visualize the hierarchy of your link.",
+        "repo": "kdnk/obsidian-hierarchy"
     },
-    {
-        "id": "tokenz",
-        "name": "Tokenz",
-        "author": "Ferenc Moricz",
-        "description": "Insert any type of short codes into your document. You can add smileys (:), ;), ...) or emojis (:smile:, :wink:, ...). More code maps will be added later. Even you, as a user can create your own.",
-        "repo": "ferenk/obsidian-tokenz"
-    },
-	{
-		"id": "diarian",
-		"name": "Diarian",
-		"author": "Erika Gozar",
-		"description": "All-in-one journaling toolkit.",
-		"repo": "Erallie/diarian"
-	},
-    {
-        "id": "nexus-ai-chat-importer",
-        "name": "Nexus AI Chat Importer",
-        "author": "Superkikim",
-        "description": "Import conversations from ChatGPT export files.",
-        "repo": "superkikim/nexus-ai-chat-importer"
-    },
-    {
-        "id": "auto-periodic-notes",
-        "name": "Auto Periodic Notes",
-        "author": "Jamie Hurst",
-        "description": "Creates new periodic notes automatically in the background and allows these to be pinned in your open tabs, requires the Periodic Notes plugin.",
-        "repo": "jamiefdhurst/obsidian-auto-periodic-notes"
-    },
-    {
-        "id": "mesh-ai",
-        "name": "Mesh AI",
-        "author": "Chasebank87",
-        "description": "Enables you to store AI prompts as patterns and run them seemlessly with most providers.",
-        "repo": "chasebank87/mesh-ai"
-    },
-	{
-        "id": "onto-tracker",
-        "name": "Onto Tracker",
-        "author": "Jacob Hart",
-        "description": "Manage projects according to an ontology.",
-        "repo": "jdchart/onto-tracker"
-    },
-    {
-        "id": "journaling",
-        "name": "Journaling",
-        "author": "Ordeeper",
-        "description": "View daily notes in a journal-like format, similar to Logseq. It enhances note organization and facilitates better reflection by consolidating daily notes into a continuous journaling view.",
-        "repo": "Ordeeper/obsidian-journaling-plugin"
-    },
-    {
-        "id": "shortcut-edit-mode",
-        "name": "Edit mode switch",
-        "author": "Mara-Li",
-        "description": "Add a button in the file header, in edit mode, to switch between source and live-preview.",
-        "repo": "Mara-Li/obsidian-edit-shortcut"
-     },
-     {
-         "id": "print",
-         "name": "Print",
-         "author": "Marijn Bent",
-         "description": "A simple plugin to add a print action.",
-         "repo": "marijnbent/obsidian-print"
-    },
-     {
-        "id": "morgen-tasks",
-        "name": "Morgen Tasks",
-        "author": "Morgen AG",
-        "description": "Plan, time block, and track tasks from your vault in any calendar using Morgen.",
-        "repo": "morgen-so/morgen-obsidian"
-     },
-     {
-        "id": "immich",
-        "name": "Immich",
-        "author": "Talal Abou Haiba",
-        "description": "Link your Immich images within your vault.",
-        "repo": "Talal-A/obsidian-immich"
-     },
      {
         "id": "minimize-on-close",
         "name": "Minimize on Close",
         "author": "Andrea Alberti",
-        "description": "Minimizes Obsidian's window to icon after closing the last open pane",
-        "repo": "alberti42/obsidian-minimize-on-close"
+        "description": "Minimizes the app window to an icon after closing the last open pane",
+        "repo": "alberti42/obsidian-minimize-on-close" 
      }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13445,5 +13445,12 @@
         "author": "Kodai Nakamura",
         "description": "Visualize the hierarchy of your link.",
         "repo": "kdnk/obsidian-hierarchy"
-    }
+    },
+    {
+        "id": "minimize-on-close",
+        "name": "Minimize on Close",
+        "author": "Andrea Alberti",
+        "description": "Minimizes Obsidian's window to icon after closing the last open pane",
+        "repo": "alberti42/obsidian-minimize-on-close"
+     }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

This plugin for [Obsidian](https://obsidian.md/) minimizes the application window to the dock or taskbar when all open panes are closed. This behavior is particularly standard on macOS and can now be optionally applied across all platforms.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/alberti42/obsidian-minimize-on-close

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [X]  macOS
  - [X]  Linux
- [X] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
