### PR TITLE
[Update]: rename mermaid popup to diagram popup

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13461,7 +13461,7 @@
         "repo": "jackvonhouse/custom-node-size"
   },
   {
-      "id": "Mermaid-popup",
+      "id": "mermaid-popup",
       "name": "Diagram Popup",
       "author": "ChenPengyuan",
       "description": "Show diagrams, from Mermaid, Plantuml, Graphviz and so on, in a draggable and zoomable popup",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13461,10 +13461,10 @@
         "repo": "jackvonhouse/custom-node-size"
   },
   {
-      "id": "diagram-popup",
+      "id": "Mermaid-popup",
       "name": "Diagram Popup",
       "author": "ChenPengyuan",
-      "description": "Show diagrams, from mermaid, plantuml, graphviz and so on, in a draggable and zoomable popup",
+      "description": "Show diagrams, from Mermaid, Plantuml, Graphviz and so on, in a draggable and zoomable popup",
       "repo": "gitcpy/obsidian-diagram-popup"
   },
   {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13464,7 +13464,7 @@
       "id": "mermaid-popup",
       "name": "Diagram Popup",
       "author": "ChenPengyuan",
-      "description": "Show diagrams, from Mermaid, Plantuml, Graphviz and so on, in a draggable and zoomable popup",
+      "description": "Show diagrams, from Mermaid, PlantUML, Graphviz and so on, in a draggable and zoomable popup",
       "repo": "gitcpy/obsidian-diagram-popup"
   },
   {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13461,11 +13461,11 @@
         "repo": "jackvonhouse/custom-node-size"
   },
   {
-      "id": "mermaid-popup",
-      "name": "Mermaid Popup",
+      "id": "diagram-popup",
+      "name": "Diagram Popup",
       "author": "ChenPengyuan",
-      "description": "Show mermaid diagrams in a draggable and zoomable popup",
-      "repo": "gitcpy/obsidian-mermaid-pop"
+      "description": "Show diagrams, from mermaid, plantuml, graphviz and so on, in a draggable and zoomable popup",
+      "repo": "gitcpy/obsidian-diagram-pop"
   },
   {
     "id": "newledge",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13465,7 +13465,7 @@
       "name": "Diagram Popup",
       "author": "ChenPengyuan",
       "description": "Show diagrams, from mermaid, plantuml, graphviz and so on, in a draggable and zoomable popup",
-      "repo": "gitcpy/obsidian-diagram-pop"
+      "repo": "gitcpy/obsidian-diagram-popup"
   },
   {
     "id": "newledge",


### PR DESCRIPTION
# I am renaming the Plugin Mermaid Popup to Diagram Popup

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/gitcpy/obsidian-diagram-popup

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.