### PR TITLE
Name Change : AndreasSasDev to AnnaSasDev

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8906,7 +8906,7 @@
     {
         "id": "colored-tags-wrangler",
         "name": "Colored Tags Wrangler",
-        "author": "AndreasSasDev",
+        "author": "AnnaSasDev",
         "description": "Assign colors to tags. Has integrations with other plugins, like Kanban.",
         "repo": "code-of-chaos/obsidian-colored_tags_wrangler"
     },


### PR DESCRIPTION
I'm transitioning and it would be nice to be able to have my name change be reflected for the plugin I have named under my old name.