### PR TITLE
Update plugin: Pexels Banner

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13314,11 +13314,11 @@
         "repo": "Epiphany-Notes/epiphany-obsidian-plugin"
     },
     {
-        "id": "pexels-banner",
-        "name": "Pexels Banner",
+        "id": "pixel-banner",
+        "name": "Pixel Banner",
         "author": "Justin Parker",
-        "description": "Apply an image from Pexels as a banner to your notes.",
-        "repo": "jparkerweb/pexels-banner"
+        "description": "Apply an image from various sources as a banner to your notes.",
+        "repo": "jparkerweb/pixel-banner"
     },
     {
         "id": "rich-foot",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13314,7 +13314,7 @@
         "repo": "Epiphany-Notes/epiphany-obsidian-plugin"
     },
     {
-        "id": "pixel-banner",
+        "id": "pexels-banner",
         "name": "Pixel Banner",
         "author": "Justin Parker",
         "description": "Apply an image from various sources as a banner to your notes.",


### PR DESCRIPTION
rename / rebrand `Pexels-Banner` to `Pixel-Banner`

# I am renaming my existing Community Plugin

old repo: https://github.com/jparkerweb/pexels-banner
rename repo: https://github.com/jparkerweb/pixel-banner

---

As I now support more than just the "Pexels" API it is fitting to update the Plugin name to be more generic.

Thank you :)