### PR TITLE
Add plugin: Quick Share Note to Gist

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13740,12 +13740,19 @@
 	"author": "Alexey Sedoykin",
 	"description": "Find and highlight all occurrences of selected text in notes, similar to Notepad++ or IDEs.",
 	"repo": "Krusty84/obsidian-occura-plugin"
-    },
+  },
   {
     "id": "callout-toggles",
     "name": "Callout Toggles",
     "author": "Aly Thobani",
     "description": "Quickly add, change, or remove callouts in your notes.",
     "repo": "alythobani/obsidian-callout-toggles"
+  },
+  {
+    "id": "share-note-img-with-gist",
+    "name": "Quick Share Note to Gist",
+    "author": "Por Chainarong Tangsurakit",
+    "description": "Quick publish and share Obsidian notes to GitHub Gist and its image by upload images to Imgur.",
+    "repo": "chaintng/quick-share-note-to-gist"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13740,7 +13740,7 @@
 	"author": "Alexey Sedoykin",
 	"description": "Find and highlight all occurrences of selected text in notes, similar to Notepad++ or IDEs.",
 	"repo": "Krusty84/obsidian-occura-plugin"
-  },
+    },
   {
     "id": "callout-toggles",
     "name": "Callout Toggles",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13754,5 +13754,5 @@
     "author": "Por Chainarong Tangsurakit",
     "description": "Quick publish and share Obsidian notes to GitHub Gist and its image by upload images to Imgur.",
     "repo": "chaintng/quick-share-note-to-gist"
-  }
+  },
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13754,5 +13754,5 @@
     "author": "Por Chainarong Tangsurakit",
     "description": "Quick publish and share Obsidian notes to GitHub Gist and its image by upload images to Imgur.",
     "repo": "chaintng/quick-share-note-to-gist"
-  },
+  }
 ]


### PR DESCRIPTION
Quick publish and share notes to GitHub Gist and its image by upload images to Imgur.

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
