### PR TITLE
Add "Todos sort" plugin by @jsifalda

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13606,5 +13606,12 @@
         "author": "Moritz Jung",
         "description": "A blazingly fast fuzzy finder with file preview.",
         "repo": "mProjectsCode/obsidian-lemons-search-plugin"
+	},
+	{
+	  "id": "obsidian-todos-sort",
+	  "name": "Todos sort",
+	  "description": "A plugin for Obsidian (https://obsidian.md) that sorts todos by completion status.",
+	  "author": "@jsifalda",
+	  "repo": "jsifalda/obsidian-todos-sort"
 	}
 ]


### PR DESCRIPTION
A plugin for Obsidian that sorts todos by completion status

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
