### PR TITLE
Description change: update UNITADE's plugin description because of it's update

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7542,7 +7542,7 @@
         "id": "unitade",
         "name": "UNITADE.md",
         "author": "Falcion",
-        "description": "Effortlessly treat any file extension as note, organize diverse file formats in your vault and take advancements in control of extension system even with custom modals.",
+        "description": "Treat any file as any view, code editor and syntax highlighting, modals for creating and renaming files, assign views for files, unloading registries and many more for advanced work with non-markdown files.",
         "repo": "Falcion/UNITADE.md"
     },
     {


### PR DESCRIPTION
# I am submitting a new Community Plugin

The UNITADE plugin has received a massive update and its current description is no longer up to date, the description now includes elements of the old one and explains the new functionality in brief.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Falcion/UNITADE.md

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
