### PR TITLE
Add plugin: Gemini Scribe

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14035,10 +14035,10 @@
      "repo": "Hosstell/image-tools-obsidian-plugin" 
   },
   {
-    "id": "obsidian-gemini",
-    "name": "Gemini Plugin for Obsidian",
+    "id": "gemini-scribe",
+    "name": "Gemini Scribe",
     "author": "Allen Hutchison",
-    "description": "Gemini Plugin for Obsidian, allows you to interact with the model and use your notes as context.",
+    "description": "Gemini Scribe, allows you to interact with the model and use your notes as context.",
     "repo": "allenhutchison/obsidian-gemini"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14033,5 +14033,12 @@
      "author": "Andrey Serov",
      "description": "Formatter for image on page.",
      "repo": "Hosstell/image-tools-obsidian-plugin" 
+  },
+  {
+    "id": "obsidian-gemini",
+    "name": "Gemini Plugin for Obsidian",
+    "author": "Allen Hutchison",
+    "description": "Gemini Plugin for Obsidian, allows you to interact with the model and use your notes as context.",
+    "repo": "allenhutchison/obsidian-gemini"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14038,7 +14038,7 @@
     "id": "gemini-scribe",
     "name": "Gemini Scribe",
     "author": "Allen Hutchison",
-    "description": "Gemini Scribe, allows you to interact with the model and use your notes as context.",
+    "description": "Allows you to interact with Gemini and use your notes as context.",
     "repo": "allenhutchison/obsidian-gemini"
   }
 ]


### PR DESCRIPTION
Add obsidian-gemini plugin.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/allenhutchison/obsidian-gemini

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [X]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [X]  iOS _(if applicable)_
- [X] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
