### PR TITLE
Add plugin: Japanese Novel Ruby

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13669,5 +13669,12 @@
         "author": "ahts4962",
         "description": "Display navigation links at the top of the notes.",
         "repo": "ahts4962/nav-link-header"
-    }
+    },
+  {
+      "id": "japanese-novel-ruby",
+      "name": "Japanese Novel Ruby",
+      "author": "quels <@k-quels>",
+      "description": "Treat ruby(Furigana) ​​marks commonly used in Japanese novels",
+      "repo": "k-quels/japanese-novel-ruby"
+  }
 ]


### PR DESCRIPTION
Add Japanese Novel Ruby plugin

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/k-quels/japanese-novel-ruby

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.