### PR TITLE
Update: Move obsidian-findoc repo to studiowebux github organization

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6773,7 +6773,7 @@
         "name": "Financial Doc",
         "author": "Studio Webux",
         "description": "Financial documentation and tracking using CSV format and Chart.js.",
-        "repo": "yet-another-tool/obsidian-findoc"
+        "repo": "studiowebux/obsidian-findoc"
     },
     {
         "id": "file-include",


### PR DESCRIPTION
Hello, 

I created the findoc plugin a while ago, 
I am cleaning up my github organizations and moving everything to my main account "studiowebux".

So this PR is only renaming the repo url.

Can I move my repo before your approval ? 

Thanks you !