### PR TITLE
Add plugin: SVG Style Editor

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13929,6 +13929,13 @@
     "author": "hafuhafu",
     "description": "A search bar that supports search, replace, regular expressions, and case sensitivity.",
     "repo": "nyable/obsidian-text-finder"
+  },
+  {
+    "id": "obsidian-svg-styler",
+    "name": "SVG Style Editor",
+    "author": "ARGOSTA",
+    "description": "Change the style properies of an embded SVG file",
+    "repo": "arg1998/obsidian-svg-styler"
 }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13931,7 +13931,7 @@
     "repo": "nyable/obsidian-text-finder"
   },
   {
-    "id": "obsidian-svg-styler",
+    "id": "argosta-svg-styler",
     "name": "SVG Style Editor",
     "author": "ARGOSTA",
     "description": "Change the style properies of an embded SVG file",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13931,10 +13931,10 @@
     "repo": "nyable/obsidian-text-finder"
   },
   {
-    "id": "argosta-svg-styler",
+    "id": "svg-styler",
     "name": "SVG Style Editor",
     "author": "ARGOSTA",
-    "description": "Change the style properies of an embded SVG file",
+    "description": "Change the color and other style properies of an embded SVG file",
     "repo": "arg1998/obsidian-svg-styler"
 }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

Description from the original repository:
 > Obsidian SVG Styler is a simple plugin designed to help you easily modify the style properties of SVG images directly within the editor. With this plugin, you can customize properties like color, border, opacity, and more. Supported drawable tags include: `path`, `line`, `rect`, `circle`, `ellipse`, and `polygon`.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
[arg1998/obsidian-svg-styler](https://github.com/arg1998/obsidian-svg-styler)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
