### PR TITLE
Added obsidian-canvas-viewport

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13606,5 +13606,13 @@
         "author": "Moritz Jung",
         "description": "A blazingly fast fuzzy finder with file preview.",
         "repo": "mProjectsCode/obsidian-lemons-search-plugin"
-	}
-]
+	},
+    {
+        "id": "obsidian-canvas-viewport",
+        "name": "Canvas Viewport",
+        "author": "Mattia Traverso",
+        "description": "Save and restore viewports for Canvas views",
+        "repo": "MattiaTraverso/obsidian-canvas-viewport",
+        "branch": "main"
+    }
+}


### PR DESCRIPTION
Added plugin to save viewport position and zoom values to restore them later on your canvas.

# I am submitting a new Community Plugin

## Repo URL
Link to my plugin: https://github.com/MattiaTraverso/obsidian-canvas-viewport/

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [X]  macOS
  - [X]  Linux
  - [ ]  Android _(if applicable)_
  - [X]  iOS _(if applicable)_
- [X] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
