### PR TITLE
Add plugin: Youtube Iframe Timestamps

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13723,7 +13723,7 @@
   {
     "id": "youtube-iframe-timestamps",
     "name": "Youtube Iframe Timestamps",
-    "description": "This Obsidian plugin allows you to embed YouTube videos with timestamps directly in your notes, enabling seamless referencing and note-taking without needing to open a separate browser window.",
+    "description": "Allows you to embed YouTube videos with timestamps directly in your notes, enabling seamless referencing and note-taking without needing to open a separate browser window.",
     "author": "Nils Leo",
     "repo": "NilsLeo/obsidian-youtube-iframe-timestamps"
   }

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13719,5 +13719,12 @@
     "author": "Lucas Langholf",
     "description": "Translations at your fingertips. Inline Translations for your Notes.",
     "repo": "kon-foo/Obsidian-Translate-Inline"
+  },
+  {
+    "id": "youtube-iframe-timestamps",
+    "name": "Youtube Iframe Timestamps",
+    "description": "This Obsidian plugin allows you to embed YouTube videos with timestamps directly in your notes, enabling seamless referencing and note-taking without needing to open a separate browser window.",
+    "author": "Nils Leo",
+    "repo": "NilsLeo/obsidian-youtube-iframe-timestamps"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:  https://github.com/NilsLeo/obsidian-youtube-iframe-timestamps

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
