### PR TITLE
Add plugin: Send note via email

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13613,5 +13613,5 @@
         "author": "Sentiago",
         "description": "Send your markdown note via email",
         "repo": "Ssentiago/obdidian-send-note-via-email"
-	},
+	}
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13601,10 +13601,10 @@
 		"repo": "DvorakDwarf/scrambling-title-animations"
     },
     {
-        "id": "lemons-search",
-        "name": "Lemons Search",
-        "author": "Moritz Jung",
-        "description": "A blazingly fast fuzzy finder with file preview.",
-        "repo": "mProjectsCode/obsidian-lemons-search-plugin"
-	}
+        "id": "send-note-via-email",
+        "name": "Send note via email",
+        "author": "Sentiago",
+        "description": "Send your markdown note via email",
+        "repo": "Ssentiago/obdidian-send-note-via-email"
+	},
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13599,7 +13599,14 @@
 		"author": "HistidineDwarf",
 		"description": "Animates the title of any note you open by scrambling and revealing it in several visually appealing ways.",
 		"repo": "DvorakDwarf/scrambling-title-animations"
-    },
+    }, 
+	{
+	 "id": "lemons-search",
+        "name": "Lemons Search",
+        "author": "Moritz Jung",
+        "description": "A blazingly fast fuzzy finder with file preview.",
+        "repo": "mProjectsCode/obsidian-lemons-search-plugin"
+	},
     {
         "id": "send-note-via-email",
         "name": "Send note via email",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13612,7 +13612,7 @@
         "name": "Send note via email",
         "author": "Sentiago",
         "description": "Send your markdown note via email",
-        "repo": "Ssentiago/obdidian-send-note-via-email"
+        "repo": "Ssentiago/obsidian-send-note-via-email"
 	}
 	
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13614,4 +13614,5 @@
         "description": "Send your markdown note via email",
         "repo": "Ssentiago/obdidian-send-note-via-email"
 	}
+	
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13599,7 +13599,7 @@
 		"author": "HistidineDwarf",
 		"description": "Animates the title of any note you open by scrambling and revealing it in several visually appealing ways.",
 		"repo": "DvorakDwarf/scrambling-title-animations"
-    }, 
+    },
     {
         "id": "lemons-search",
         "name": "Lemons Search",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13600,8 +13600,8 @@
 		"description": "Animates the title of any note you open by scrambling and revealing it in several visually appealing ways.",
 		"repo": "DvorakDwarf/scrambling-title-animations"
     }, 
-	{
-	 "id": "lemons-search",
+    {
+        "id": "lemons-search",
         "name": "Lemons Search",
         "author": "Moritz Jung",
         "description": "A blazingly fast fuzzy finder with file preview.",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Ssentiago/obdidian-send-note-via-email

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
