### PR TITLE
Add plugin: Attachment Name Formatting

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13468,10 +13468,10 @@
       "repo": "gitcpy/obsidian-mermaid-pop"
   },
   {
-      "id": "obsidian-attachment-name-formatting",
+      "id": "attachment-name-formatting",
       "name": "Attachment Name Formatting",
       "author": "LogicalSapien",
       "description": "This plugin will format all attachments in the spacified format",
-      "repo": "https://github.com/LogicalSapien/obsidian-attachment-name-formatting"
+      "repo": "logicalsapien/obsidian-attachment-name-formatting"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13466,5 +13466,12 @@
       "author": "ChenPengyuan",
       "description": "Show mermaid diagrams in a draggable and zoomable popup",
       "repo": "gitcpy/obsidian-mermaid-pop"
+  },
+  {
+      "id": "obsidian-attachment-name-formatting",
+      "name": "Attachment Name Formatting",
+      "author": "LogicalSapien",
+      "description": "This plugin will format all attachments in the spacified format",
+      "repo": "https://github.com/LogicalSapien/obsidian-attachment-name-formatting"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

This PR continues the development of the previously archived plugin, which formats attachment names in Obsidian for better organization.

## Repo URL

Link to my plugin: https://github.com/LogicalSapien/obsidian-attachment-name-formatting

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - []  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
