### PR TITLE
Add plugin: Gravity Well

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13263,5 +13263,12 @@
         "author": "Talal Abou Haiba",
         "description": "Link your Immich images within your vault.",
         "repo": "Talal-A/obsidian-immich"
+    },
+    {
+        "id": "gravity_well",
+        "name": "Gravity Well",
+        "author": "John Major & Cal",
+        "description": "A tool to import text, markdown, and PDF files into Obsidian as new notes, add NPL derived tags, and track other properties.",
+        "repo": "iamh2o/gravity_well"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13268,7 +13268,7 @@
         "id": "gravity_well",
         "name": "Gravity Well",
         "author": "John Major & Cal",
-        "description": "A tool to import text, markdown, and PDF files into Obsidian as new notes, add NPL derived tags, and track other properties.",
+        "description": "A tool to import text, markdown, and PDF files as new notes, add NPL derived tags, and track other properties.",
         "repo": "iamh2o/gravity_well"
     }
 ]


### PR DESCRIPTION
Adding gravity_well txt/pdf/md file importer (with NLP tagging and metadata preservation).

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [https://github.com/iamh2o/gravity_well](https://github.com/iamh2o/gravity_well)

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows (no access to a windows machine)
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.

**my plugin runs via BRAT on my mac/linux box**