### PR TITLE
Add plugin: Vault Full Statistics

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13468,6 +13468,13 @@
         "repo": "gitcpy/obsidian-mermaid-pop"
     },
     {
+        "id": "vault-full-statistics",
+        "name": "Vault Full Statistics",
+        "author": "Mikhail Savin",
+        "description": "Status bar item with vault full statistics such as number of notes, files, attachments, links, tags and quality of vault.",
+        "repo": "jtprogru/obsidian-vault-full-statistics-plugin"
+    },
+    {
         "id": "newledge",
         "name": "新枝Newledge",
         "author": "新枝Newledge",
@@ -13501,12 +13508,5 @@
         "author": "Titus",
         "description": "World building toolset with OnlyWorlds integration.",
         "repo": "OnlyWorlds/obsidian-plugin"
-    },
-    {
-        "id": "vault-full-statistics",
-        "name": "Vault Full Statistics",
-        "author": "Mikhail Savin",
-        "description": "Status bar item with vault full statistics such as number of notes, files, attachments, links, tags and quality of vault.",
-        "repo": "jtprogru/obsidian-vault-full-statistics-plugin"
     }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13446,60 +13446,67 @@
         "description": "Visualize the hierarchy of your link.",
         "repo": "kdnk/obsidian-hierarchy"
     },
-     {
+    {
         "id": "minimize-on-close",
         "name": "Minimize on Close",
         "author": "Andrea Alberti",
         "description": "Minimizes the app window to an icon after closing the last open pane",
         "repo": "alberti42/obsidian-minimize-on-close" 
-     },
+    },
     {
         "id": "custom-node-size",
         "name": "Custom Node Size",
         "author": "jackvonhouse",
         "description": "Customize nodes size for improved graph understanding.",
         "repo": "jackvonhouse/custom-node-size"
-  },
-  {
-      "id": "mermaid-popup",
-      "name": "Mermaid Popup",
-      "author": "ChenPengyuan",
-      "description": "Show mermaid diagrams in a draggable and zoomable popup",
-      "repo": "gitcpy/obsidian-mermaid-pop"
-  },
-  {
-    "id": "newledge",
-    "name": "新枝Newledge",
-    "author": "新枝Newledge",
-    "description": "Import Newledge data.",
-    "repo": "DepartingAgain/obsidian-newledge"
-  },
-  {
+    },
+    {
+        "id": "mermaid-popup",
+        "name": "Mermaid Popup",
+        "author": "ChenPengyuan",
+        "description": "Show mermaid diagrams in a draggable and zoomable popup",
+        "repo": "gitcpy/obsidian-mermaid-pop"
+    },
+    {
+        "id": "newledge",
+        "name": "新枝Newledge",
+        "author": "新枝Newledge",
+        "description": "Import Newledge data.",
+        "repo": "DepartingAgain/obsidian-newledge"
+    },
+    {
         "id": "immersive-translate",
         "name": "Immersive Translate",
         "author": "imfenghuang",
         "description": "A free-to-use translatation service for foreign language markdown file.",
         "repo": "imfenghuang/obsidian-immersive-translate"
-  },
-  {
-	"id": "scripture-indexer",
-	"name": "Scripture Indexer",
-	"author": "jdrbrn",
-	"description": "Indexes references to scriptures in notes.",
-	"repo": "jdrbrn/obsidian-scripture-indexer"
-  },
-  {
+    },
+    {
+	    "id": "scripture-indexer",
+    	"name": "Scripture Indexer",
+	    "author": "jdrbrn",
+    	"description": "Indexes references to scriptures in notes.",
+	    "repo": "jdrbrn/obsidian-scripture-indexer"
+    },
+    {
         "id": "open-sidebar-on-hover",
         "name": "Open Sidebar on Hover",
         "author": "AnAngryRaven",
         "description": "Enables the ability to open the sidebar by hovering over it.",
         "repo": "AnAngryRaven/obsidian-open-sidebar-on-hover"
-  },
-  {
-    "id": "onlyworlds-builder",
-    "name": "OnlyWorlds Builder",
-    "author": "Titus",
-    "description": "World building toolset with OnlyWorlds integration.",
-    "repo": "OnlyWorlds/obsidian-plugin"
-  }
+    },
+    {
+        "id": "onlyworlds-builder",
+        "name": "OnlyWorlds Builder",
+        "author": "Titus",
+        "description": "World building toolset with OnlyWorlds integration.",
+        "repo": "OnlyWorlds/obsidian-plugin"
+    },
+    {
+        "id": "vault-full-statistics",
+        "name": "Vault Full Statistics",
+        "author": "Mikhail Savin",
+        "description": "Status bar item with vault full statistics such as number of notes, files, attachments, links, tags and quality of vault.",
+        "repo": "jtprogru/obsidian-vault-full-statistics-plugin"
+    }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13508,5 +13508,12 @@
         "author": "Titus",
         "description": "World building toolset with OnlyWorlds integration.",
         "repo": "OnlyWorlds/obsidian-plugin"
+    },
+    {
+        "id": "vault-full-statistics",
+        "name": "Vault Full Statistics",
+        "author": "Mikhail Savin",
+        "description": "Status bar item with vault full statistics such as number of notes, files, attachments, links, tags and quality of vault.",
+        "repo": "jtprogru/obsidian-vault-full-statistics-plugin"
     }
 ]


### PR DESCRIPTION
Add plugin "vault-full-statistics" and formatting file.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/jtprogru/obsidian-vault-full-statistics-plugin/

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
