### PR TITLE
Add plugin: GitHub Repo Notes

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13501,5 +13501,12 @@
     "author": "Titus",
     "description": "World building toolset with OnlyWorlds integration.",
     "repo": "OnlyWorlds/obsidian-plugin"
+  },
+  {
+		"id": "github-repo-notes",
+	  "name": "GitHub Repo Notes",
+	  "author": "eLafo",
+	  "description": "An Obsidian plugin to create notes from GitHub repository URLs.",
+	  "repo": "eLafo/github-repo-notes"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13506,7 +13506,7 @@
 		"id": "github-repo-notes",
 	  "name": "GitHub Repo Notes",
 	  "author": "eLafo",
-	  "description": "An Obsidian plugin to create notes from GitHub repository URLs.",
+	  "description": "Create notes from GitHub repository URLs.",
 	  "repo": "eLafo/github-repo-notes"
   }
 ]


### PR DESCRIPTION
Adds github-repo-notes plugin

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/eLafo/github-repo-notes

## Release Checklist
- [x] I have tested the plugin on
  - []  Windows
  - [x]  macOS
  - []  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
