### PR TITLE
Add plugin: Attachmate

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13469,7 +13469,7 @@
   },
     {
         "id": "attachmate",
-        "name": "AttachMate",
+        "name": "Attachmate",
         "author": "Gustav Gnosspelius",
         "description": "Better handling of non-supported attachments.",
         "repo": "Gnopps/AttachMate"

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13466,5 +13466,12 @@
       "author": "ChenPengyuan",
       "description": "Show mermaid diagrams in a draggable and zoomable popup",
       "repo": "gitcpy/obsidian-mermaid-pop"
-  }
+  },
+    {
+        "id": "attachmate",
+        "name": "AttachMate",
+        "author": "Gustav Gnosspelius",
+        "description": "Better handling of non-supported attachments.",
+        "repo": "Gnopps/obsidian-rewarder"
+    },
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13472,6 +13472,6 @@
         "name": "AttachMate",
         "author": "Gustav Gnosspelius",
         "description": "Better handling of non-supported attachments.",
-        "repo": "Gnopps/obsidian-rewarder"
+        "repo": "Gnopps/AttachMate"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13473,5 +13473,5 @@
         "author": "Gustav Gnosspelius",
         "description": "Better handling of non-supported attachments.",
         "repo": "Gnopps/obsidian-rewarder"
-    },
+    }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Gnopps/AttachMate

## Release Checklist
- [ ] I have tested the plugin on
  - [X]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
