### PR TITLE
Add obsidian-auto-complete plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,4 +1,11 @@
 [
+    {
+        "id": "obsidian-auto-correct",
+        "name": "Obsidian Auto Correct",
+        "author": "optimizeforall",
+        "description": "Auto corrects your markdown files using OpenAI's GPT-3.5 and GPT-4o Mini.",
+        "repo": "optimizeforall/obsidian-auto-correct"
+    },
 {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,11 +1,4 @@
 [
-    {
-        "id": "obsidian-auto-correct",
-        "name": "Obsidian Auto Correct",
-        "author": "optimizeforall",
-        "description": "Auto corrects your markdown files using OpenAI's GPT-3.5 and GPT-4o Mini.",
-        "repo": "optimizeforall/obsidian-auto-correct"
-    },
 {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
@@ -13508,5 +13501,12 @@
     "author": "Titus",
     "description": "World building toolset with OnlyWorlds integration.",
     "repo": "OnlyWorlds/obsidian-plugin"
-  }
+  },
+  {
+    "id": "obsidian-auto-correct",
+    "name": "Obsidian Auto Correct",
+    "author": "optimizeforall",
+    "description": "Auto corrects your markdown files using OpenAI's GPT-3.5 and GPT-4o Mini.",
+    "repo": "optimizeforall/obsidian-auto-correct"
+}
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [obsidian-auto-correct](https://github.com/optimizeforall/obsidian-auto-correct/tree/main)

## Release Checklist
- [x] I have tested the plugin on (
  - [x]  Windows ( it's difficult for me to test on Windows. However, the plugin is designed to be cross-platform, I will test soon and update here, but am 95% sure it works )
  - [ ]  macOS (don't have access to one atm)
  - [x]  Linux (Works perfectly
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all necessary files.

- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [n/a] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
