### PR TITLE
Add Separate Explorer Views plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,0 +1,13758 @@
+[
+{
+        "id": "nldates-obsidian",
+        "name": "Natural Language Dates",
+        "author": "Argentina Ortega Sainz",
+        "description": "Create date-links based on natural language.",
+        "repo": "argenos/nldates-obsidian"
+    },
+    {
+        "id": "hotkeysplus-obsidian",
+        "name": "Hotkeys++",
+        "author": "Argentina Ortega Sainz",
+        "description": "Additional hotkeys to do common things.",
+        "repo": "argenos/hotkeysplus-obsidian"
+    },
+    {
+        "id": "obsidian-git",
+        "name": "Git",
+        "author": "Vinzent, (Denis Olehov)",
+        "description": "Integrate Git version control with automatic backup and other advanced features.",
+        "repo": "Vinzent03/obsidian-git"
+    },
+    {
+        "id": "url-into-selection",
+        "name": "Paste URL into selection",
+        "author": "Denis Olehov",
+        "description": "Paste URL \"into\" selected text.",
+        "repo": "denolehov/obsidian-url-into-selection"
+    },
+    {
+        "id": "table-editor-obsidian",
+        "name": "Advanced Tables",
+        "author": "Tony Grosinger",
+        "description": "Improved table navigation, formatting, and manipulation.",
+        "repo": "tgrosinger/advanced-tables-obsidian"
+    },
+    {
+        "id": "leader-hotkeys-obsidian",
+        "name": "Leader Hotkeys",
+        "author": "Tony Grosinger",
+        "description": "Add leader hotkey support to any command (like tmux or vim).",
+        "repo": "tgrosinger/leader-hotkeys-obsidian"
+    },
+    {
+        "id": "recent-files-obsidian",
+        "name": "Recent Files",
+        "author": "Tony Grosinger",
+        "description": "Display a list of recently opened files.",
+        "repo": "tgrosinger/recent-files-obsidian"
+    },
+    {
+        "id": "ledger-obsidian",
+        "name": "Ledger",
+        "author": "Tony Grosinger",
+        "description": "Plain text accounting.",
+        "repo": "tgrosinger/ledger-obsidian"
+    },
+    {
+        "id": "note-refactor-obsidian",
+        "name": "Note Refactor",
+        "author": "James Lynch",
+        "description": "Extract note content into new notes and split notes.",
+        "repo": "lynchjames/note-refactor-obsidian"
+    },
+    {
+        "id": "calendar",
+        "name": "Calendar",
+        "author": "Liam Cain",
+        "description": "Simple calendar widget.",
+        "repo": "liamcain/obsidian-calendar-plugin"
+    },
+    {
+        "id": "mrj-text-expand",
+        "name": "Text expand",
+        "author": "MrJackphil",
+        "description": "Search and paste/transclude links to found files.",
+        "repo": "mrjackphil/obsidian-text-expand"
+    },
+    {
+        "id": "mrj-jump-to-link",
+        "name": "Jump to link",
+        "author": "MrJackphil",
+        "description": "Quickly navigate between links, or jump to any word on the page using hotkeys.",
+        "repo": "mrjackphil/obsidian-jump-to-link"
+    },
+    {
+        "id": "obsidian-reading-time",
+        "name": "Reading Time",
+        "author": "avr",
+        "description": "Add the current note's reading time to the status bar.",
+        "repo": "avr/obsidian-reading-time"
+    },
+    {
+        "id": "todoist-sync-plugin",
+        "name": "Todoist Sync",
+        "author": "jamiebrynes7",
+        "description": "Materialize Todoist tasks within your notes.",
+        "repo": "jamiebrynes7/obsidian-todoist-plugin"
+    },
+    {
+        "id": "obsidian-vimrc-support",
+        "name": "Vimrc Support",
+        "author": "esm",
+        "description": "Auto-load a startup file with Vim commands.",
+        "repo": "esm7/obsidian-vimrc-support"
+    },
+    {
+        "id": "shortcuts-extender",
+        "name": "Shortcuts extender",
+        "author": "kitchenrunner",
+        "description": "Use shortcuts for input special symbols without language switching.",
+        "repo": "ryjjin/Obsidian-shortcuts-extender"
+    },
+    {
+        "id": "mrj-crosslink-between-notes",
+        "name": "Add links to current note",
+        "author": "MrJackphil",
+        "description": "A command to add a link to the current note at the bottom of selected notes.",
+        "repo": "mrjackphil/obsidian-crosslink-between-notes"
+    },
+    {
+        "id": "darlal-switcher-plus",
+        "name": "Quick Switcher++",
+        "author": "darlal",
+        "description": "Enhanced Quick Switcher, search open panels, and symbols.",
+        "repo": "darlal/obsidian-switcher-plus"
+    },
+    {
+        "id": "obsidian-day-planner",
+        "name": "Day Planner",
+        "author": "James Lynch (continued by Ivan Lednev)",
+        "description": "Day planning from a task list in a Markdown note with enhanced time block functionality.",
+        "repo": "ivan-lednev/obsidian-day-planner"
+    },
+    {
+        "id": "review-obsidian",
+        "name": "Review",
+        "author": "ryanjamurphy",
+        "description": "Add a link to the current note to a daily note on a future date (or a past date, you time traveller).",
+        "repo": "ryanjamurphy/review-obsidian"
+    },
+    {
+        "id": "obsidian-hider",
+        "name": "Hider",
+        "author": "@kepano",
+        "description": "Hide UI elements such as tooltips, status, titlebar and more.",
+        "repo": "kepano/obsidian-hider"
+    },
+    {
+        "id": "obsidian-minimal-settings",
+        "name": "Minimal Theme Settings",
+        "author": "@kepano",
+        "description": "Control the colors and fonts in Minimal Theme.",
+        "repo": "kepano/obsidian-minimal-settings"
+    },
+    {
+        "id": "obsidian-discordrpc",
+        "name": "Discord Rich Presence",
+        "author": "Luke Leppan",
+        "description": "Update your Discord Status to show your friends what you are working on.",
+        "repo": "lukeleppan/obsidian-discordrpc"
+    },
+    {
+        "id": "templater-obsidian",
+        "name": "Templater",
+        "author": "SilentVoid",
+        "description": "Create and use templates.",
+        "repo": "SilentVoid13/Templater"
+    },
+    {
+        "id": "convert-url-to-iframe",
+        "name": "Convert url to preview (iframe)",
+        "author": "FHachez",
+        "description": "Convert a URL (e.g. YouTube) into an iframe (preview).",
+        "repo": "FHachez/obsidian-convert-url-to-iframe"
+    },
+    {
+        "id": "searchpp",
+        "name": "Search++",
+        "author": "Noureddine Haouari",
+        "description": "Insert text context search results in the active note.",
+        "repo": "nhaouari/searchpp"
+    },
+    {
+        "id": "better-word-count",
+        "name": "Better Word Count",
+        "author": "Luke Leppan",
+        "description": "Count the words of selected text in the editor.",
+        "repo": "lukeleppan/better-word-count"
+    },
+    {
+        "id": "workbench-obsidian",
+        "name": "Workbench",
+        "author": "ryanjamurphy",
+        "description": "Keep a workbench of knowledge materials.",
+        "repo": "ryanjamurphy/workbench-obsidian"
+    },
+    {
+        "id": "obsidian-latex-environments",
+        "name": "Latex Environments",
+        "author": "Zach Raines",
+        "description": "Quickly insert and change LaTeX environments within math environments.",
+        "repo": "raineszm/obsidian-latex-environments"
+    },
+    {
+        "id": "obsidian-rtl",
+        "name": "RTL Support",
+        "author": "esm",
+        "description": "Right-to-left (RTL) text direction support for languages like Arabic, Hebrew, and Farsi.",
+        "repo": "esm7/obsidian-rtl"
+    },
+    {
+        "id": "markdown-prettifier",
+        "name": "Markdown prettifier",
+        "description": "Fix and reformats ugly Markdown.",
+        "author": "pelao",
+        "repo": "cristianvasquez/obsidian-prettify"
+    },
+    {
+        "id": "css-snippets",
+        "name": "css snippets",
+        "description": "Load and manage CSS snippets.",
+        "author": "Daniel Brandenburg",
+        "repo": "jdbrice/obsidian-css-snippets"
+    },
+    {
+        "id": "obsidian-link-indexer",
+        "name": "Link indexer",
+        "description": "Generate index notes with links based on various conditions.",
+        "author": "Yuliya Bagriy",
+        "repo": "aviskase/obsidian-link-indexer"
+    },
+    {
+        "id": "macOS-keyboard-nav-obsidian",
+        "name": "macOS Keyboard Navigation",
+        "description": "Enable alt+\u2191 and alt+\u2193 keyboard navigation.",
+        "author": "ryanjamurphy",
+        "repo": "ryanjamurphy/macOS-keyboard-nav-obsidian"
+    },
+    {
+        "id": "extract-highlights-plugin",
+        "name": "Extract Highlights",
+        "description": "Extract all ==highlights== in a note into your clipboard.",
+        "author": "Alexis Rondeau",
+        "repo": "akaalias/extract-highlights-plugin"
+    },
+    {
+        "id": "find-unlinked-files",
+        "name": "Find orphaned files and broken links",
+        "description": "Find files that are not linked anywhere and would otherwise be lost in your vault. In other words: files with no backlinks.",
+        "author": "Vinzent",
+        "repo": "Vinzent03/find-unlinked-files"
+    },
+    {
+        "id": "wikilinks-to-mdlinks-obsidian",
+        "name": "Wikilinks to MDLinks",
+        "author": "Agatha Uy",
+        "description": "Convert wikilinks to Markdown links and vice versa.",
+        "repo": "agathauy/wikilinks-to-mdlinks-obsidian"
+    },
+    {
+        "id": "smart-random-note",
+        "name": "Smart Random Note",
+        "author": "Eric Hall",
+        "description": "Open random notes with greater control.",
+        "repo": "erichalldev/obsidian-smart-random-note"
+    },
+    {
+        "id": "cycle-through-panes",
+        "name": "Tab Switcher",
+        "author": "Vinzent & phibr0",
+        "description": "Switch your tabs with Ctrl + Tab in recently used order like in a browser.",
+        "repo": "Vinzent03/tab-switcher"
+    },
+    {
+        "id": "music-code-blocks",
+        "name": "ABC Music Notation",
+        "author": "Til Blechschmidt",
+        "description": "Render music sheets directly from code blocks using ABC music notation via abcjs.",
+        "repo": "abcjs-music/obsidian-plugin-abcjs"
+    },
+    {
+        "id": "cm-typewriter-scroll-obsidian",
+        "name": "Typewriter Scroll",
+        "author": "death_au",
+        "description": "Typewriter-style scrolling which keeps the view centered in the editor.",
+        "repo": "deathau/cm-typewriter-scroll-obsidian"
+    },
+    {
+        "id": "obsidian-youglish-plugin",
+        "name": "Youglish",
+        "description": "Use YouTube to improve your pronunciation. YouGlish gives you fast, unbiased answers about how words is spoken by real people and in context.",
+        "author": "Noureddine Haouari",
+        "repo": "nhaouari/obsidian-youglish-plugin"
+    },
+    {
+        "id": "obsidian-dangling-links",
+        "name": "Dangling links",
+        "author": "Graydon Hoare",
+        "description": "Add a sidebar showing any dangling links in a vault. Dangling links are orphaned links that don't point to anything in the vault.",
+        "repo": "graydon/obsidian-dangling-links"
+    },
+    {
+        "id": "dangerzone-writing-plugin",
+        "name": "Dangerzone Writing",
+        "author": "Alexis Rondeau",
+        "description": "This plugin is dangerous! When you start it, you have to write without stopping for 100 seconds. If you stop, think and look around, after 3 seconds the plugin will DELETE what you've written in this note.",
+        "repo": "akaalias/dangerzone-writing-plugin"
+    },
+    {
+        "id": "maximise-active-pane-obsidian",
+        "name": "Maximise Active Pane",
+        "author": "death_au",
+        "description": "Fill the workspace with the active pane.",
+        "repo": "deathau/maximise-active-pane-obsidian"
+    },
+    {
+        "id": "obsidian-juliandate",
+        "name": "Julian Date",
+        "author": "thek3nger",
+        "description": "Add a shortcut to insert the current Julian date for astronomical observations.",
+        "repo": "THeK3nger/obsidian-juliandate"
+    },
+    {
+        "id": "obsidian-emoji-toolbar",
+        "name": "Emoji Toolbar",
+        "author": "oliveryh",
+        "description": "Quickly search for and insert emojis into your editor.",
+        "repo": "oliveryh/obsidian-emoji-toolbar"
+    },
+    {
+        "id": "obsidian-fullscreen-plugin",
+        "name": "Fullscreen Focus Mode",
+        "author": "Razum",
+        "description": "Add a command to view a single document leaf in a fullscreen focus mode.",
+        "repo": "Razumihin/obsidian-fullscreen-plugin"
+    },
+    {
+        "id": "footlinks",
+        "name": "Footlinks",
+        "author": "Daha",
+        "description": "Extract URLs from main text to footer.",
+        "repo": "DahaWong/obsidian-footlinks"
+    },
+    {
+        "id": "obsidian-mind-map",
+        "name": "Mind Map",
+        "author": "James Lynch",
+        "description": "Display Markdown notes as mind maps using Markmap.",
+        "repo": "lynchjames/obsidian-mind-map"
+    },
+    {
+        "id": "flashcards-obsidian",
+        "name": "Flashcards",
+        "author": "Alex Colucci",
+        "description": "Anki integration.",
+        "repo": "reuseman/flashcards-obsidian"
+    },
+    {
+        "id": "completed-area",
+        "name": "Completed Area",
+        "author": "Daha",
+        "description": "Move completed to-do items to a separate completed area.",
+        "repo": "DahaWong/obsidian-completed-area"
+    },
+    {
+        "id": "obsidian-citation-plugin",
+        "name": "Citations",
+        "author": "Jon Gauthier",
+        "description": "Automatically search and insert citations from a Zotero library.",
+        "repo": "hans/obsidian-citation-plugin"
+    },
+    {
+        "id": "obsidian-to-anki-plugin",
+        "name": "Export to Anki",
+        "author": "Pseudonium",
+        "description": "Anki integration designed for efficient bulk exporting. Previously known as Obsidian_to_Anki.",
+        "repo": "Pseudonium/Obsidian_to_Anki"
+    },
+    {
+        "id": "obsidian-rollover-daily-todos",
+        "name": "Rollover Daily Todos",
+        "author": "Matt Sessions",
+        "description": "Rollover any unchecked checkboxes from your last daily note into today's note.",
+        "repo": "lumoe/obsidian-rollover-daily-todos"
+    },
+    {
+        "id": "obsidian-reveal-active-file",
+        "name": "Automatically reveal active file",
+        "author": "Matt Sessions",
+        "description": "Automatically reveal the currently active file in the side navigation.",
+        "repo": "shichongrui/obsidian-reveal-active-file"
+    },
+    {
+        "id": "obsidian-export-to-tex",
+        "name": "Export To TeX",
+        "author": "Zach Raines",
+        "description": "Export vault files in a format amenable to pasting into a TeX document.",
+        "repo": "raineszm/obsidian-export-to-tex"
+    },
+    {
+        "id": "obsidian-latex",
+        "name": "Extended MathJax",
+        "author": "Xavier Denis & Ng Wei En",
+        "description": "Enable additional MathJax packages and adds a global preamble for MathJax.",
+        "repo": "wei2912/obsidian-latex"
+    },
+    {
+        "id": "obsidian-apple-reminders-plugin",
+        "name": "Apple Reminders",
+        "author": "Rishi Raval",
+        "description": "Import Apple Reminders.",
+        "repo": "urishiraval/obsidian-apple-reminders-plugin"
+    },
+    {
+        "id": "obsidian-contextual-typography",
+        "name": "Contextual Typography",
+        "author": "mgmeyers",
+        "description": "Add a data-tag-name attribute to all top-level divs in preview mode containing the child's tag name, allowing contextual typography styling.",
+        "repo": "mgmeyers/obsidian-contextual-typography"
+    },
+    {
+        "id": "neo4j-graph-view",
+        "name": "Neo4j Graph View",
+        "author": "Emile van Krieken",
+        "description": "Advanced graph visualization and querying using Neo4j.",
+        "repo": "HEmile/obsidian-neo4j-graph-view"
+    },
+    {
+        "id": "snippets",
+        "name": "Snippets",
+        "author": "Pelao",
+        "description": "Execute simple scripts/snippets. This plugin is experimental.",
+        "repo": "cristianvasquez/obsidian-snippets-plugin"
+    },
+    {
+        "id": "obsidian-temple",
+        "name": "Temple",
+        "author": "garyng",
+        "description": "Templating powered by Nunjucks.",
+        "repo": "garyng/obsidian-temple"
+    },
+    {
+        "id": "obsidian-relative-line-numbers",
+        "name": "Relative Line Numbers",
+        "author": "Nadav Spiegelman",
+        "description": "Enable relative line numbers in editor mode.",
+        "repo": "nadavspi/obsidian-relative-line-numbers"
+    },
+    {
+        "id": "obsidian-charts",
+        "name": "Charts",
+        "author": "phibr0",
+        "description": "Easily create interactive charts in your notes.",
+        "repo": "phibr0/obsidian-charts"
+    },
+    {
+        "id": "discordian-plugin",
+        "name": "Discordian Theme",
+        "author": "@radekkozak",
+        "description": "Fine-grained control of Discordian Theme.",
+        "repo": "radekkozak/discordian-plugin"
+    },
+    {
+        "id": "obsidian-autocomplete-plugin",
+        "name": "Autocomplete",
+        "author": "Yeboster",
+        "description": "Autocomplete text to increase your typing speed.",
+        "repo": "Yeboster/autocomplete-obsidian"
+    },
+    {
+        "id": "completed-task-display",
+        "name": "Completed Task Display",
+        "author": "Ben Lee-Cohen",
+        "description": "Controls for displaying or hiding completed tasks.",
+        "repo": "heliostatic/completed-task-display"
+    },
+    {
+        "id": "obsidian-extract-pdf-highlights",
+        "name": "PDF Highlights",
+        "author": "Alexis Rondeau",
+        "description": "Extract highlights, underlines and annotations from your PDFs.",
+        "repo": "akaalias/obsidian-extract-pdf-highlights"
+    },
+    {
+        "id": "youhavebeenstaring-plugin",
+        "name": "YouHaveBeenStaring",
+        "author": "Felix Almer",
+        "description": "Add a status bar indicator showing how long your vault has been open.",
+        "repo": "fxal/obsidian-youhavebeenstaring-plugin"
+    },
+    {
+        "id": "obsidian-metatemplates",
+        "name": "metatemplates",
+        "author": "avirut",
+        "description": "Generate notes from templates using YAML frontmatter.",
+        "repo": "avirut/obsidian-metatemplates"
+    },
+    {
+        "id": "obsidian-imgur-plugin",
+        "name": "Imgur",
+        "author": "Kirill Gavrilov",
+        "description": "Upload images from your clipboard to imgur.com and embeds uploaded image to your note.",
+        "repo": "gavvvr/obsidian-imgur-plugin"
+    },
+    {
+        "id": "obsidian-checklist-plugin",
+        "name": "Checklist",
+        "author": "delashum",
+        "description": "Consolidate checklists across all files into a single view.",
+        "repo": "delashum/obsidian-checklist-plugin"
+    },
+    {
+        "id": "search-on-internet",
+        "name": "Search on Internet",
+        "author": "Emile",
+        "description": "Add context menu items to search the internet based on the title of your note.",
+        "repo": "HEmile/obsidian-search-on-internet"
+    },
+    {
+        "id": "obsidian-file-path-to-uri",
+        "name": "File path to URI",
+        "author": "Michal Bure\u0161",
+        "description": "Convert file path to URI for easier use of links to local files outside of Obsidian.",
+        "repo": "MichalBures/obsidian-file-path-to-uri"
+    },
+    {
+        "id": "page-heading-from-links",
+        "name": "Page Heading From Links",
+        "author": "Mark Beattie",
+        "description": "Populate page headings from the file name.",
+        "repo": "beet/page-headings-obsidian-plugin"
+    },
+    {
+        "id": "obsidian-icons-plugin",
+        "name": "Icons",
+        "author": "Camillo Visini",
+        "description": "Add icons to your notes.",
+        "repo": "visini/obsidian-icons-plugin"
+    },
+    {
+        "id": "folder-note-plugin",
+        "name": "Folder Note",
+        "author": "xpgo",
+        "description": "Add description note to a folder.",
+        "repo": "xpgo/obsidian-folder-note-plugin"
+    },
+    {
+        "id": "vantage-obsidian",
+        "name": "Vantage - Advanced search builder",
+        "author": "ryanjamurphy",
+        "description": "Build advanced search queries.",
+        "repo": "ryanjamurphy/vantage-obsidian"
+    },
+    {
+        "id": "obsidian-sort-and-permute-lines",
+        "name": "Sort & Permute lines",
+        "description": "Sort and Permute lines in whole file or selection.",
+        "author": "Vinzent",
+        "repo": "Vinzent03/obsidian-sort-and-permute-lines"
+    },
+    {
+        "id": "obsidian-min3ditorhotkeys-plugin",
+        "name": "Min3ditorHotkeys",
+        "author": "Davor Sauer",
+        "description": "Additional editor hotkeys inspired by coding editors.",
+        "repo": "d-sauer/Obsidian-Min3ditorHotkeys-plugin"
+    },
+    {
+        "id": "obsidian-jsonifier",
+        "name": "JSONifier",
+        "author": "Kjell Connelly",
+        "description": "JSON.stringify() or JSON.parse() highlighted text and copy to clipboard.",
+        "repo": "KjellConnelly/obsidian-jsonifier"
+    },
+    {
+        "id": "things-logbook",
+        "name": "Things Logbook",
+        "author": "Liam Cain",
+        "description": "Sync your Things logbook with your daily notes.",
+        "repo": "liamcain/obsidian-things-logbook"
+    },
+    {
+        "id": "obsidian-shortcuts-for-starred-files",
+        "name": "Hotkeys for Bookmarks",
+        "description": "Set an individual hotkey for the first 9 bookmarked files and open them just with your keyboard.",
+        "author": "Vinzent",
+        "repo": "Vinzent03/obsidian-shortcuts-for-starred-files"
+    },
+    {
+        "id": "obsidian-filename-heading-sync",
+        "name": "Filename Heading Sync",
+        "description": "Keep the filename with the first heading of a file in sync.",
+        "author": "dvcrn",
+        "repo": "dvcrn/obsidian-filename-heading-sync"
+    },
+    {
+        "id": "obsidian-orthography",
+        "name": "Orthography",
+        "author": "denisoed",
+        "description": "Check & fix orthography errors in text.",
+        "repo": "denisoed/obsidian-orthography"
+    },
+    {
+        "id": "obsidian-query-language",
+        "name": "Obsidian Query Language",
+        "author": "Joost Plattel",
+        "description": "Query notes and represent data.",
+        "repo": "jplattel/obsidian-query-language"
+    },
+    {
+        "id": "obsidian-markdown-formatting-assistant-plugin",
+        "name": "Markdown Formatting Assistant",
+        "author": "Reocin",
+        "description": "A formatting sidebar for Markdown and a command line interface to facilitate a faster workflow.",
+        "repo": "Reocin/obsidian-markdown-formatting-assistant-plugin"
+    },
+    {
+        "id": "obsidian-journey-plugin",
+        "name": "Journey",
+        "author": "Alexis Rondeau",
+        "description": "Discover the story between your notes.",
+        "repo": "akaalias/obsidian-journey-plugin"
+    },
+    {
+        "id": "tag-wrangler",
+        "name": "Tag Wrangler",
+        "author": "PJ Eby",
+        "description": "Rename, merge, toggle, and search tags from the tag pane.",
+        "repo": "pjeby/tag-wrangler"
+    },
+    {
+        "id": "better-pdf-plugin",
+        "name": "Better PDF",
+        "author": "MSzturc",
+        "description": "Insert, scale, rotate and cut-out PDF pages into your notes.",
+        "repo": "MSzturc/obsidian-better-pdf-plugin"
+    },
+    {
+        "id": "dataview",
+        "name": "Dataview",
+        "author": "Michael Brenan",
+        "description": "Advanced queries over your vault for the data-obsessed.",
+        "repo": "blacksmithgu/obsidian-dataview"
+    },
+    {
+        "id": "periodic-notes",
+        "name": "Periodic Notes",
+        "author": "Liam Cain",
+        "description": "Create/manage your daily, weekly, and monthly notes.",
+        "repo": "liamcain/obsidian-periodic-notes"
+    },
+    {
+        "id": "obsidian-show-file-path",
+        "name": "Show Current File Path",
+        "author": "Ravi Mashru",
+        "description": "Show the full path of the currently open file in the status bar.",
+        "repo": "ravimashru/obsidian-show-file-path"
+    },
+    {
+        "id": "obsidian-paper-cut",
+        "name": "PaperCut",
+        "author": "darakah",
+        "description": "Express an idea in the simplest possible way... or else.",
+        "repo": "Darakah/obsidian-paper-cut"
+    },
+    {
+        "id": "obsidian-comments",
+        "name": "Comments",
+        "author": "darakah",
+        "description": "Add, track and easily navigate between a note's comments.",
+        "repo": "Darakah/obsidian-comments-plugin"
+    },
+    {
+        "id": "various-complements",
+        "name": "Various Complements",
+        "author": "tadashi-aikawa",
+        "description": "Complete words similar to auto-completion in an IDE.",
+        "repo": "tadashi-aikawa/obsidian-various-complements-plugin"
+    },
+    {
+        "id": "obsidian-timelines",
+        "name": "Timelines",
+        "author": "darakah",
+        "description": "Create a timeline view of all notes with the specified combination of tags.",
+        "repo": "Darakah/obsidian-timelines"
+    },
+    {
+        "id": "note-folder-autorename",
+        "name": "Note Folder Autorename",
+        "author": "PJ Eby",
+        "description": "Turn notes into folders and automatically move/rename their folders when they move or are renamed.",
+        "repo": "pjeby/note-folder-autorename"
+    },
+    {
+        "id": "daily-activity",
+        "name": "Daily Activity",
+        "description": "Output a list of the files changed/created today in the active file.",
+        "author": "trydalch",
+        "repo": "trydalch/obsidian-daily-activity"
+    },
+    {
+        "id": "obsidian-daily-stats",
+        "name": "Daily Stats",
+        "description": "Track your daily word count.",
+        "author": "Dhruvik Parikh",
+        "repo": "dhruvik7/obsidian-daily-stats"
+    },
+    {
+        "id": "open-note-to-window-title",
+        "name": "Custom window title",
+        "description": "Show the current open note in the window title.",
+        "author": "Joost Plattel",
+        "repo": "jplattel/open-note-to-window-title"
+    },
+    {
+        "id": "meld-encrypt",
+        "name": "Meld Encrypt",
+        "description": "Hide secrets in your notes.",
+        "author": "meld-cp",
+        "repo": "meld-cp/obsidian-encrypt"
+    },
+    {
+        "id": "obsidian-vault-statistics-plugin",
+        "name": "Vault Statistics",
+        "description": "Status bar item with vault statistics such as number of notes, files, attachments, and links.",
+        "author": "Bryan Kyle",
+        "repo": "bkyle/obsidian-vault-statistics-plugin"
+    },
+    {
+        "id": "obsidian-plugin-todo",
+        "name": "TODO | Text-based GTD",
+        "description": "Collect all outstanding TODOs from your vault and presents them in lists Today, Scheduled, Inbox and Someday/Maybe.",
+        "author": "Lars Lockefeer",
+        "repo": "larslockefeer/obsidian-plugin-todo"
+    },
+    {
+        "id": "obsidian-hotkeys-for-specific-files",
+        "name": "Hotkeys for specific files",
+        "description": "Add commands for specific files and open them with a hotkey.",
+        "author": "Vinzent",
+        "repo": "Vinzent03/obsidian-hotkeys-for-specific-files"
+    },
+    {
+        "id": "csv-obsidian",
+        "name": "CSV Editor",
+        "description": "Edit CSV files.",
+        "author": "death_au",
+        "repo": "deathau/csv-obsidian"
+    },
+    {
+        "id": "obsidian-plugin-toc",
+        "name": "Table of Contents",
+        "description": "Create a table of contents for a note.",
+        "author": "hipstersmoothie",
+        "repo": "hipstersmoothie/obsidian-plugin-toc"
+    },
+    {
+        "id": "mochi-cards-exporter",
+        "name": "Mochi Cards Exporter",
+        "description": "Export Markdown notes to Mochi cards.",
+        "author": "kalbetre",
+        "repo": "kalbetredev/mochi-cards-exporter"
+    },
+    {
+        "id": "obsidian-plugin-prettier",
+        "name": "Prettier Format",
+        "description": "Opinionated formatting for your notes.",
+        "author": "Andrew Lisowski",
+        "repo": "hipstersmoothie/obsidian-plugin-prettier"
+    },
+    {
+        "id": "obsidian-furigana",
+        "name": "Furigana",
+        "description": "Display furigana using <ruby> syntax.",
+        "author": "Koppa",
+        "repo": "uonr/obsidian-furigana"
+    },
+    {
+        "id": "obsidian-vault-changelog",
+        "name": "Vault Changelog",
+        "description": "Maintain a changelog of recently edited files in your vault.",
+        "author": "Badr Bouslikhin",
+        "repo": "badrbouslikhin/obsidian-vault-changelog"
+    },
+    {
+        "id": "chesser-obsidian",
+        "name": "Chesser",
+        "description": "A chess game viewer/editor.",
+        "author": "SilentVoid",
+        "repo": "SilentVoid13/Chesser"
+    },
+    {
+        "id": "obsidian-activity-history",
+        "name": "Activity History",
+        "description": "Track activity of specified projects, Github like activity board.",
+        "author": "darakah",
+        "repo": "Darakah/obsidian-activity-history"
+    },
+    {
+        "id": "obsidian-chessboard",
+        "name": "Chessboard Viewer",
+        "description": "Render chess positions diagrams in note preview.",
+        "author": "Davide Aversa",
+        "repo": "THeK3nger/obsidian-chessboard"
+    },
+    {
+        "id": "obsidian-footnotes",
+        "name": "Footnote Shortcut",
+        "description": "Makes creating footnotes more fun!",
+        "author": "Alexis Rondeau, Micha Brugger",
+        "repo": "MichaBrugger/obsidian-footnotes"
+    },
+    {
+        "id": "obsidian-gallery",
+        "name": "Gallery",
+        "description": "Interactive card-like gallery display of images.",
+        "author": "darakah",
+        "repo": "Darakah/obsidian-gallery"
+    },
+    {
+        "id": "notetweet",
+        "name": "NoteTweet",
+        "description": "Post to Twitter.",
+        "author": "Christian B. B. Houmann",
+        "repo": "chhoumann/notetweet_obsidian"
+    },
+    {
+        "id": "code-block-from-selection",
+        "name": "Code block from selection",
+        "description": "Turn the selected text into a code block.",
+        "author": "Dmitry Savosh",
+        "repo": "dy-sh/obsidian-code-block-from-selection"
+    },
+    {
+        "id": "format-hotkeys-obsidian",
+        "name": "Format Hotkeys",
+        "author": "Ansel Santosa",
+        "description": "Google Docs style formatting hotkeys.",
+        "repo": "anstosa/format-hotkeys-obsidian"
+    },
+    {
+        "id": "obsidian-leaflet-plugin",
+        "name": "Leaflet",
+        "description": "Interactive maps inside your notes.",
+        "author": "Jeremy Valentine",
+        "repo": "javalent/obsidian-leaflet"
+    },
+    {
+        "id": "remember-cursor-position",
+        "name": "Remember cursor position",
+        "description": "Remember cursor and scroll position for each note.",
+        "author": "Dmitry Savosh",
+        "repo": "dy-sh/obsidian-remember-cursor-position"
+    },
+    {
+        "id": "pane-relief",
+        "name": "Pane Relief",
+        "author": "PJ Eby",
+        "description": "Per-pane history, hotkeys for pane movement + navigation, and more.",
+        "repo": "pjeby/pane-relief"
+    },
+    {
+        "id": "DEVONlink-obsidian",
+        "name": "DEVONlink",
+        "description": "Open or reveal the current note in DEVONthink.",
+        "author": "ryanjamurphy",
+        "repo": "ryanjamurphy/DEVONlink-obsidian"
+    },
+    {
+        "id": "hotkey-helper",
+        "name": "Hotkey Helper",
+        "author": "PJ Eby",
+        "description": "Easily see and access any plugin's settings or hotkey assignments (and conflicts) from the Community Plugins tab.",
+        "repo": "pjeby/hotkey-helper"
+    },
+    {
+        "id": "text-snippets-obsidian",
+        "name": "Text Snippets",
+        "author": "Ariana Khitrova",
+        "description": "Snippets for faster typing. Replace text templates, create your own, and expand text shortcuts.",
+        "repo": "ArianaKhit/text-snippets-obsidian"
+    },
+    {
+        "id": "consistent-attachments-and-links",
+        "name": "Consistent attachments and links",
+        "description": "Move note attachments and update links automatically.",
+        "author": "Dmitry Savosh",
+        "repo": "dy-sh/obsidian-consistent-attachments-and-links"
+    },
+    {
+        "id": "obsidian-plantuml",
+        "name": "PlantUML",
+        "description": "Generate PlantUML diagrams.",
+        "author": "Johannes Theiner",
+        "repo": "joethei/obsidian-plantuml"
+    },
+    {
+        "id": "imdone-obsidian-plugin",
+        "name": "Open cards in imdone.",
+        "description": "Open cards in imdone kanban from their source in Obsidian.",
+        "author": "saxmanjes",
+        "repo": "imdone/imdone-obsidian-plugin"
+    },
+    {
+        "id": "obsidian-spotlight",
+        "name": "Spotlight",
+        "description": "Block that features random notes or block of a note from vault / in a specified project or with a certain combination of tags.",
+        "author": "darakah",
+        "repo": "Darakah/obsidian-spotlight"
+    },
+    {
+        "id": "unique-attachments",
+        "name": "Unique attachments",
+        "description": "Rename attachments, making their names unique (based on hashing of file content).",
+        "author": "Dmitry Savosh",
+        "repo": "dy-sh/obsidian-unique-attachments"
+    },
+    {
+        "id": "obsidian-dice-roller",
+        "name": "Dice Roller",
+        "description": "Add a little randomness to your notes!",
+        "author": "Jeremy Valentine",
+        "repo": "javalent/dice-roller"
+    },
+    {
+        "id": "obsidian-languagetool-plugin",
+        "name": "LanguageTool Integration",
+        "description": "advanced spell/grammar checks with the help of language-tool.",
+        "author": "Clemens Ertle",
+        "repo": "Clemens-E/obsidian-languagetool-plugin"
+    },
+    {
+        "id": "obsidian-commits",
+        "name": "Commits",
+        "description": "Track & show commits in your vault or specified project.",
+        "author": "darakah",
+        "repo": "Darakah/obsidian-commits"
+    },
+    {
+        "id": "obsidian-outliner",
+        "name": "Outliner",
+        "description": "Work with your lists like in Workflowy or Roam Research.",
+        "author": "Viacheslav Slinko",
+        "repo": "vslinko/obsidian-outliner"
+    },
+    {
+        "id": "extract-url",
+        "name": "Extract url content",
+        "description": "Extract URL converting content into Markdown.",
+        "author": "Stephen Solka",
+        "repo": "trashhalo/obsidian-extract-url"
+    },
+    {
+        "id": "find-and-replace-in-selection",
+        "name": "Find and replace in selection",
+        "description": "Find what you are looking for in the selected text and replace it with the specified text.",
+        "author": "Dmitry Savosh",
+        "repo": "dy-sh/obsidian-find-and-replace-in-selection"
+    },
+    {
+        "id": "buttons",
+        "name": "Buttons",
+        "description": "Create Buttons in your notes to run commands, open links, and insert templates.",
+        "author": "Sam Morrison",
+        "repo": "shabegom/buttons"
+    },
+    {
+        "id": "obsidian-admonition",
+        "name": "Admonition",
+        "description": "Admonition block-styled content.",
+        "author": "Jeremy Valentine",
+        "repo": "javalent/admonitions"
+    },
+    {
+        "id": "obsidian-tracker",
+        "name": "Tracker",
+        "description": "Track occurrences and numbers in your notes.",
+        "author": "pyrochlore",
+        "repo": "pyrochlore/obsidian-tracker"
+    },
+    {
+        "id": "obsidian-hotkeys-for-templates",
+        "name": "Hotkeys for templates",
+        "description": "Add commands to insert specific templates with a hotkey.",
+        "author": "Vinzent",
+        "repo": "Vinzent03/obsidian-hotkeys-for-templates"
+    },
+    {
+        "id": "obsidian-style-settings",
+        "name": "Style Settings",
+        "description": "Adjust theme, plugin, and snippet CSS variables.",
+        "author": "mgmeyers",
+        "repo": "mgmeyers/obsidian-style-settings"
+    },
+    {
+        "id": "obsidian-advanced-uri",
+        "name": "Advanced URI",
+        "description": "Control everything with URI.",
+        "author": "Vinzent",
+        "repo": "Vinzent03/obsidian-advanced-uri"
+    },
+    {
+        "id": "obsidian-fountain",
+        "name": "Fountain",
+        "description": "Edit, write and render Fountain Writing Syntax for screenplays and scripts.",
+        "author": "darakah",
+        "repo": "Darakah/obsidian-fountain"
+    },
+    {
+        "id": "cm-chs-patch",
+        "name": "Word Splitting for Simplified Chinese in Edit Mode and Vim Mode",
+        "author": "AidenLx",
+        "description": "A patch for Obsidian's built-in CodeMirror editor to support Simplified Chinese word splitting.",
+        "repo": "aidenlx/cm-chs-patch"
+    },
+    {
+        "id": "table-extended",
+        "name": "Table Extended",
+        "author": "AidenLx",
+        "description": "Enable extended table support with MultiMarkdown 6 syntax.",
+        "repo": "aidenlx/table-extended"
+    },
+    {
+        "id": "privacy-glasses",
+        "name": "Privacy Glasses",
+        "description": "A ribbon icon and command to blur onscreen text for better privacy.",
+        "author": "Jill Alberts",
+        "repo": "jillalberts/privacy-glasses"
+    },
+    {
+        "id": "obsidian-highlightpublicnotes-plugin",
+        "name": "Highlight Public Notes",
+        "description": "Warn that a note is public (based on a frontmatter attribute) by coloring the note red.",
+        "author": "dennis seidel",
+        "repo": "dennisseidel/highlightpublicnotes-obsidian-plugin"
+    },
+    {
+        "id": "media-extended",
+        "name": "Media Extended",
+        "author": "AidenLx",
+        "description": "Add extended media features for video and audio, including timestamp links and playback speed.",
+        "repo": "aidenlx/media-extended"
+    },
+    {
+        "id": "obsidian-regex-pipeline",
+        "name": "Regex Pipeline",
+        "description": "Set up custom regex rules to automatically format notes.",
+        "author": "No3371",
+        "repo": "No3371/obsidian-regex-pipeline"
+    },
+    {
+        "id": "juggl",
+        "name": "Juggl",
+        "author": "Emile van Krieken",
+        "description": "Add a completely interactive, stylable and expandable graph view.",
+        "repo": "HEmile/juggl"
+    },
+    {
+        "id": "obsidian-spaced-repetition",
+        "name": "Spaced Repetition",
+        "description": "Fight the forgetting curve by reviewing flashcards & entire notes.",
+        "author": "Stephen Mwangi",
+        "repo": "st3v3nmw/obsidian-spaced-repetition"
+    },
+    {
+        "id": "obsidian-readwise",
+        "name": "Readwise Community",
+        "description": "Sync Readwise highlights into your notes.",
+        "author": "renehernandez",
+        "repo": "renehernandez/obsidian-readwise"
+    },
+    {
+        "id": "obsidian-icon-swapper",
+        "name": "Icon Swapper",
+        "author": "mgmeyers",
+        "description": "Swap out Obsidian's default icons.",
+        "repo": "mgmeyers/obsidian-icon-swapper"
+    },
+    {
+        "id": "mdx-as-md-obsidian",
+        "name": "mdx as md",
+        "author": "Nikolay Kozhukharenko",
+        "description": "Edit mdx files as Markdown.",
+        "repo": "mkozhukharenko/mdx-as-md-obsidian"
+    },
+    {
+        "id": "obsidian-excalidraw-plugin",
+        "name": "Excalidraw",
+        "author": "Zsolt Viczian",
+        "description": "Edit and view Excalidraw drawings.",
+        "repo": "zsviczian/obsidian-excalidraw-plugin"
+    },
+    {
+        "id": "obsidian-auto-link-title",
+        "name": "Auto Link Title",
+        "description": "Automatically fetches the titles of links from the web.",
+        "author": "Matt Furden",
+        "repo": "zolrath/obsidian-auto-link-title"
+    },
+    {
+        "id": "python-lab-plugin",
+        "name": "Python lab",
+        "description": "An interface to experiment with Python scripts and more.",
+        "author": "Cristian Vasquez",
+        "repo": "cristianvasquez/obsidian-lab"
+    },
+    {
+        "id": "obsidian-kanban",
+        "name": "Kanban",
+        "author": "mgmeyers",
+        "description": "Create Markdown-backed Kanban boards.",
+        "repo": "mgmeyers/obsidian-kanban"
+    },
+    {
+        "id": "obsidian-incremental-writing",
+        "name": "Incremental Writing",
+        "author": "Jamesb | Experimental Learning",
+        "description": "Incrementally review notes and blocks over time.",
+        "repo": "bjsi/incremental-writing"
+    },
+    {
+        "id": "obsidian-kindle-plugin",
+        "name": "Kindle Highlights",
+        "description": "Sync your Kindle book highlights using your Amazon login or uploading your My Clippings file.",
+        "author": "Hady Osman",
+        "repo": "hadynz/obsidian-kindle-plugin"
+    },
+    {
+        "id": "oz-image-plugin",
+        "name": "Image in Editor",
+        "author": "Ozan Tellioglu",
+        "description": "View Images, Transclusions, iFrames and PDF Files within the Editor without a necessity to switch to Preview.",
+        "repo": "ozntel/oz-image-in-editor-obsidian"
+    },
+    {
+        "id": "obsidian-recall",
+        "name": "Recall",
+        "description": "A flexible and configurable spaced repetition plugin with multiple algorithms to choose from.",
+        "author": "Martin Jirlow",
+        "repo": "martin-jw/obsidian-recall"
+    },
+    {
+        "id": "obsidian-tidy-footnotes",
+        "name": "Tidy Footnotes",
+        "description": "Tidy your footnotes seamlessly.",
+        "author": "Charlie Chao",
+        "repo": "charliecm/obsidian-tidy-footnotes"
+    },
+    {
+        "id": "beeminder-word-count-plugin",
+        "name": "Beeminder Word Count",
+        "description": "Post word counts directly to Beeminder.",
+        "author": "Yuta Miyama",
+        "repo": "kenzan100/beeminder-obsidian-word-count"
+    },
+    {
+        "id": "obsidian-qrcode-plugin",
+        "name": "QR Code Generator",
+        "description": "QR code generator.",
+        "author": "Rudi H\u00e4usler",
+        "repo": "rudimuc/obsidian-qrcode"
+    },
+    {
+        "id": "obsidian-focus-mode",
+        "name": "Focus Mode",
+        "description": "Add a toggle to hide interface elements so you can focus on your note.",
+        "author": "ryanpcmcquen",
+        "repo": "ryanpcmcquen/obsidian-focus-mode"
+    },
+    {
+        "id": "obsidian-underline",
+        "name": "Underline",
+        "description": "Add underline with shortcut.",
+        "author": "Benature",
+        "repo": "Benature/obsidian-underline"
+    },
+    {
+        "id": "oz-clear-unused-images",
+        "name": "Clear Unused Images",
+        "author": "Ozan Tellioglu",
+        "description": "Clear the images that you are not using anymore in your Markdown notes to save space.",
+        "repo": "ozntel/oz-clear-unused-images-obsidian"
+    },
+    {
+        "id": "obsidian-markdown-furigana",
+        "name": "Markdown Furigana",
+        "description": "Display furigana using Markdown syntax.",
+        "author": "Steven Kraft",
+        "repo": "steven-kraft/obsidian-markdown-furigana"
+    },
+    {
+        "id": "obsidian-2hop-links-plugin",
+        "name": "2Hop Links",
+        "author": "Tokuhiro Matsuno",
+        "description": "Display the page linked 2hop ahead.",
+        "repo": "tokuhirom/obsidian-2hop-links-plugin"
+    },
+    {
+        "id": "obsidian-image-auto-upload-plugin",
+        "name": "Image auto upload",
+        "description": "Upload images from your clipboard by PicGo.",
+        "author": "renmu123",
+        "repo": "renmu123/obsidian-image-auto-upload-plugin"
+    },
+    {
+        "id": "obsidian-org-mode",
+        "name": "Org Mode",
+        "description": "Add Org Mode support.",
+        "author": "ryanpcmcquen",
+        "repo": "ryanpcmcquen/obsidian-org-mode"
+    },
+    {
+        "id": "obsidian-open-link-with",
+        "name": "Open Link With",
+        "description": "Open external link with specific browser.",
+        "author": "MamoruDS",
+        "repo": "MamoruDS/obsidian-open-link-with"
+    },
+    {
+        "id": "obsidian-stopwatch-plugin",
+        "name": "Stopwatch",
+        "description": "Display a stopwatch in the sidebar.",
+        "author": "Tokuhiro Matsuno",
+        "repo": "tokuhirom/obsidian-stopwatch-plugin"
+    },
+    {
+        "id": "supercharged-links-obsidian",
+        "name": "Supercharged Links",
+        "description": "Add attributes to internal links with the values of target note's frontmatter attributes.",
+        "author": "mdelobelle",
+        "repo": "mdelobelle/obsidian_supercharged_links"
+    },
+    {
+        "id": "obsidian-pangu",
+        "name": "\u76d8\u53e4 PanGu",
+        "description": "Add spaces between Chinese characters and English alphabet. A boon for typographically compulsive people.",
+        "author": "Natumsol",
+        "repo": "Natumsol/obsidian-pangu"
+    },
+    {
+        "id": "obsidian-related-notes-finder",
+        "name": "Related Notes Finder",
+        "description": "Add extra features for finding related notes.",
+        "author": "Joshua Michalik",
+        "repo": "lifegems/obsidian-related-notes-finder"
+    },
+    {
+        "id": "koncham-workspace",
+        "name": "koncham workspace",
+        "author": "mano",
+        "description": "Workspace management.",
+        "repo": "manogna4/obsidian-koncham-workspace"
+    },
+    {
+        "id": "obsidian-react-components",
+        "name": "React Components",
+        "description": "Write and use React (Jsx) components in your notes.",
+        "author": "Elias Sundqvist",
+        "repo": "elias-sundqvist/obsidian-react-components"
+    },
+    {
+        "id": "obsidian-tasks-plugin",
+        "name": "Tasks",
+        "author": "Clare Macrae and Ilyas Landikov (created by Martin Schenck)",
+        "description": "Track tasks across your vault. Supports due dates, recurring tasks, done dates, sub-set of checklist items, and filtering.",
+        "repo": "obsidian-tasks-group/obsidian-tasks"
+    },
+    {
+        "id": "readwise-mirror",
+        "name": "Readwise Mirror",
+        "description": "Mirror your Readwise library.",
+        "author": "jsonmartin",
+        "repo": "jsonMartin/readwise-mirror"
+    },
+    {
+        "id": "obsidian-auto-pair-chinese-symbol",
+        "name": "Auto pair chinese symbol",
+        "description": "Auto-pair Chinese symbols.",
+        "author": "renmu123",
+        "repo": "renmu123/obsidian-auto-pair-chinese-symbol"
+    },
+    {
+        "id": "obsidian-pomodoro-plugin",
+        "name": "Pomodoro",
+        "description": "Simple pomodoro time tracking.",
+        "author": "Tokuhiro Matsuno",
+        "repo": "tokuhirom/obsidian-pomodoro-plugin"
+    },
+    {
+        "id": "obsidian-5e-statblocks",
+        "name": "Fantasy Statblocks",
+        "description": "Create, manage and view a Fantasy Bestiary with Dungeons and Dragons style statblocks.",
+        "author": "Jeremy Valentine",
+        "repo": "javalent/fantasy-statblocks"
+    },
+    {
+        "id": "obsidian-zoom",
+        "name": "Zoom",
+        "description": "Zoom into heading and lists.",
+        "author": "Viacheslav Slinko",
+        "repo": "vslinko/obsidian-zoom"
+    },
+    {
+        "id": "obsidian-collapse-all-plugin",
+        "name": "Collapse All",
+        "description": "Extend collapse/expand all with commands that can be bound to hotkeys.",
+        "author": "Nathonius",
+        "repo": "nathonius/obsidian-collapse-all"
+    },
+    {
+        "id": "obsidian-chartsview-plugin",
+        "name": "Charts View",
+        "description": "Visualize data from your notes with plots and graphs.",
+        "author": "caronchen",
+        "repo": "caronchen/obsidian-chartsview-plugin"
+    },
+    {
+        "id": "obsidian-dictionary-plugin",
+        "name": "Dictionary",
+        "description": "A multilingual dictionary that shows word definitions in the sidebar and popover synonyms.",
+        "author": "phibr0",
+        "repo": "phibr0/obsidian-dictionary"
+    },
+    {
+        "id": "liquid-templates",
+        "name": "Liquid Templates",
+        "author": "Diomede Tripicchio",
+        "description": "Create your templates with LiquidJS tags support.",
+        "repo": "oeN/liquid-template"
+    },
+    {
+        "id": "better-fn",
+        "name": "Better footnote",
+        "description": "Display footnotes inline as a popover.",
+        "author": "AidenLx",
+        "repo": "aidenlx/better-fn"
+    },
+    {
+        "id": "obsidian-dropbox-backups",
+        "name": "Aut-O-Backups",
+        "description": "Automated Dropbox backups of your entire vault.",
+        "author": "ryanpcmcquen",
+        "repo": "ryanpcmcquen/obsidian-dropbox-backups"
+    },
+    {
+        "id": "metaedit",
+        "name": "MetaEdit",
+        "description": "Manage your metadata.",
+        "author": "Christian B. B. Houmann",
+        "repo": "chhoumann/MetaEdit"
+    },
+    {
+        "id": "obsidian-static-file-server",
+        "name": "Static File Server",
+        "description": "Host subfolders as static file servers.",
+        "author": "Elias Sundqvist",
+        "repo": "elias-sundqvist/obsidian-static-file-server"
+    },
+    {
+        "id": "easy-typing-obsidian",
+        "name": "Easy Typing",
+        "description": "Auto format when typing.",
+        "author": "yaozhuwa",
+        "repo": "Yaozhuwa/easy-typing-obsidian"
+    },
+    {
+        "id": "obsidian-sidebar-expand-on-hover",
+        "name": "Sidebar Expand on Hover",
+        "description": "Expand or collapse the sidebar when your mouse is hovering on the left ribbon.",
+        "author": "Tousif Iqbal Anik (toiq)",
+        "repo": "toiq/obsidian-sidebar-expand-on-hover"
+    },
+    {
+        "id": "zoottelkeeper-obsidian-plugin",
+        "name": "Zoottelkeeper",
+        "description": "It maintains index files in all of your folders in your vault: if you create/delete/move a note, the index files will be updated automatically. It can be used to show folders in Graph View.",
+        "author": "Akos Balasko",
+        "repo": "akosbalasko/zoottelkeeper-obsidian-plugin"
+    },
+    {
+        "id": "file-tree-alternative",
+        "name": "File Tree Alternative",
+        "author": "Ozan Tellioglu",
+        "description": "An alternative file tree view with separate folder and file panes.",
+        "repo": "ozntel/file-tree-alternative"
+    },
+    {
+        "id": "obsidian-electron-window-tweaker",
+        "name": "Electron Window Tweaker",
+        "author": "mgmeyers",
+        "description": "Tweak various Electron window settings.",
+        "repo": "mgmeyers/obsidian-electron-window-tweaker"
+    },
+    {
+        "id": "obsidian-smart-typography",
+        "name": "Smart Typography",
+        "author": "mgmeyers",
+        "description": "Convert quotes to curly quotes, dashes to em dashes, and periods to ellipses.",
+        "repo": "mgmeyers/obsidian-smart-typography"
+    },
+    {
+        "id": "obsidian-grandfather",
+        "name": "Grandfather",
+        "description": "Display the time and date in the status bar.",
+        "author": "Danny Hernandez",
+        "repo": "noatpad/obsidian-grandfather"
+    },
+    {
+        "id": "obsidian-text-format",
+        "name": "Text Format",
+        "author": "Benature",
+        "description": "Format selected text upper/lower/capitalize.",
+        "repo": "Benature/obsidian-text-format"
+    },
+    {
+        "id": "adjacency-matrix-maker",
+        "name": "Adjacency Matrix Maker",
+        "author": "SkepticMystic",
+        "description": "Create an interactive adjacency matrix of your vault.",
+        "repo": "SkepticMystic/adjacency-matrix-maker"
+    },
+    {
+        "id": "taskbone-ocr-plugin",
+        "name": "Taskbone",
+        "description": "Extract text and equations from images and PDFs and make it available for search.",
+        "author": "Dominik Schlund",
+        "repo": "schlundd/obsidian-ocr-plugin"
+    },
+    {
+        "id": "obsidian-gist",
+        "name": "Gist",
+        "description": "Display the GitHub Gist.",
+        "author": "Jun Lin",
+        "repo": "linjunpop/obsidian-gist"
+    },
+    {
+        "id": "obsidian-argdown-plugin",
+        "name": "Argument Map with Argdown",
+        "description": "Write Argdown code blocks and view the maps in reading mode.",
+        "author": "amdecker",
+        "repo": "amdecker/obsidian-argdown-plugin"
+    },
+    {
+        "id": "obsidian-csv-table",
+        "name": "CSV Table",
+        "description": "Render CSV data as a table within your notes.",
+        "author": "Adam Coddington",
+        "repo": "coddingtonbear/obsidian-csv-table"
+    },
+    {
+        "id": "obsidian-advanced-new-file",
+        "name": "Advanced New File",
+        "description": "Create notes in chosen folder.",
+        "author": "Ivan Chernov",
+        "repo": "vanadium23/obsidian-advanced-new-file"
+    },
+    {
+        "id": "file-explorer-note-count",
+        "name": "File Explorer Note Count",
+        "author": "Ozan Tellioglu",
+        "description": "See the number of notes in each folder within the file explorer.",
+        "repo": "ozntel/file-explorer-note-count"
+    },
+    {
+        "id": "obsidian-title-index",
+        "name": "Title index",
+        "description": "Add serial numbers to your Markdown title.",
+        "author": "renmu123",
+        "repo": "renmu123/obsidian-markdown-index"
+    },
+    {
+        "id": "quickadd",
+        "name": "QuickAdd",
+        "description": "Quickly add new notes or content to your vault.",
+        "author": "Christian B. B. Houmann",
+        "repo": "chhoumann/quickadd"
+    },
+    {
+        "id": "obsidian-pluck",
+        "name": "Pluck",
+        "author": "Kevin Barrett",
+        "description": "Quickly create notes from web pages.",
+        "repo": "kevboh/obsidian-pluck"
+    },
+    {
+        "id": "obsidian-pandoc",
+        "name": "Pandoc",
+        "description": "Commands to export to Pandoc-supported formats like DOCX, ePub and PDF.",
+        "author": "Oliver Balfour",
+        "repo": "OliverBalfour/obsidian-pandoc"
+    },
+    {
+        "id": "obsidian-habit-tracker",
+        "name": "Habit Tracker",
+        "description": "Create a simple month view for visualizing your punch records.",
+        "author": "duo",
+        "repo": "duoani/obsidian-habit-tracker"
+    },
+    {
+        "id": "obsidian-amazingmarvin-plugin",
+        "name": "Amazing Marvin",
+        "author": "Shirayuki Nekomata",
+        "description": "Get data from Amazing Marvin.",
+        "repo": "ikuyarihS/obsidian-amazingmarvin-plugin"
+    },
+    {
+        "id": "obsidian-statusbar-pomo",
+        "name": "Status Bar Pomodoro Timer",
+        "author": "kzhovn",
+        "description": "Add a pomodoro timer to your status bar.",
+        "repo": "kzhovn/statusbar-pomo-obsidian"
+    },
+    {
+        "id": "obsidian-kroki",
+        "name": "Kroki",
+        "author": "Greg Zuro",
+        "description": "Render Kroki diagrams.",
+        "repo": "gregzuro/obsidian-kroki"
+    },
+    {
+        "id": "obsidian-timeline",
+        "name": "Timeline",
+        "author": "George Butco",
+        "description": "Build great timelines.",
+        "repo": "George-debug/obsidian-timeline"
+    },
+    {
+        "id": "obsidian-map-view",
+        "name": "Map View",
+        "author": "esm",
+        "description": "An interactive map view for your notes.",
+        "repo": "esm7/obsidian-map-view"
+    },
+    {
+        "id": "copy-url-in-preview",
+        "name": "Image Context Menus",
+        "author": "NomarCub",
+        "description": "Copy, open in default app, show in system explorer, reveal in navigation context menu for images. Also Open PDF externally context menu.",
+        "repo": "NomarCub/obsidian-copy-url-in-preview"
+    },
+    {
+        "id": "initiative-tracker",
+        "name": "Initiative Tracker",
+        "author": "Jeremy Valentine",
+        "description": "TTRPG initiative tracker.",
+        "repo": "javalent/initiative-tracker"
+    },
+    {
+        "id": "obsidian-cursor-location-plugin",
+        "name": "Cursor Location",
+        "author": "Sean Slater",
+        "description": "Display the location of the cursor (character and line number).",
+        "repo": "spslater/obsidian-cursor-location-plugin"
+    },
+    {
+        "id": "obsidian-enhancing-mindmap",
+        "name": "Enhancing Mindmap",
+        "author": "Mark",
+        "description": "Edit mindmaps with Markdown.",
+        "repo": "MarkMindCkm/obsidian-enhancing-mindmap"
+    },
+    {
+        "id": "breadcrumbs",
+        "name": "Breadcrumbs",
+        "author": "SkepticMystic",
+        "description": "Visualise the hierarchy of your vault using a breadcrumb trail or matrix view.",
+        "repo": "SkepticMystic/breadcrumbs"
+    },
+    {
+        "id": "open-vscode",
+        "name": "Open vault in VS Code",
+        "author": "NomarCub",
+        "description": "Ribbon button and command to open vault as a Visual Studio Code workspace.",
+        "repo": "NomarCub/obsidian-open-vscode"
+    },
+    {
+        "id": "obsidian-image-uploader",
+        "name": "Image Uploader",
+        "author": "Creling",
+        "description": "Upload the image in your clipboard to any image hosting automatically when pasting.",
+        "repo": "Creling/obsidian-image-uploader"
+    },
+    {
+        "id": "garble-text",
+        "name": "Garble Text",
+        "author": "kurakart",
+        "description": "Turn all content in the app (notes, sidebar, etc) into garbled text so you can take screenshots without exposing sensitive data.",
+        "repo": "kurakart/garble-text"
+    },
+    {
+        "id": "obsidian-paste-to-current-indentation",
+        "name": "Paste Mode",
+        "author": "Jacob Levernier",
+        "description": "Paste content and mark block quotes at any level of indentation.",
+        "repo": "jglev/obsidian-paste-mode"
+    },
+    {
+        "id": "obsimian-exporter",
+        "name": "Obsimian Exporter",
+        "author": "Oliver Lade",
+        "description": "Simulation framework for testing Obsidian plugins.",
+        "repo": "motif-software/obsimian"
+    },
+    {
+        "id": "obsidian-find-and-replace-in-selection",
+        "name": "Find & Replace in Selection",
+        "description": "Replace text within your current selection.",
+        "author": "TClark1011",
+        "repo": "TClark1011/obsidian-find-and-replace-in-selection"
+    },
+    {
+        "id": "obsidian-embedded-code-title",
+        "name": "Embedded Code Title",
+        "author": "tadashi-aikawa",
+        "description": "Embed a title in code blocks.",
+        "repo": "tadashi-aikawa/obsidian-embedded-code-title"
+    },
+    {
+        "id": "homepage",
+        "name": "Homepage",
+        "author": "mirnovov",
+        "description": "Open a specified note, canvas, or workspace on startup, or set it for quick access later.",
+        "repo": "mirnovov/obsidian-homepage"
+    },
+    {
+        "id": "obsidian-random-todo",
+        "name": "Random To-Do",
+        "author": "NatiAris",
+        "description": "Open a random file containing your custom to-do marker, or a random marker at its position.",
+        "repo": "NatiAris/obsidian-random-todo"
+    },
+    {
+        "id": "cmenu-plugin",
+        "name": "cMenu",
+        "description": "Add a minimal text formatting toolbar for a smoother writing/editing experience.",
+        "author": "Chetachi",
+        "repo": "chetachiezikeuzor/cMenu-Plugin"
+    },
+    {
+        "id": "obsidian-daf-yomi",
+        "name": "Daf Yomi",
+        "author": "lyonsquark",
+        "description": "Prepare Daf Yomi notes.",
+        "repo": "lyonsquark/obsidian-daf-yomi"
+    },
+    {
+        "id": "markdown-attributes",
+        "name": "Markdown Attributes",
+        "author": "Jeremy Valentine",
+        "description": "Add Markdown attributes to elements.",
+        "repo": "javalent/markdown-attributes"
+    },
+    {
+        "id": "obsidian-wavedrom",
+        "name": "WaveDrom",
+        "author": "Alex Stewart",
+        "description": "Create wavedrom plots.",
+        "repo": "kingsquirrel152/obsidian-wavedrom"
+    },
+    {
+        "id": "phone-to-roam-to-obsidian",
+        "name": "Phone to Note",
+        "author": "Dylan Garrett",
+        "description": "An unofficial client for phonetonote.com (previously phonetoroam.com).",
+        "repo": "dgarrett/phone-to-roam-to-obsidian"
+    },
+    {
+        "id": "obsidian-pocket",
+        "name": "Pocket",
+        "author": "Nimalan Mahendran",
+        "description": "Access your Pocket reading list entries and create notes for them easily.",
+        "repo": "nybbles/obsidian-pocket"
+    },
+    {
+        "id": "obsidian-wordnet-plugin",
+        "name": "WordNet Dictionary",
+        "description": "A large lexical database of English developed by Princeton University.",
+        "author": "TfTHacker",
+        "repo": "TfTHacker/Obsidian-WordNet"
+    },
+    {
+        "id": "multi-line-formatting",
+        "name": "Multi-line Formatting",
+        "author": "nmady",
+        "description": "Apply formatting to selected text, dealing with the paragraph breaks.",
+        "repo": "nmady/obsidian-multi-line-formatting"
+    },
+    {
+        "id": "obsidian-apply-patterns",
+        "name": "Apply Patterns",
+        "author": "Jacob Levernier",
+        "description": "Apply custom patterns of find-and-replace in succession to text.",
+        "repo": "jglev/obsidian-apply-patterns-plugin"
+    },
+    {
+        "id": "longform",
+        "name": "Longform",
+        "author": "Kevin Barrett",
+        "description": "Helps you write and edit novels, screenplays, and other long projects.",
+        "repo": "kevboh/longform"
+    },
+    {
+        "id": "readwise-official",
+        "name": "Readwise Official",
+        "author": "Readwise",
+        "description": "Official Readwise integration.",
+        "repo": "readwiseio/obsidian-readwise"
+    },
+    {
+        "id": "obsidian-activity-logger",
+        "name": "Activity Logger",
+        "author": "Creling",
+        "description": "Log your activities like creating notes, modifying notes, deleting notes and so on.",
+        "repo": "Creling/obsidian-activity-logger"
+    },
+    {
+        "id": "obsidian-toggl-integration",
+        "name": "Toggl Track",
+        "description": "Add integration with the Toggl Track API to manage your timers.",
+        "author": "Maxime Cannoodt",
+        "repo": "mcndt/obsidian-toggl-integration"
+    },
+    {
+        "id": "alx-folder-note",
+        "name": "AidenLx's Folder Note",
+        "description": "Add description, summary and more info to folders with folder notes.",
+        "author": "AidenLx",
+        "repo": "aidenlx/alx-folder-note"
+    },
+    {
+        "id": "obsidian-hide-sidebars-when-narrow",
+        "name": "Hide Sidebars on Window Resize",
+        "author": "NomarCub, Michael Hanson",
+        "description": "Automatically hides the sidebars when your window is narrow on window resize.",
+        "repo": "NomarCub/obsidian-hide-sidebars-on-window-resize"
+    },
+    {
+        "id": "obsidian-linter",
+        "name": "Linter",
+        "description": "Format and style your notes. Linter can be used to format YAML tags, aliases, arrays, and metadata; footnotes; headings; spacing; math blocks; regular Markdown contents like list, italics, and bold styles; and more with the use of custom rule options.",
+        "author": "Victor Tao",
+        "repo": "platers/obsidian-linter"
+    },
+    {
+        "id": "number-headings-obsidian",
+        "name": "Number Headings",
+        "description": "Automatically number or re-number headings.",
+        "author": "Kevin Albrecht",
+        "repo": "onlyafly/number-headings-obsidian"
+    },
+    {
+        "id": "obsidian-view-mode-by-frontmatter",
+        "name": "Force note view mode",
+        "description": "Force the view mode for a note by using frontmatter: YAML block with 'obsidian_ui_mode' as key.",
+        "author": "Benny Wydooghe",
+        "repo": "bwydoogh/obsidian-force-view-mode-of-note"
+    },
+    {
+        "id": "file-explorer-markdown-titles",
+        "name": "File Explorer Markdown Titles",
+        "author": "Dylan Elliott",
+        "description": "Show the first Markdown header of a note in the file explorer.",
+        "repo": "Dyldog/file-explorer-markdown-titles"
+    },
+    {
+        "id": "theme-picker",
+        "name": "Theme Picker",
+        "author": "kenset",
+        "description": "Quickly preview and select installed themes.",
+        "repo": "kenset/obsidian-theme-picker"
+    },
+    {
+        "id": "emoji-shortcodes",
+        "name": "Emoji Shortcodes",
+        "description": "Enable the use of Markdown Emoji shortcodes :smile:, just like in Slack or Discord.",
+        "author": "phibr0",
+        "repo": "phibr0/obsidian-emoji-shortcodes"
+    },
+    {
+        "id": "obsidian-reminder-plugin",
+        "name": "Reminder",
+        "author": "uphy",
+        "description": "Manage Markdown TODOs with reminder.",
+        "repo": "uphy/obsidian-reminder"
+    },
+    {
+        "id": "obsidian-go-to-line",
+        "name": "Go to Line",
+        "author": "phibr0",
+        "description": "Add a Go to Line command.",
+        "repo": "phibr0/obsidian-go-to-line"
+    },
+    {
+        "id": "open-with",
+        "name": "Open with",
+        "author": "phibr0",
+        "description": "Add multiple other programs to open notes with.",
+        "repo": "phibr0/obsidian-open-with"
+    },
+    {
+        "id": "editor-commands-remap",
+        "name": "Editor Commands Remap",
+        "description": "Map hotkeys to editor commands.",
+        "author": "cactus5",
+        "repo": "c4ctus5/editor-commands-remap"
+    },
+    {
+        "id": "obsidian-command-alias-plugin",
+        "name": "Command Alias",
+        "description": "Give aliases to commands.",
+        "author": "@Yajamon",
+        "repo": "yajamon/obsidian-command-alias-plugin"
+    },
+    {
+        "id": "obsidian-rich-links",
+        "name": "Rich Links",
+        "author": "dhamaniasad",
+        "description": "Convert URLs in your notes to rich link previews.",
+        "repo": "dhamaniasad/obsidian-rich-links"
+    },
+    {
+        "id": "ObsidianAnkiSync",
+        "name": "Anki Sync",
+        "author": "debanjandhar12",
+        "description": "Make flashcards and sync them to Anki.",
+        "repo": "debanjandhar12/Obsidian-Anki-Sync"
+    },
+    {
+        "id": "window-collapse",
+        "name": "Window Collapse",
+        "author": "Guilherme Quental",
+        "description": "An easy way to collapse the sidebars without going fullscreen.",
+        "repo": "gquental/obsidian-window-collapse"
+    },
+    {
+        "id": "obsidian-relative-find",
+        "name": "Relative Find",
+        "author": "phibr0",
+        "description": "Search relative to your cursor position.",
+        "repo": "phibr0/obsidian-relative-find"
+    },
+    {
+        "id": "obsidian-image-toolkit",
+        "name": "Image Toolkit",
+        "description": "When you click an image, it will be displayed in a popup layer and you can view, drag, zoom, rotate the image.",
+        "author": "sissilab",
+        "repo": "sissilab/obsidian-image-toolkit"
+    },
+    {
+        "id": "obsidian-shellcommands",
+        "name": "Shell commands",
+        "description": "Define system commands that you want to execute via command palette, hotkeys, URI links or automated events. E.g. open external applications or perform automated file modifications.",
+        "author": "Jarkko Linnanvirta",
+        "repo": "Taitava/obsidian-shellcommands"
+    },
+    {
+        "id": "hover-external-link",
+        "name": "Hover External Link",
+        "description": "Hover on external links to see the destination URL.",
+        "author": "Jamie Brynes",
+        "repo": "jamiebrynes7/obsidian-hover-external-link"
+    },
+    {
+        "id": "obsidian-copy-block-link",
+        "name": "Copy Block Link",
+        "author": "mgmeyers",
+        "description": "Get links to blocks and headings from the right-click menu.",
+        "repo": "mgmeyers/obsidian-copy-block-link"
+    },
+    {
+        "id": "drawio-obsidian",
+        "name": "Diagrams",
+        "description": "Create and edit Draw.io diagrams.",
+        "author": "Sam Greenhalgh",
+        "repo": "zapthedingbat/drawio-obsidian"
+    },
+    {
+        "id": "obsidian-vim-im-switch-plugin",
+        "name": "Vim Input Method Switch",
+        "description": "Switch input method with fcitx-remote when Vim keymap is enabled.",
+        "author": "yuanotes",
+        "repo": "yuanotes/obsidian-vim-im-switch-plugin"
+    },
+    {
+        "id": "luhman",
+        "name": "Luhman",
+        "author": "Dylan Elliott",
+        "description": "Commands for handling a zettelkasten with Luhman-style IDs as filenames.",
+        "repo": "Dyldog/luhman-obsidian-plugin"
+    },
+    {
+        "id": "obsidian-daily-named-folder",
+        "name": "Daily Named Folder",
+        "author": "Nemo Andrea",
+        "description": "Like daily notes, but nested in a daily folder with a oneline summary. Better for attachment management & glanceability.",
+        "repo": "NemoAndrea/obsidian-daily-named-folder"
+    },
+    {
+        "id": "obsidian-trello",
+        "name": "Trello",
+        "description": "Connect Trello cards to notes.",
+        "author": "Nathonius",
+        "repo": "nathonius/obsidian-trello"
+    },
+    {
+        "id": "obsidian-annotator",
+        "name": "Annotator",
+        "description": "Read and annotate PDFs and EPUB files.",
+        "author": "Elias Sundqvist",
+        "repo": "elias-sundqvist/obsidian-annotator"
+    },
+    {
+        "id": "customjs",
+        "name": "CustomJS",
+        "author": "Sam Lewis",
+        "description": "Reuse custom JavaScript across desktop and mobile.",
+        "repo": "saml-dev/obsidian-custom-js"
+    },
+    {
+        "id": "random-structural-diary-plugin",
+        "name": "Random Structural Diary",
+        "description": "Pick random questions from a prepared question list and answer different questions each time.",
+        "author": "Timur Sidoriuk",
+        "repo": "ShockThunder/RandomStructuralDiary"
+    },
+    {
+        "id": "obsidian-file-link",
+        "name": "Better File Link",
+        "description": "Add better external file links to notes.",
+        "author": "Marc Julian Schwarz",
+        "repo": "marcjulianschwarz/obsidian-file-link"
+    },
+    {
+        "id": "quick-explorer",
+        "name": "Quick Explorer",
+        "description": "Perform file explorer operations (and see your current file path) from the title bar, using the mouse or keyboard.",
+        "author": "PJ Eby",
+        "repo": "pjeby/quick-explorer"
+    },
+    {
+        "id": "obsidian-banners",
+        "name": "Banners",
+        "author": "Danny Hernandez",
+        "description": "Add banner images to your notes!",
+        "repo": "noatpad/obsidian-banners"
+    },
+    {
+        "id": "obsidian-jump-to-date-plugin",
+        "name": "Jump-to-Date",
+        "description": "Popup calendar for quickly navigating dates.",
+        "author": "TfTHacker",
+        "repo": "TfTHacker/obsidian42-jump-to-date"
+    },
+    {
+        "id": "obsidian-icon-folder",
+        "name": "Iconize",
+        "author": "FlorianWoelki",
+        "description": "Add icons to anything in Obsidian, including files, folders, and text.",
+        "repo": "FlorianWoelki/obsidian-iconize"
+    },
+    {
+        "id": "ghost-fade-focus",
+        "name": "Ghost Fade Focus",
+        "author": "Sami Korpela",
+        "description": "Focused on the current line, others faded like a ghost!",
+        "repo": "skipadu/obsidian-ghost-fade-focus"
+    },
+    {
+        "id": "folder-note-core",
+        "name": "Folder Note Core",
+        "description": "Provide core features and API for folder notes.",
+        "author": "AidenLx",
+        "repo": "aidenlx/folder-note-core"
+    },
+    {
+        "id": "obsidian-hackernews",
+        "name": "HackerNews",
+        "author": "arpitbbhayani",
+        "description": "Periodically fetches and displays top stories from HackerNews.",
+        "repo": "arpitbbhayani/obsidian-hackernews"
+    },
+    {
+        "id": "obsidian-reset-font-size",
+        "name": "Reset Font Size",
+        "author": "luckman212",
+        "description": "Add a button and command to reset the font size back to its default value.",
+        "repo": "luckman212/obsidian-reset-font-size"
+    },
+    {
+        "id": "podcast-note",
+        "name": "Podcast Note",
+        "author": "Marc Julian Schwarz",
+        "description": "Podcast Note lets you automatically add podcast information to your notes.",
+        "repo": "marcjulianschwarz/obsidian-podcast-note"
+    },
+    {
+        "id": "obsidian-stille",
+        "name": "Stille",
+        "author": "Michael Lee",
+        "description": "Focus on your writing, a section at a time.",
+        "repo": "michaellee/stille"
+    },
+    {
+        "id": "obsidian-markmind",
+        "name": "Markmind",
+        "author": "Mark",
+        "description": "Mind map, outline and PDF annotation tool. (Closed source)",
+        "repo": "MarkMindCkm/obsidian-markmind"
+    },
+    {
+        "id": "obsidian-carry-forward",
+        "name": "Carry-Forward",
+        "author": "Jacob Levernier",
+        "description": "Copy text from a note, linking back to its copied source, or copy a link to a note block.",
+        "repo": "jglev/obsidian-carry-forward"
+    },
+    {
+        "id": "obsidian-task-archiver",
+        "name": "Archiver",
+        "description": "Move completed tasks to an archive with a date tree.",
+        "author": "ivan-lednev",
+        "repo": "ivan-lednev/obsidian-task-archiver"
+    },
+    {
+        "id": "obsidian-card-view-mode",
+        "name": "Card View Mode",
+        "description": "Enable to view your notes as cards.",
+        "author": "PADAone",
+        "repo": "yo-goto/obsidian-card-view-mode"
+    },
+    {
+        "id": "scales-chords",
+        "name": "Scales and Chords",
+        "description": "Capture musical tab notation. Chords become clickable links to modal images (provided by scales-chords.com).",
+        "author": "egradman",
+        "repo": "egradman/scales-chords"
+    },
+    {
+        "id": "copy-note",
+        "name": "Enhance Copy Note",
+        "author": "kzhovn",
+        "description": "Add commands to copy active note and copy folders.",
+        "repo": "kzhovn/copy-command-obsidian"
+    },
+    {
+        "id": "customizable-menu",
+        "name": "Customizable Menu",
+        "author": "kzhovn",
+        "description": "Add any command to Obsidian's right-click menu.",
+        "repo": "kzhovn/obsidian-customizable-menu"
+    },
+    {
+        "id": "workspaces-plus",
+        "name": "Workspaces Plus",
+        "description": "Quickly switch and manage workspaces.",
+        "author": "NothingIsLost",
+        "repo": "nothingislost/obsidian-workspaces-plus"
+    },
+    {
+        "id": "obsidian-read-it-later",
+        "name": "ReadItLater",
+        "description": "Collect interesting information from your clipboard into your vault. A website will be converted to MD, Tweets and YouTube Videos embedded, plain text will just saved into a new notice.",
+        "author": "Dominik Pieper",
+        "repo": "DominikPieper/obsidian-ReadItLater"
+    },
+    {
+        "id": "obsidian42-text-transporter",
+        "name": "Text Transporter",
+        "description": "Advanced text tools for working with text in your vault.",
+        "author": "TfTHacker",
+        "repo": "TfTHacker/obsidian42-text-transporter"
+    },
+    {
+        "id": "marginnote-companion",
+        "name": "MarginNote Companion",
+        "description": "Bridge MarginNote 3 and Obsidian.",
+        "author": "AidenLx",
+        "repo": "aidenlx/marginnote-companion"
+    },
+    {
+        "id": "netwik",
+        "name": "Netwik",
+        "description": "Union Vault. Access a global network of notes. Anyone can create, view or edit notes. All changes will be synchronized between all participants.",
+        "author": "Boris Bondarenko",
+        "repo": "fivol/netwik-obsidian"
+    },
+    {
+        "id": "obsidian-prominent-starred-files",
+        "name": "Prominent Bookmarked Files",
+        "description": "Prominently display bookmarked notes in the file explorer.",
+        "author": "Jeremy Valentine",
+        "repo": "javalent/prominent-files"
+    },
+    {
+        "id": "ozanshare-publish",
+        "name": "OzanShare Publish",
+        "description": "Publish your Markdown notes with a single click from your vault. (Closed source)",
+        "author": "Ozan Tellioglu",
+        "repo": "ozntel/ozanshare-publish-plugin"
+    },
+    {
+        "id": "obsidian-editor-shortcuts",
+        "name": "Code Editor Shortcuts",
+        "author": "Tim Hor",
+        "description": "Add keyboard shortcuts (hotkeys) commonly found in code editors such as Visual Studio Code (VS Code) or Sublime Text.",
+        "repo": "timhor/obsidian-editor-shortcuts"
+    },
+    {
+        "id": "obsidian-task-collector",
+        "name": "Task Collector (TC)",
+        "description": "Change task status and collect tasks within a document using hotkeys and context menus.",
+        "author": "ebullient",
+        "repo": "ebullient/obsidian-task-collector"
+    },
+    {
+        "id": "metadata-extractor",
+        "name": "Metadata Extractor",
+        "description": "Metadata export (on a schedule) for integration with third-party apps like launchers or graph analysis software.",
+        "author": "kometenstaub",
+        "repo": "kometenstaub/metadata-extractor"
+    },
+    {
+        "id": "quick-latex",
+        "name": "Quick LaTeX",
+        "description": "Simplify and speed up LaTeX math typing.",
+        "author": "joeyuping",
+        "repo": "joeyuping/quick_latex_obsidian"
+    },
+    {
+        "id": "obsidian-itinerary",
+        "name": "Itinerary",
+        "description": "Make planning your trip or event easier by rendering a calendar from event information found in your notes.",
+        "author": "Adam Coddington",
+        "repo": "coddingtonbear/obsidian-itinerary"
+    },
+    {
+        "id": "uri-commands",
+        "name": "URI Commands",
+        "description": "Execute URIs from the command palette.",
+        "author": "kzhovn",
+        "repo": "kzhovn/uri-commands-obsidian"
+    },
+    {
+        "id": "update-time-on-edit",
+        "name": "Update time on edit",
+        "description": "Keep frontmatter in sync with the last edit time.",
+        "author": "beaussan",
+        "repo": "beaussan/update-time-on-edit-obsidian"
+    },
+    {
+        "id": "obsidian-nomnoml-diagram",
+        "name": "Nomnoml Diagram",
+        "description": "Draw nomnoml diagrams.",
+        "author": "Daeik Kim",
+        "repo": "Daeik/obsidian-nomnoml-diagram"
+    },
+    {
+        "id": "map-of-content",
+        "name": "Map of Content",
+        "description": "Automatically generate a Map of Content for your vault.",
+        "author": "Robin Haupt",
+        "repo": "Robin-Haupt-1/Obsidian-Map-of-Content"
+    },
+    {
+        "id": "obsidian-local-images",
+        "name": "Local images",
+        "description": "Find all links to external images in your notes, download and save images locally, and adjust the image links in your notes to point to the saved image files.",
+        "author": "catalysm, aleksey-rezvov",
+        "repo": "aleksey-rezvov/obsidian-local-images"
+    },
+    {
+        "id": "obsidian-vocabulary-view",
+        "name": "Vocabulary View",
+        "description": "Write down some words with their explanations and preview them in a vocabulary test style.",
+        "author": "nnshi-s",
+        "repo": "nnshi-s/obsidian-vocabulary-view-plugin"
+    },
+    {
+        "id": "obsidian42-brat",
+        "name": "BRAT",
+        "description": "Easily install a beta version of a plugin for testing.",
+        "author": "TfTHacker",
+        "repo": "TfTHacker/obsidian42-brat"
+    },
+    {
+        "id": "snippet-commands-obsidian",
+        "name": "Snippet Commands",
+        "author": "death_au",
+        "description": "Register custom CSS snippets as commands (which you can bind hotkeys to).",
+        "repo": "deathau/snippet-commands-obsidian"
+    },
+    {
+        "id": "obsidian-javascript-init",
+        "name": "JavaScript Init",
+        "description": "Run JavaScript when Obsidian loads, or at any other time.",
+        "author": "ryanpcmcquen",
+        "repo": "ryanpcmcquen/obsidian-javascript-init"
+    },
+    {
+        "id": "key-promoter",
+        "name": "Key Promoter",
+        "description": "Learn keyboard shortcuts by showing them when using the mouse.",
+        "author": "Johannes Theiner",
+        "repo": "joethei/obsidian-key-promoter"
+    },
+    {
+        "id": "obsidian-livesync",
+        "name": "Self-hosted LiveSync",
+        "author": "vorotamoroz",
+        "description": "Community implementation of self-hosted livesync. Reflect your vault changes to some other devices immediately. Please make sure to disable other synchronize solutions to avoid content corruption or duplication.",
+        "repo": "vrtmrz/obsidian-livesync"
+    },
+    {
+        "id": "obsidian-plotly",
+        "name": "Plotly",
+        "author": "Dmitriy Shulha",
+        "description": "Embed Plotly charts in your notes.",
+        "repo": "Dmytro-Shulha/obsidian-plotly"
+    },
+    {
+        "id": "obsidian-wikipedia",
+        "name": "Wikipedia",
+        "description": "Get the first section of Wikipedia for a note title or search term.",
+        "author": "Jonathan Miller",
+        "repo": "jmilldotdev/obsidian-wikipedia"
+    },
+    {
+        "id": "lumberjack-obsidian",
+        "name": "Lumberjack",
+        "description": "Log your thoughts! Lumberjack adds URL commands to help you axe inefficiency and get right to writing.",
+        "author": "ryanjamurphy",
+        "repo": "ryanjamurphy/lumberjack-obsidian"
+    },
+    {
+        "id": "obsidian-link-converter",
+        "name": "Link Converter",
+        "description": "Scan all your links in the vault and convert them to your desired format.",
+        "author": "Ozan Tellioglu",
+        "repo": "ozntel/obsidian-link-converter"
+    },
+    {
+        "id": "mysnippets-plugin",
+        "name": "MySnippets",
+        "description": "A status bar menu allowing you to quickly toggle snippets on and off.",
+        "author": "Chetachi",
+        "repo": "chetachiezikeuzor/MySnippets-Plugin"
+    },
+    {
+        "id": "obsidian-hypothesis-plugin",
+        "name": "Hypothes.is",
+        "description": "Sync your Hypothesis highlights.",
+        "author": "weichenw",
+        "repo": "weichenw/obsidian-hypothesis-plugin"
+    },
+    {
+        "id": "obsidian-another-quick-switcher",
+        "name": "Another Quick Switcher",
+        "author": "tadashi-aikawa",
+        "description": "Another choice of Quick switcher.",
+        "repo": "tadashi-aikawa/obsidian-another-quick-switcher"
+    },
+    {
+        "id": "link-headers-directly",
+        "name": "Link Headers Directly",
+        "description": "When a header is linked, preview mode will show only the header, and not the note name.",
+        "author": "Signynt",
+        "repo": "Signynt/link-headers-directly"
+    },
+    {
+        "id": "meld-calc",
+        "name": "Meld Calc",
+        "description": "Do math! Evaluate math expressions within your notes.",
+        "author": "meld-cp",
+        "repo": "meld-cp/obsidian-calc"
+    },
+    {
+        "id": "tabout",
+        "name": "Tabout",
+        "author": "phibr0",
+        "description": "Easily 'tab out' of links or other Markdown formatting characters.",
+        "repo": "phibr0/obsidian-tabout"
+    },
+    {
+        "id": "quote-of-the-day",
+        "name": "Quote of the Day",
+        "description": "Insert random quotes in the editor.",
+        "author": "Florin Bobis",
+        "repo": "twentytwokhz/quote-of-the-day"
+    },
+    {
+        "id": "obsidian-limelight",
+        "name": "Limelight",
+        "description": "Spotlight your active pane.",
+        "author": "Scott Mikula",
+        "repo": "smikula/obsidian-limelight"
+    },
+    {
+        "id": "prompt",
+        "name": "Prompt",
+        "author": "Hung-Su Nguyen",
+        "description": "Show inspirational prompts, from a prompt file in your vault.",
+        "repo": "hungsu/obsidian-prompt"
+    },
+    {
+        "id": "obsidian-link-archive",
+        "name": "Link Archive",
+        "author": "Tam\u00e1s Deme",
+        "description": "Archive links in your note so they're available to you even if the original site goes down or gets removed.",
+        "repo": "tomzorz/obsidian-link-archive"
+    },
+    {
+        "id": "obsidian-html-tags-autocomplete",
+        "name": "HTML Tags Autocomplete",
+        "description": "Automatically add closing HTML tags.",
+        "author": "bicarlsen",
+        "repo": "bicarlsen/obsidian_html_tags_autocomplete"
+    },
+    {
+        "id": "advanced-cursors",
+        "name": "Advanced Cursors",
+        "description": "Use multiple cursors even more powerfully.",
+        "author": "SkepticMystic",
+        "repo": "SkepticMystic/advanced-cursors"
+    },
+    {
+        "id": "stenography-obsidian",
+        "name": "Stenography",
+        "description": "Translate code blocks into simple English using Machine Learning with the Stenography API.",
+        "author": "bramses",
+        "repo": "bramses/stenography-obsidian"
+    },
+    {
+        "id": "obsidian-webhooks",
+        "name": "Webhooks",
+        "author": "Stephen Solka",
+        "description": "Connect your editor to the internet of things through webhooks.",
+        "repo": "trashhalo/obsidian-webhooks"
+    },
+    {
+        "id": "obsidian-tweet-to-markdown",
+        "name": "Tweet to Markdown",
+        "description": "Save tweets as Markdown files, along with their images, polls, etc.",
+        "author": "kbravh",
+        "repo": "kbravh/obsidian-tweet-to-markdown"
+    },
+    {
+        "id": "obsidian-habitica-integration",
+        "name": "Habitica Sync",
+        "description": "Integrate Habitica tasks and stats.",
+        "author": "Leoh and Ran",
+        "repo": "SuperChamp234/habitica-sync"
+    },
+    {
+        "id": "obsidian-oura-plugin",
+        "name": "Oura Ring",
+        "description": "Import Oura Ring data into a note.",
+        "author": "Andrew Lombardi",
+        "repo": "kinabalu/obsidian-oura-plugin"
+    },
+    {
+        "id": "obsidian-metacopy",
+        "name": "Metacopy & URL",
+        "description": "Copy the value of a frontmatter key and create a link from it using various settings.",
+        "author": "Mara-Li",
+        "repo": "Mara-Li/obsidian-metacopy"
+    },
+    {
+        "id": "obsidian-image-caption",
+        "name": "Image Caption",
+        "description": "Add caption to images.",
+        "author": "bicarlsen",
+        "repo": "bicarlsen/obsidian_image_caption"
+    },
+    {
+        "id": "graph-analysis",
+        "name": "Graph Analysis",
+        "description": "Find hidden connections between notes in your vault using cool graph algorithms.",
+        "author": "SkepticMystic & Emile",
+        "repo": "SkepticMystic/graph-analysis"
+    },
+    {
+        "id": "obsidian-custom-attachment-location",
+        "name": "Custom Attachment Location",
+        "description": "Customize attachment location with variables($filename, $data, etc) like Typora.",
+        "author": "RainCat1998",
+        "repo": "RainCat1998/obsidian-custom-attachment-location"
+    },
+    {
+        "id": "cryptsidian",
+        "name": "Cryptsidian",
+        "description": "Encrypt all files in your vault with a password.",
+        "author": "triumphantomato",
+        "repo": "triumphantomato/cryptsidian"
+    },
+    {
+        "id": "obsidian-crypto-lookup",
+        "name": "Crypto Lookup",
+        "description": "Use the Cryptonator API to pull prices for crypto in a target currency.",
+        "author": "Andrew Lombardi",
+        "repo": "kinabalu/obsidian-crypto-lookup"
+    },
+    {
+        "id": "copy-as-latex",
+        "name": "Copy as LaTeX",
+        "description": "Quickly copy Markdown as LaTeX, with citations.",
+        "author": "mo-seph",
+        "repo": "mo-seph/obsidian-copy-as-latex"
+    },
+    {
+        "id": "obsidian-auto-split",
+        "name": "Auto Split",
+        "description": "Open notes with split editor & preview.",
+        "author": "James Sartelle",
+        "repo": "jsartelle/obsidian-auto-split"
+    },
+    {
+        "id": "obsidian-word-sprint",
+        "name": "Word Sprint",
+        "description": "Word Sprint for your writing projects like NaNoWriMo.",
+        "author": "Andrew Lombardi",
+        "repo": "kinabalu/obsidian-word-sprint"
+    },
+    {
+        "id": "copy-publish-url",
+        "name": "Publish and GitHub URL",
+        "description": "Copy or open the URL of the corresponding note on your Publish site. You can also open its Git commit history on GitHub.",
+        "author": "kometenstaub",
+        "repo": "kometenstaub/copy-publish-url"
+    },
+    {
+        "id": "card-board",
+        "name": "CardBoard",
+        "author": "roovo",
+        "description": "Display Markdown tasks on kanban-style boards.",
+        "repo": "roovo/obsidian-card-board"
+    },
+    {
+        "id": "obsidian-bible-reference",
+        "name": "Bible Reference",
+        "description": "Take Bible study notes easily. Automatically suggests Bible verses as references.",
+        "author": "tim-hub",
+        "repo": "tim-hub/obsidian-bible-reference"
+    },
+    {
+        "id": "obsidian-sentence-navigator",
+        "name": "Sentence Navigator",
+        "author": "Tim Hor & Andrew Brown",
+        "description": "Manipulate sentences as a unit of movement.",
+        "repo": "timhor/obsidian-sentence-navigator"
+    },
+    {
+        "id": "language-translator",
+        "name": "Language Translator",
+        "description": "Translate selected text in the desired language.",
+        "author": "Florin Bobis",
+        "repo": "twentytwokhz/language-translator"
+    },
+    {
+        "id": "auto-class",
+        "name": "Auto Class",
+        "description": "Automatically apply CSS classes to Markdown views based on a note's path.",
+        "author": "Nathonius",
+        "repo": "nathonius/obsidian-auto-class"
+    },
+    {
+        "id": "obsidian-cloudinary-uploader",
+        "name": "Cloudinary Uploader",
+        "author": "Jordan Handy",
+        "description": "Upload pasted images from your clipboard to Cloudinary.",
+        "repo": "jordanhandy/obsidian-cloudinary-uploader"
+    },
+    {
+        "id": "rss-reader",
+        "name": "RSS Reader",
+        "description": "Read articles from RSS feeds and incorporate them into your notes.",
+        "author": "Johannes Theiner",
+        "repo": "joethei/obsidian-rss"
+    },
+    {
+        "id": "mousewheel-image-zoom",
+        "name": "Mousewheel Image zoom",
+        "description": "Increase or decrease the size of an image by scrolling.",
+        "author": "Nico Jeske",
+        "repo": "nicojeske/mousewheel-image-zoom"
+    },
+    {
+        "id": "obsidian-flexible-pomo",
+        "name": "Flexible Pomodoro",
+        "description": "Add a pomodoro timer to your status bar. This pomodoro has additional options such as early log and extend.",
+        "author": "grassbl8d",
+        "repo": "grassbl8d/flexible-pomo-obsidian"
+    },
+    {
+        "id": "obsidian-lineup-builder",
+        "name": "Lineup Builder",
+        "description": "Build football lineups.",
+        "author": "James Fallon",
+        "repo": "James-Fallon/obsidian-lineup-builder"
+    },
+    {
+        "id": "reveal-active-file-button",
+        "name": "Reveal Active File Button",
+        "description": "Add a button to the top of the File Explorer, to reveal the active file.",
+        "author": "Clare Macrae",
+        "repo": "claremacrae/reveal-active-file-button-plugin"
+    },
+    {
+        "id": "obsidian-structured-plugin",
+        "name": "Structured",
+        "description": "Structured plugin. Create hierarchy in notes using \".\"",
+        "author": "dobrovolsky",
+        "repo": "dobrovolsky/obsidian-structure"
+    },
+    {
+        "id": "cooklang-obsidian",
+        "name": "CookLang Editor",
+        "description": "Edit and display CookLang recipes.",
+        "author": "death_au/cooklang",
+        "repo": "cooklang/cooklang-obsidian"
+    },
+    {
+        "id": "highlightr-plugin",
+        "name": "Highlightr",
+        "description": "A minimal and aesthetically pleasing highlighting menu that makes color-coded highlighting much easier with a configurable assortment of highlight colors.",
+        "author": "Chetachi",
+        "repo": "chetachiezikeuzor/Highlightr-Plugin"
+    },
+    {
+        "id": "remotely-save",
+        "name": "Remotely Save",
+        "author": "fyears",
+        "description": "Sync notes between local and cloud with smart conflict: S3 (Amazon S3/Cloudflare R2/Backblaze B2/...), Dropbox, webdav (NextCloud/InfiniCLOUD/Synology/...), OneDrive, Google Drive (GDrive), Box, pCloud, Yandex Disk, Koofr, Azure Blob Storage.",
+        "repo": "remotely-save/remotely-save"
+    },
+    {
+        "id": "obsidian-notes-from-template",
+        "name": "From Template",
+        "description": "Create new notes from Templates - for each Template, provides a Command to trigger it, and a form to fill in any variables in the template.",
+        "author": "mo-seph",
+        "repo": "mo-seph/obsidian-note-from-template"
+    },
+    {
+        "id": "obsidian-overdue",
+        "name": "Overdue",
+        "description": "Mark items as [[Overdue]] if they are not checked off by their due date.",
+        "author": "Peter Parente",
+        "repo": "parente/obsidian-overdue"
+    },
+    {
+        "id": "obsidian-dialogue-plugin",
+        "name": "Dialogue",
+        "description": "Create dialogues in Markdown.",
+        "author": "Jakub Holub",
+        "repo": "holubj/obsidian-dialogue-plugin"
+    },
+    {
+        "id": "obsidian-title-serial-number-plugin",
+        "name": "Title Serial Number",
+        "description": "Add serial numbers to your Markdown title.",
+        "author": "Domenic",
+        "repo": "yalvhe2009/obsidian-title-serial-number-plugin"
+    },
+    {
+        "id": "obsidian-theme-design-utilities",
+        "name": "Theme Design Utilities",
+        "description": "Some utilities and quality-of-life features for designers of Obsidian themes.",
+        "author": "pseudometa",
+        "repo": "chrisgrieser/obsidian-theme-design-utilities"
+    },
+    {
+        "id": "generic-initiative-tracker",
+        "name": "Generic Initiative Tracker",
+        "description": "TTRPG generic initiative tracker.",
+        "author": "Beau Shinkle",
+        "repo": "beaushinkle/obsidian-generic-initiative-tracker"
+    },
+    {
+        "id": "obsidian-ankibridge",
+        "name": "AnkiBridge",
+        "description": "Yet Another Anki Bridge. Focuses on a strict grammar and integrity of your data.",
+        "author": "JeppeKlitgaard",
+        "repo": "JeppeKlitgaard/ObsidianAnkiBridge"
+    },
+    {
+        "id": "obsidian-tressel",
+        "name": "Tressel Sync",
+        "description": "Official Tressel plugin to sync/export your tweets and threads.",
+        "author": "Tressel",
+        "repo": "tresselteam/obsidian-tressel"
+    },
+    {
+        "id": "image-window",
+        "name": "Second Window",
+        "description": "Allow images & notes to be viewed in new windows.",
+        "author": "Jeremy Valentine",
+        "repo": "javalent/second-window"
+    },
+    {
+        "id": "obsidian-tts",
+        "name": "Text to Speech",
+        "description": "Hear your notes.",
+        "author": "Johannes Theiner",
+        "repo": "joethei/obsidian-tts"
+    },
+    {
+        "id": "link-favicon",
+        "name": "Link Favicons",
+        "description": "See the favicon for a linked website.",
+        "author": "Johannes Theiner",
+        "repo": "joethei/obsidian-link-favicon"
+    },
+    {
+        "id": "get-info-plugin",
+        "name": "Get Info",
+        "description": "Tuck a menu inside your status bar and show helpful information for your chosen file.",
+        "author": "Chetachi",
+        "repo": "chetachiezikeuzor/Get-Info-Plugin"
+    },
+    {
+        "id": "matter",
+        "name": "Matter",
+        "author": "Matter",
+        "description": "Official Matter integration.",
+        "repo": "getmatterapp/obsidian-matter"
+    },
+    {
+        "id": "obsidian-regex-replace",
+        "name": "Regex Find/Replace",
+        "description": "A find/replace dialog which optionally supports regular expressions and scope (full document or text selection).",
+        "author": "Martin Eder",
+        "repo": "Gru80/obsidian-regex-replace"
+    },
+    {
+        "id": "obsidian-wordpress",
+        "name": "WordPress",
+        "description": "Publish to WordPress.",
+        "author": "devbean",
+        "repo": "devbean/obsidian-wordpress"
+    },
+    {
+        "id": "obsidian-icon-shortcodes",
+        "name": "Icon Shortcodes",
+        "description": "Insert emoji and custom icons with shortcodes.",
+        "author": "AidenLx",
+        "repo": "aidenlx/obsidian-icon-shortcodes"
+    },
+    {
+        "id": "obsidian-tagfolder",
+        "name": "TagFolder",
+        "author": "vorotamoroz",
+        "description": "Show tags as folder.",
+        "repo": "vrtmrz/obsidian-tagfolder"
+    },
+    {
+        "id": "obsidian-advanced-slides",
+        "name": "Advanced Slides",
+        "author": "MSzturc",
+        "description": "Create Markdown-based presentations.",
+        "repo": "MSzturc/obsidian-advanced-slides"
+    },
+    {
+        "id": "obsidian-graphviz",
+        "name": "Graphviz",
+        "description": "Render Graphviz diagrams.",
+        "author": "Feng Peng",
+        "repo": "QAMichaelPeng/obsidian-graphviz"
+    },
+    {
+        "id": "vim-im-select",
+        "name": "Vim IM Select",
+        "description": "Support auto select the apposite input method in different vim mode.",
+        "author": "Alonelur",
+        "repo": "ALONELUR/vim-im-select-obsidian"
+    },
+    {
+        "id": "obsidian-emotion-picker",
+        "name": "Emotion Picker",
+        "author": "dartungar",
+        "description": "Choose an emotion from a list to insert into a note.",
+        "repo": "dartungar/obsidian-emotion-picker"
+    },
+    {
+        "id": "quoth",
+        "name": "Quoth",
+        "description": "More flexible embedding. Embed precise selections, inline embeds, optionally include author and title.",
+        "author": "Eric Rykwalder",
+        "repo": "erykwalder/quoth"
+    },
+    {
+        "id": "obsidian-metronome-plugin",
+        "name": "Metronome",
+        "description": "Add interactive metronomes to your notes.",
+        "author": "Curt Grimes",
+        "repo": "curtgrimes/obsidian-metronome-plugin"
+    },
+    {
+        "id": "obsidian-wrap-with-shortcuts",
+        "name": "Wrap with shortcuts",
+        "description": "Wrap selected text in custom tags with shortcuts. E.g.: underline, sub, ruby(\u30d5\u30ea\u30ac\u30ca).",
+        "author": "Manic Chuang",
+        "repo": "manic/obsidian-wrap-with-shortcuts"
+    },
+    {
+        "id": "obsidian-tomorrows-daily-note",
+        "name": "Tomorrow's Daily Note",
+        "author": "Will Olson",
+        "description": "Create tomorrow's daily note for preemptive planning.",
+        "repo": "frankolson/obsidian-tomorrows-daily-note"
+    },
+    {
+        "id": "obsidian-rant",
+        "name": "Rant-Lang",
+        "author": "Leander Nei\u00df",
+        "description": "Thin wrapper around the high-level procedural templating language Rant.",
+        "repo": "lanice/obsidian-rant"
+    },
+    {
+        "id": "obsidian-global-hotkeys",
+        "name": "Global Hotkeys",
+        "description": "Configurable system-wide hotkeys for running commands.",
+        "author": "Marc Jessome",
+        "repo": "mjessome/obsidian-global-hotkeys"
+    },
+    {
+        "id": "obsidian-timestamper",
+        "name": "TimeStamper",
+        "description": "Insert a customized or predefined time- or date-stamp at the current cursor position.",
+        "author": "Martin Eder",
+        "repo": "Gru80/obsidian-timestamper"
+    },
+    {
+        "id": "obsidian-import-json",
+        "name": "JSON/CSV Importer",
+        "author": "farling42",
+        "description": "Import a JSON file containing an array of data, creating notes from a Handlebars template file.",
+        "repo": "farling42/obsidian-import-json"
+    },
+    {
+        "id": "obsidian-completr",
+        "name": "Completr",
+        "author": "tth05",
+        "description": "Advanced auto-completion for LaTeX, frontmatter, and standard writing.",
+        "repo": "tth05/obsidian-completr"
+    },
+    {
+        "id": "obsidian-binary-file-manager-plugin",
+        "name": "Binary File Manager",
+        "description": "Detect new binary files in the vault and create Markdown files with metadata.",
+        "author": "qawatake",
+        "repo": "qawatake/obsidian-binary-file-manager-plugin"
+    },
+    {
+        "id": "obsidian-local-file-interface-plugin",
+        "name": "Local File Interface",
+        "description": "Commands for moving files in and out of the vault.",
+        "author": "qawatake",
+        "repo": "qawatake/obsidian-local-file-interface-plugin"
+    },
+    {
+        "id": "obsidian-siteswap",
+        "name": "Siteswap",
+        "description": "Visualize Juggling Pattern Siteswap via the JugglingLab gif server.",
+        "author": "Tim Dresser",
+        "repo": "tdresser/obsidian-siteswap"
+    },
+    {
+        "id": "obsidian-tweaks",
+        "name": "Tweaks",
+        "description": "Add convenient tweaks including improved toggling and ergonomic commands.",
+        "author": "Jeppe Klitgaard",
+        "repo": "JeppeKlitgaard/ObsidianTweaks"
+    },
+    {
+        "id": "obsidian-memos",
+        "name": "Thino",
+        "description": "Quickly capture memos and display them in the sidebar with a heatmap. (Closed source)",
+        "author": "Boninall",
+        "repo": "Quorafind/Obsidian-Thino"
+    },
+    {
+        "id": "para-shortcuts",
+        "name": "PARA Shortcuts",
+        "description": "Useful commands to set up and manage your knowledge using the PARA method.",
+        "author": "gOAT",
+        "repo": "gOATiful/para-shortcuts"
+    },
+    {
+        "id": "13th-age-statblocks",
+        "name": "13th Age Statblocks",
+        "author": "ben",
+        "description": "Render 13th Age statblocks.",
+        "repo": "ben/obsidian-13th-age-statblocks"
+    },
+    {
+        "id": "obsidian-dynamic-highlights",
+        "name": "Dynamic Highlights",
+        "description": "Dynamically highlight text based on cursor selection or search query with full regex, mobile, and live preview support.",
+        "author": "nothingislost",
+        "repo": "nothingislost/obsidian-dynamic-highlights"
+    },
+    {
+        "id": "obsidian-koreader-plugin",
+        "name": "KOReader Highlights",
+        "description": "Sync highlights/notes from KOReader.",
+        "author": "Federico \"Edo\" Granata",
+        "repo": "Edo78/obsidian-koreader-sync"
+    },
+    {
+        "id": "obsidian-snippetor",
+        "name": "Snippetor",
+        "description": "Create and tweak common snippets.",
+        "author": "ebullient",
+        "repo": "ebullient/obsidian-snippetor"
+    },
+    {
+        "id": "weather-fetcher",
+        "name": "Weather Fetcher",
+        "author": "fyears",
+        "description": "Fetch and insert current weather into a note.",
+        "repo": "fyears/weather-fetcher"
+    },
+    {
+        "id": "obsidian-lock-screen-plugin",
+        "name": "Lock Screen",
+        "author": "Eric Biewener",
+        "description": "Protect your vault with a lock screen.",
+        "repo": "ericbiewener/obsidian-lock-screen-plugin"
+    },
+    {
+        "id": "pinboard-sync",
+        "name": "Pinboard Sync",
+        "author": "Mathew Spolin",
+        "description": "Sync Pinboard.in links with your daily notes.",
+        "repo": "Automatt/obsidian-pinboard-sync"
+    },
+    {
+        "id": "obsidian-shortcut-launcher",
+        "name": "Shortcut Launcher",
+        "author": "MacStories",
+        "description": "Trigger shortcuts in Apple's Shortcuts app from Obsidian with custom commands.",
+        "repo": "macstories/obsidian-shortcut-launcher"
+    },
+    {
+        "id": "obsidian-file-info-plugin",
+        "name": "File Info Panel",
+        "description": "Create a File Info view that displays the active file's date created, date modified, file size, and links to open the file in its native application and to open the file's folder.",
+        "author": "CattailNu",
+        "repo": "CattailNu/obsidian-file-info-panel-plugin"
+    },
+    {
+        "id": "obsidian-topic-linking",
+        "name": "Topic Linking",
+        "author": "Liam Magee",
+        "description": "Convert PDF files and web links to Markdown, and create topics from Markdown.",
+        "repo": "liammagee/obsidian-topic-linking"
+    },
+    {
+        "id": "multi-column-markdown",
+        "name": "Multi-Column Markdown",
+        "author": "Cameron Robinson",
+        "description": "Create Markdown documents with multiple columns of content viewable in reading mode.",
+        "repo": "ckRobinson/multi-column-markdown"
+    },
+    {
+        "id": "copy-as-html",
+        "name": "Copy as HTML",
+        "author": "Bailey Jennings",
+        "description": "Convert the selected Markdown to HTML and copy it to the clipboard.",
+        "repo": "jenningsb2/copy-as-html"
+    },
+    {
+        "id": "obsidian-frontmatter-tag-suggest",
+        "name": "Frontmatter Tag Suggest",
+        "description": "Autocomplete tags in the frontmatter tags field.",
+        "author": "Jonathan Miller",
+        "repo": "jmilldotdev/obsidian-frontmatter-tag-suggest"
+    },
+    {
+        "id": "simple-note-quiz",
+        "name": "Simple Note Quiz",
+        "author": "beginner137",
+        "description": "Start a simple quiz on your current note.",
+        "repo": "beginner137/Obsidian-simple-note-quiz"
+    },
+    {
+        "id": "obsidian-local-rest-api",
+        "name": "Local REST API",
+        "description": "Unlock your automation needs by interacting with your notes over a secure REST API.",
+        "author": "Adam Coddington",
+        "repo": "coddingtonbear/obsidian-local-rest-api"
+    },
+    {
+        "id": "obsidian-codeblock-labels",
+        "name": "Code Block Labels",
+        "author": "Sean Bowers",
+        "description": "Add labels to fenced code blocks.",
+        "repo": "stbowers/obsidian-codeblock-labels"
+    },
+    {
+        "id": "obsidian-better-command-palette",
+        "name": "Better Command Palette",
+        "author": "Alex Bieg",
+        "description": "A command palette that does all of the things you want it to do.",
+        "repo": "AlexBieg/obsidian-better-command-palette"
+    },
+    {
+        "id": "obsidian-relativenumber",
+        "name": "Relativenumber (relative line numbers)",
+        "author": "Rob Stevenson",
+        "description": "Display relative line numbers in the editor's gutter.",
+        "repo": "thisdotrob/obsidian-relativenumber-plugin"
+    },
+    {
+        "id": "obsidian-core-search-assistant-plugin",
+        "name": "Core Search Assistant",
+        "description": "Enhance built-in search: keyboard interface, card preview, bigger preview.",
+        "author": "qawatake",
+        "repo": "qawatake/obsidian-core-search-assistant-plugin"
+    },
+    {
+        "id": "obsidian-save-as-gist",
+        "name": "Save as Gist",
+        "author": "ghedamat",
+        "description": "Save current note as a GitHub Gist.",
+        "repo": "ghedamat/obsidian-save-as-gist"
+    },
+    {
+        "id": "obsidian-divide-and-conquer",
+        "name": "Divide & Conquer",
+        "author": "pseudometa",
+        "description": "Commands for bulk enabling/disabling of plugins. Useful for debugging when you have many plugins.",
+        "repo": "chrisgrieser/obsidian-divide-and-conquer"
+    },
+    {
+        "id": "obsidian-excel-to-markdown-table",
+        "name": "Excel to Markdown Table",
+        "author": "Ganessh Kumar R P",
+        "description": "Paste data from Microsoft Excel, Google Sheets, Apple Numbers and LibreOffice Calc as Markdown tables.",
+        "repo": "ganesshkumar/obsidian-excel-to-markdown-table"
+    },
+    {
+        "id": "obsidian-power-search",
+        "name": "Power Search",
+        "author": "Aviral Batra",
+        "description": "Search notes based on current line.",
+        "repo": "aviral-batra/obsidian-power-search"
+    },
+    {
+        "id": "tag-word-cloud",
+        "name": "Tag, Word & Link Cloud",
+        "author": "Johannes Theiner",
+        "description": "Show a cloud of your tags, words, or links.",
+        "repo": "joethei/obsidian-tagcloud"
+    },
+    {
+        "id": "persistent-graph",
+        "name": "Persistent Graph",
+        "author": "Sanqui",
+        "description": "Save and restore the positions of nodes on your graph.",
+        "repo": "Sanqui/obsidian-persistent-graph"
+    },
+    {
+        "id": "auto-note-mover",
+        "name": "Auto Note Mover",
+        "author": "faru",
+        "description": "Automatically move the active notes to their respective folders according to rules you set.",
+        "repo": "farux/obsidian-auto-note-mover"
+    },
+    {
+        "id": "insert-heading-link",
+        "name": "Insert Heading Link",
+        "author": "Signynt",
+        "description": "Add a command to create a link to a heading.",
+        "repo": "Signynt/insert-heading-link"
+    },
+    {
+        "id": "settings-search",
+        "name": "Settings Search",
+        "author": "Jeremy Valentine",
+        "description": "Globally search settings.",
+        "repo": "javalent/settings-search"
+    },
+    {
+        "id": "japanese-word-splitter",
+        "name": "Word Splitting for Japanese in Edit Mode",
+        "author": "sonarAIT",
+        "description": "A patch for Obsidian's built-in CodeMirror Editor to support Japanese word splitting.",
+        "repo": "sonarAIT/cm-japanese-patch"
+    },
+    {
+        "id": "alx-folder-note-folderv",
+        "name": "AidenLx's Folder Note - folderv Component",
+        "description": "Optional `folderv` component for alx-folder-note.",
+        "author": "AidenLx",
+        "repo": "aidenlx/alx-folder-note-folderv"
+    },
+    {
+        "id": "obsidian-chevereto-image-uploader",
+        "name": "Chevereto Image Uploader",
+        "description": "Upload images in your clipboard to Chevereto.",
+        "author": "kkzzhizhou",
+        "repo": "kkzzhizhou/obsidian-chevereto-image-uploader"
+    },
+    {
+        "id": "todoist-text",
+        "name": "Todoist Text",
+        "author": "Wes Moncrief",
+        "description": "Integrate your Todoist tasks with Markdown checkboxes.",
+        "repo": "wesmoncrief/obsidian-todoist-text"
+    },
+    {
+        "id": "big-calendar",
+        "name": "Big Calendar",
+        "author": "Boninall",
+        "description": "A big calendar for Obsidian. All events from your daily notes OR tasks used TASKS/DATAVIEW/KANBAN format.",
+        "repo": "Quorafind/Obsidian-Big-Calendar"
+    },
+    {
+        "id": "obsidian-command-palette-minus-plugin",
+        "name": "Command Palette--",
+        "author": "qawatake",
+        "description": "Command palette without unwanted commands.",
+        "repo": "qawatake/obsidian-command-palette-minus-plugin"
+    },
+    {
+        "id": "obsidian-remember-file-state",
+        "name": "Remember File State",
+        "author": "Ludovic Chabant",
+        "description": "Remember cursor position, selection, scrolling, and more for each file.",
+        "repo": "ludovicchabant/obsidian-remember-file-state"
+    },
+    {
+        "id": "obsidian-things-link",
+        "name": "Things Link",
+        "author": "@gavmn",
+        "description": "Seamlessly link an Note to a Things Project.",
+        "repo": "gavinmn/obsidian-things-link"
+    },
+    {
+        "id": "markdown-shortcuts",
+        "name": "Markdown shortcuts",
+        "author": "Jules Guesnon",
+        "description": "Write Markdown from shortcuts.",
+        "repo": "JulesGuesnon/obsidian-markdown-shortcuts"
+    },
+    {
+        "id": "digitalgarden",
+        "name": "Digital Garden",
+        "description": "Publish your notes to a digital garden for others to enjoy.",
+        "author": "Ole Eskild Steensen",
+        "repo": "oleeskild/obsidian-digital-garden"
+    },
+    {
+        "id": "obsidian-living-graph",
+        "name": "Living Graph",
+        "description": "A for-fun graph plugin.",
+        "author": "Garrett",
+        "repo": "geoffreysflaminglasersword/obsidian-living-graph"
+    },
+    {
+        "id": "obsidian-hotkeys-chords",
+        "name": "Hotkeys Chords",
+        "author": "Dario Balboni",
+        "description": "Configurable hotkeys chords to activate commands.",
+        "repo": "trenta3/obsidian-hotkeys-chords"
+    },
+    {
+        "id": "obsidian-key-sequence-shortcut",
+        "name": "Key Sequence Shortcut",
+        "author": "anselmwang",
+        "description": "Execute commands with short key sequences. For example, 'tp' for 'Toggle Preview' and 'tb' for 'Toggle Sidebar'. Easier to remember.",
+        "repo": "anselmwang/obsidian-key-sequence-shortcut"
+    },
+    {
+        "id": "obsidian-full-calendar",
+        "name": "Full Calendar",
+        "author": "Davis Haupt (@davish)",
+        "description": "Keep events and manage your calendar alongside all your other notes in your vault.",
+        "repo": "obsidian-community/obsidian-full-calendar"
+    },
+    {
+        "id": "heatmap-calendar",
+        "name": "Heatmap Calendar",
+        "author": "Richard Slettevoll",
+        "description": "Activity Year Overview for DataviewJS, Github style \u2013 Track Goals, Progress, Habits, Tasks, Exercise, Finances, \"Dont Break the Chain\" etc.",
+        "repo": "Richardsl/heatmap-calendar-obsidian"
+    },
+    {
+        "id": "obsidian-daily-notes-opener",
+        "name": "Daily notes opener",
+        "author": "Reorx",
+        "description": "Easily open daily notes and periodic notes in new pane; customize periodic notes background; quick append new line to daily notes.",
+        "repo": "reorx/obsidian-daily-notes-opener"
+    },
+    {
+        "id": "obsidian-mark-and-select",
+        "name": "Mark and Select",
+        "author": "anselmwang",
+        "description": "Set mark, move cursors freely and select from mark to cursor position.",
+        "repo": "anselmwang/obsidian-mark-and-select"
+    },
+    {
+        "id": "obsidian-bible-linker",
+        "name": "Bible Linker",
+        "author": "Jakub Kuchejda",
+        "description": "Link/Copy multiple Bible verses easily using your own Bible files. Compatible with the Bible Study Kit.",
+        "repo": "kuchejak/obsidian-bible-linker-plugin"
+    },
+    {
+        "id": "obsidian-circuitjs",
+        "name": "CircuitJS",
+        "author": "Steven Gann",
+        "description": "Embed CircuitJS circuit simulations into notes.",
+        "repo": "StevenGann/obsidian-circuitjs"
+    },
+    {
+        "id": "creases",
+        "name": "Creases",
+        "author": "Liam Cain",
+        "description": "Tools for effectively folding Markdown sections.",
+        "repo": "liamcain/obsidian-creases"
+    },
+    {
+        "id": "obsidian-kobo-highlights-importer-plugin",
+        "name": "Kobo Highlights Importer",
+        "author": "Kevin Hellemun & Flavio Cordari",
+        "description": "Import highlights from Kobo devices.",
+        "repo": "OGKevin/obsidian-kobo-highlights-import"
+    },
+    {
+        "id": "obsidian-dynamic-embed",
+        "name": "Dynamic Embed",
+        "author": "Ivaylo Dimitrov Dabravin",
+        "description": "Embed snippets, templates and any linkable by delegating the current scope to the embedded file, treating it as content instead of a reference.",
+        "repo": "dabravin/obsidian-dynamic-embed"
+    },
+    {
+        "id": "obsidian-steemit",
+        "name": "Steemit",
+        "author": "anpigon",
+        "description": "Publish documents to Steemit.",
+        "repo": "anpigon/obsidian-steemit-plugin"
+    },
+    {
+        "id": "obsidian-kindle-export",
+        "name": "Kindle Export",
+        "author": "Simeon Stanek",
+        "description": "Export your notes to your Kindle, including embedded notes and images.",
+        "repo": "SimeonLukas/obsidian-kindle-export"
+    },
+    {
+        "id": "obsidian-search-everywhere-plugin",
+        "name": "Search Everywhere",
+        "author": "Mom0",
+        "description": "Search everywhere by pressing double shift like in IntelliJ.",
+        "repo": "Mom0aut/obsidian-search-everywhere"
+    },
+    {
+        "id": "obsidian-textgenerator-plugin",
+        "name": "Text Generator",
+        "description": "Generate text content using GPT-3 (OpenAI).",
+        "author": "Noureddine Haouari",
+        "repo": "nhaouari/obsidian-textgenerator-plugin"
+    },
+    {
+        "id": "markdown-table-editor",
+        "name": "Markdown Table Editor",
+        "author": "Ganessh Kumar R P",
+        "description": "An editor for Markdown tables. Open CSV, Microsoft Excel/Google Sheets data as Markdown tables.",
+        "repo": "ganesshkumar/obsidian-table-editor"
+    },
+    {
+        "id": "obsidian-vim-multibyte-char-search",
+        "name": "Vim Multibyte Char Search",
+        "author": "anselmwang",
+        "description": "Search multibyte characters by the first character of corresponding ASCII encoding of input method. For example, for Chinese, search by the first character of Pinyin.",
+        "repo": "anselmwang/obsidian-vim-multibyte-char-search"
+    },
+    {
+        "id": "obsidian-extract-pdf-annotations",
+        "name": "Extract PDF Annotations",
+        "author": "Franz Achermann",
+        "description": "Extract PDF annotations (notes and highlights) and sort them by topic.",
+        "repo": "munach/obsidian-extract-pdf-annotations"
+    },
+    {
+        "id": "obsidian-file-cleaner",
+        "name": "File Cleaner",
+        "author": "Johnson0907",
+        "description": "Clean empty files and unused attachments in your vault.",
+        "repo": "Johnson0907/obsidian-file-cleaner"
+    },
+    {
+        "id": "obsidian-card-view-switcher-plugin",
+        "name": "Card View Switcher",
+        "author": "qawatake",
+        "description": "Quick switcher with card view.",
+        "repo": "qawatake/obsidian-card-view-switcher-plugin"
+    },
+    {
+        "id": "novel-word-count",
+        "name": "Novel Word Count",
+        "author": "Isaac Lyman",
+        "description": "Display a word count, page count, creation date, or other statistics for each file, folder and vault in the File Explorer pane.",
+        "repo": "isaaclyman/novel-word-count-obsidian"
+    },
+    {
+        "id": "heycalmdown-navigate-cursor-history",
+        "name": "Navigate Cursor History",
+        "author": "heycalmdown",
+        "description": "Remember the recent cursor position history and jump back and forth like VS Code.",
+        "repo": "heycalmdown/navigate-cursor-history"
+    },
+    {
+        "id": "obsidian-matrix",
+        "name": "Matrix",
+        "author": "Jonas Mohr",
+        "description": "Utility to easily create LaTeX matrices.",
+        "repo": "MohrJonas/obsidian-matrix"
+    },
+    {
+        "id": "waypoint",
+        "name": "Waypoint",
+        "author": "Idrees Hassan",
+        "description": "Easily generate dynamic MOCs in your folder notes using waypoints. Enables folders to show up in the graph view and removes the need for messy tags!",
+        "repo": "IdreesInc/Waypoint"
+    },
+    {
+        "id": "obsidian-hover-editor",
+        "name": "Hover Editor",
+        "author": "NothingIsLost",
+        "description": "Transform the Page Preview hover popover into a fully working editor instance.",
+        "repo": "nothingislost/obsidian-hover-editor"
+    },
+    {
+        "id": "obsidian-screwdriver",
+        "name": "Screwdriver",
+        "author": "vorotamoroz",
+        "description": "Utility to put any files in and out under your vault.",
+        "repo": "vrtmrz/obsidian-screwdriver"
+    },
+    {
+        "id": "obsidian-version-history-diff",
+        "name": "Version History Diff (Sync, File Recovery & Git)",
+        "description": "Diff the version history of the core Sync and File Recovery plugins and Git for the active file. Adds a command to open the core Sync version history as well.",
+        "author": "kometenstaub",
+        "repo": "kometenstaub/obsidian-version-history-diff"
+    },
+    {
+        "id": "obsidian-format-code",
+        "name": "Format code blocks of various languages",
+        "author": "iVariable",
+        "description": "Commands to format code (internally uses prettier).",
+        "repo": "iVariable/Obsidian-Format-Code"
+    },
+    {
+        "id": "obsidian-buttondown-plugin",
+        "name": "Buttondown",
+        "author": "caro401",
+        "description": "Send your notes to your buttondown.email account as email drafts.",
+        "repo": "caro401/obsidian-buttondown"
+    },
+    {
+        "id": "lapel",
+        "name": "Lapel",
+        "author": "Liam Cain",
+        "description": "Show the heading levels in the gutter of the editor.",
+        "repo": "liamcain/obsidian-lapel"
+    },
+    {
+        "id": "obsidian-desmos",
+        "name": "Desmos",
+        "author": "Nigecat",
+        "description": "Embed Desmos graphs into your notes.",
+        "repo": "Nigecat/obsidian-desmos"
+    },
+    {
+        "id": "obsidian-custom-frames",
+        "name": "Custom Frames",
+        "author": "Ellpeck",
+        "description": "Turn web apps into panes using iframes with custom styling. Also comes with presets for Google Keep, Todoist and more.",
+        "repo": "Ellpeck/ObsidianCustomFrames"
+    },
+    {
+        "id": "obsidian-etherpad-plugin",
+        "name": "Etherpad Lite",
+        "author": "egradman",
+        "description": "Copy and sync notes with an Etherpad Lite server to unlock easy web-based collaboration with others.",
+        "repo": "egradman/obsidian-etherpad-lite"
+    },
+    {
+        "id": "obsidian-quiet-outline",
+        "name": "Quiet Outline",
+        "author": "the_tree",
+        "description": "Make outline quiet and more powerful, including no-auto-expand, rendering heading as Markdown, and search support.",
+        "repo": "guopenghui/obsidian-quiet-outline"
+    },
+    {
+        "id": "obsidian-daily-notes-viewer",
+        "name": "Daily Notes Viewer",
+        "author": "Johnson0907",
+        "description": "Help you to view some recent daily notes on one page.",
+        "repo": "Johnson0907/obsidian-daily-notes-viewer"
+    },
+    {
+        "id": "obsidian-zotero-desktop-connector",
+        "name": "Zotero Integration",
+        "author": "mgmeyers",
+        "description": "Insert and import citations, bibliographies, notes, and PDF annotations from Zotero.",
+        "repo": "mgmeyers/obsidian-zotero-integration"
+    },
+    {
+        "id": "obsidian-telegraph-publish",
+        "name": "Telegraph Publish",
+        "author": "Reorx",
+        "description": "Publish your note to a Telegraph page.",
+        "repo": "reorx/obsidian-telegraph-publish"
+    },
+    {
+        "id": "obsidian-path-title",
+        "name": "Path Title",
+        "author": "Justin Deal",
+        "description": "Add the path (or optional replacement) to the filename title of each pane.",
+        "repo": "jdeal/obsidian-path-title-plugin"
+    },
+    {
+        "id": "obsidian-jira-issue",
+        "name": "Jira Issue",
+        "author": "marc0l92",
+        "description": "Track the progress of Atlassian Jira issues from your notes.",
+        "repo": "marc0l92/obsidian-jira-issue"
+    },
+    {
+        "id": "smort-obsidian",
+        "name": "Smort",
+        "author": "Smort",
+        "description": "Add Smort.io articles to Obsidian. Smort.io lets you easily edit, annotate and share articles.",
+        "repo": "SmortApp/obsidian-smort"
+    },
+    {
+        "id": "control-characters",
+        "name": "Control Characters",
+        "author": "Johannes Theiner",
+        "description": "Show control/non-printing characters in edit mode.",
+        "repo": "joethei/obsidian-control-characters"
+    },
+    {
+        "id": "obsidian-asciidoc-blocks",
+        "name": "AsciiDoc Blocks",
+        "author": "Juracy Filho",
+        "description": "Render asciidoc blocks, initially asciidoc tables.",
+        "repo": "juracy/obsidian-asciidoc-blocks"
+    },
+    {
+        "id": "fleeting-notes-obsidian",
+        "name": "Fleeting Notes Sync",
+        "author": "Matthew Wong",
+        "description": "Sync Fleeting Notes with Obsidian.",
+        "repo": "fleetingnotes/fleeting-notes-obsidian"
+    },
+    {
+        "id": "obsidian-chat-view",
+        "name": "Chat View",
+        "author": "Aditya Majethia",
+        "description": "Chat View lets you quickly and easily create elegant Chat UIs in your Markdown Files.",
+        "repo": "adifyr/obsidian-chat-view"
+    },
+    {
+        "id": "obsidian-doubleshift",
+        "name": "Doubleshift",
+        "author": "Qwyntex",
+        "description": "Open the command palette by pressing Shift (or any other key) twice like in IntelliJ and create your own shortcuts.",
+        "repo": "Qwyntex/doubleshift"
+    },
+    {
+        "id": "obsidian-list-modified",
+        "name": "List Modified",
+        "author": "Francis Kafieh",
+        "description": "Link all modified files meeting certain criteria to a daily note.",
+        "repo": "franciskafieh/obsidian-list-modified"
+    },
+    {
+        "id": "obsidian-latex-suite",
+        "name": "Latex Suite",
+        "author": "artisticat1",
+        "description": "Make typesetting LaTeX math as fast as handwriting through snippets, text expansion, and editor enhancements.",
+        "repo": "artisticat1/obsidian-latex-suite"
+    },
+    {
+        "id": "obsidian-wordnik",
+        "name": "Wordnik Definitions",
+        "author": "Henry Gustafson",
+        "description": "Grab information from Wordnik for a topic and bring it into your notes.",
+        "repo": "lizard-heart/obsidian-wordnik-definitions"
+    },
+    {
+        "id": "typing-speed",
+        "name": "Typing speed",
+        "author": "supercyp",
+        "description": "Show the current typing speed in the status bar.",
+        "repo": "Supercip971/obsidian-typing-speed"
+    },
+    {
+        "id": "obsidian-google-tasks",
+        "name": "Google Tasks",
+        "author": "YukiGasai",
+        "description": "Interact with your Google Tasks.",
+        "repo": "YukiGasai/obsidian-google-tasks"
+    },
+    {
+        "id": "obsidian-jtab",
+        "name": "jTab Guitar Codeblocks",
+        "author": "davfive",
+        "description": "Add guitar chords and tabs to your notes with jTab code blocks.",
+        "repo": "davfive/obsidian-jtab"
+    },
+    {
+        "id": "obsidian-book-search-plugin",
+        "name": "Book Search",
+        "author": "anpigon",
+        "description": "Create book notes and insert book metadata from providers including Google Books and Naver.",
+        "repo": "anpigon/obsidian-book-search-plugin"
+    },
+    {
+        "id": "obsidian-paste-image-rename",
+        "name": "Paste image rename",
+        "author": "Reorx",
+        "description": "Rename image after pasting, support name pattern and auto renaming.",
+        "repo": "reorx/obsidian-paste-image-rename"
+    },
+    {
+        "id": "obsidian-scroll-offset",
+        "name": "Scroll Offset",
+        "author": "Lijyze",
+        "description": "Preserve custom distances before or after cursor.",
+        "repo": "lijyze/scroll-offset"
+    },
+    {
+        "id": "obsius-publish",
+        "name": "Obsius Publish",
+        "author": "Jon Grythe St\u00f8dle",
+        "description": "Make single notes instantly available on the web.",
+        "repo": "jonstodle/obsius-obsidian-plugin"
+    },
+    {
+        "id": "execute-code",
+        "name": "Execute Code",
+        "author": "twibiral",
+        "description": "Execute code snippets within a note.",
+        "repo": "twibiral/obsidian-execute-code"
+    },
+    {
+        "id": "obsidian-badge",
+        "name": "Badge",
+        "description": "Render progress bars in your notes.",
+        "author": "Jun Lin",
+        "repo": "linjunpop/obsidian-badge"
+    },
+    {
+        "id": "kr-book-info-plugin",
+        "name": "Korean Book Info",
+        "author": "kmsk99",
+        "description": "Crawl Yes24 to get book information.",
+        "repo": "kmsk99/kr-book-info-plugin"
+    },
+    {
+        "id": "obsidian-link-embed",
+        "name": "Link Embed",
+        "author": "SErAphLi",
+        "description": "Convert URLs in your notes into embeded previews.",
+        "repo": "Seraphli/obsidian-link-embed"
+    },
+    {
+        "id": "obsidian-columns",
+        "name": "Columns",
+        "author": "Trevor Nichols",
+        "description": "Create columns in Markdown.",
+        "repo": "tnichols217/obsidian-columns"
+    },
+    {
+        "id": "obsidian-mkdocs-publisher",
+        "name": "Enveloppe",
+        "author": "Mara-Li",
+        "description": "Publish your notes to a preconfigured GitHub repository.",
+        "repo": "Enveloppe/obsidian-enveloppe"
+    },
+    {
+        "id": "obsidian-notion-video",
+        "name": "Notion Video Embed",
+        "author": "lastknightcoder",
+        "description": "Embed Notion videos.",
+        "repo": "LastKnightCoder/obsidian-notion-video"
+    },
+    {
+        "id": "obsidian-math-plus",
+        "name": "Math+",
+        "author": "Oscar Capraro",
+        "description": "Take math notes using Excalidraw.",
+        "repo": "ocapraro/obsidian-math-plus"
+    },
+    {
+        "id": "obsidian-todoist-link",
+        "name": "Todoist Link",
+        "author": "dennisseidel",
+        "description": "Create Todoist tasks and projects including bidirectional links from Obsidian.",
+        "repo": "dennisseidel/obsidian-todoist-link"
+    },
+    {
+        "id": "obsidian-rewarder",
+        "name": "Rewarder",
+        "author": "Gustav Gnosspelius",
+        "description": "Reward yourself for completing tasks/todos, highly configurable.",
+        "repo": "Gnopps/obsidian-rewarder"
+    },
+    {
+        "id": "obsidian-calibre-plugin",
+        "name": "Calibre",
+        "description": "Access your Calibre libraries and read books directly in Obsidian.",
+        "author": "caronchen",
+        "repo": "caronchen/obsidian-calibre-plugin"
+    },
+    {
+        "id": "omnisearch",
+        "name": "Omnisearch",
+        "author": "Simon Cambier",
+        "description": "Intelligent search for your notes, PDFs, and OCR for images.",
+        "repo": "scambier/obsidian-omnisearch"
+    },
+    {
+        "id": "plugins-galore",
+        "name": "Plugins Galore",
+        "author": "dylanpizzo",
+        "description": "Easily sideload other plugins.",
+        "repo": "plugins-galore/obsidian-plugins-galore"
+    },
+    {
+        "id": "auto-card-link",
+        "name": "Auto Card Link",
+        "author": "Nekoshita Yuki",
+        "description": "Automatically fetches metadata from a URL and makes it as a card-styled link.",
+        "repo": "nekoshita/obsidian-auto-card-link"
+    },
+    {
+        "id": "notion-like-tables",
+        "name": "DataLoom",
+        "author": "DecafDev",
+        "description": "Weave together data from diverse sources into a cohesive table view. Inspired by Excel spreadsheets and Notion.so.",
+        "repo": "decaf-dev/obsidian-dataloom"
+    },
+    {
+        "id": "auto-moc",
+        "name": "AutoMOC",
+        "author": "Diego Alcantara",
+        "description": "Look for missing linked mentions to the current note and import them into the current note.",
+        "repo": "dalcantara7/obsidian-auto-moc"
+    },
+    {
+        "id": "obsidian-paste-png-to-jpeg",
+        "name": "Paste image Png to Jpeg",
+        "author": "musug",
+        "description": "Screenshot png to jpeg and compress and rename.",
+        "repo": "musug/obsidian-paste-png-to-jpeg"
+    },
+    {
+        "id": "obsidian-folder-index",
+        "name": "Folder Index",
+        "author": "turulix",
+        "description": "Automatically generate a Map of Content for the current Folder and Subfolders.",
+        "repo": "turulix/obsidian-folder-index"
+    },
+    {
+        "id": "obsidian-filename-emoji-remover",
+        "name": "Filename Emoji Remover",
+        "author": "Y\u00fcksel Tolun",
+        "description": "Automatically remove emojis from filenames. Main purpose is to get rid of Dropbox sync issues for Readwise imported content.",
+        "repo": "YTolun/obsidian-filename-emoji-remover"
+    },
+    {
+        "id": "obsidian-epub-plugin",
+        "name": "ePub Reader",
+        "description": "Open documents with \".epub\" file extension.",
+        "author": "caronchen",
+        "repo": "caronchen/obsidian-epub-plugin"
+    },
+    {
+        "id": "obsidian-pandoc-reference-list",
+        "name": "Pandoc Reference List",
+        "author": "mgmeyers",
+        "description": "Display a formatted reference in the sidebar for each Pandoc citekey present in the current document.",
+        "repo": "mgmeyers/obsidian-pandoc-reference-list"
+    },
+    {
+        "id": "obsidian-enhancing-export",
+        "name": "Enhancing Export",
+        "author": "YISH",
+        "description": "Enhanced export based on Pandoc. Allows export to formats like HTML, DOCX, ePub and PDF or Hugo.",
+        "repo": "mokeyish/obsidian-enhancing-export"
+    },
+    {
+        "id": "enlightenment-obsidian",
+        "name": "Enlightenment",
+        "description": "Pay attention to what you're paying attention to. Enlightenment adds a 'zen mode' for Preview, hiding the contents of your notes except for what's underneath your pointer.",
+        "author": "ryanjamurphy",
+        "repo": "ryanjamurphy/enlightenment-obsidian"
+    },
+    {
+        "id": "obsidian-release-timeline",
+        "name": "Release Timeline",
+        "author": "cakechaser",
+        "description": "Release timeline rendered based on notes metadata with a Dataview-like syntax.",
+        "repo": "cakechaser/obsidian-release-timeline"
+    },
+    {
+        "id": "obsidian-folder-focus-mode",
+        "name": "Folder Focus Mode",
+        "author": "grochowski",
+        "description": "Focus the file explorer on chosen folder and its files and subdirectories, while hiding all the other elements.",
+        "repo": "grochowski/obsidian-folder-focus-mode"
+    },
+    {
+        "id": "obsidian-bbcode",
+        "name": "BBCode Convertor",
+        "author": "Alex Lockhart",
+        "description": "Convert Markdown files to BBCode.",
+        "repo": "salockhart/obsidian-bbcode"
+    },
+    {
+        "id": "obsidian-upcoming",
+        "name": "Upcoming",
+        "description": "Open upcoming daily notes in their own panes.",
+        "author": "Charlie Chao",
+        "repo": "charliecm/obsidian-upcoming"
+    },
+    {
+        "id": "nuke-orphans",
+        "name": "Nuke Orphans",
+        "author": "Sandorex",
+        "description": "Trash orphaned files and attachments.",
+        "repo": "sandorex/nuke-orphans-plugin"
+    },
+    {
+        "id": "obsidian-front-matter-title-plugin",
+        "name": "Front Matter Title",
+        "author": "Snezhig",
+        "description": "Define a title in frontmatter to be displayed as the filename.",
+        "repo": "snezhig/obsidian-front-matter-title"
+    },
+    {
+        "id": "obsidian-bellboy",
+        "name": "Bellboy",
+        "author": "Shaked Lokits",
+        "description": "Opinionated file structure manager.",
+        "repo": "shakedlokits/obsidian-bellboy"
+    },
+    {
+        "id": "obsidian-functionplot",
+        "name": "Function Plot",
+        "author": "leonhma",
+        "description": "Render mathematical functions in a Markdown code block.",
+        "repo": "leonhma/obsidian-functionplot"
+    },
+    {
+        "id": "obsidian-note-autocreator",
+        "name": "Note Auto Creator",
+        "author": "Simon T. Clement",
+        "description": "Automatically create notes when links are created to them.",
+        "repo": "SimonTC/obsidian-note-autocreation"
+    },
+    {
+        "id": "local-quotes",
+        "name": "Local Quotes",
+        "author": "sundevista",
+        "description": "Collect your quotes from all over the vault and embed them in different locations and watch them refreshing in real-time.",
+        "repo": "sundevista/local-quotes"
+    },
+    {
+        "id": "obsidian-state-switcher",
+        "name": "Yaml Manager",
+        "author": "Lijyze",
+        "description": "Keep you away from directly operating YAML frontmatter.",
+        "repo": "lijyze/obsidian-state-switcher"
+    },
+    {
+        "id": "obsidian-media-db-plugin",
+        "name": "Media DB",
+        "author": "Moritz Jung",
+        "description": "Query multiple APIs for movies, series, anime, games, music releases and wiki articles, and import them into your vault.",
+        "repo": "mProjectsCode/obsidian-media-db-plugin"
+    },
+    {
+        "id": "obsidian-sequence-hotkeys",
+        "name": "Sequence Hotkeys",
+        "author": "Ruan Moolman",
+        "description": "Set hotkeys with key sequences instead of a single chord.",
+        "repo": "moolmanruan/obsidian-sequence-hotkeys"
+    },
+    {
+        "id": "tasks-packrat-plugin",
+        "name": "Packrat",
+        "author": "Thomas Herden",
+        "description": "Manage completed instances of recurring tasks that were created and completed using the Tasks plugin.",
+        "repo": "therden/packrat"
+    },
+    {
+        "id": "excalibrain",
+        "name": "ExcaliBrain",
+        "author": "Zsolt Viczian",
+        "description": "ExcaliBrain is inspired by TheBrain and Breadcrumbs. It is an interactive, structured mind-map of your vault generated based on the folders and files in your vault by interpreting the links, Dataview fields, tags and YAML frontmatter in your Markdown files.",
+        "repo": "zsviczian/excalibrain"
+    },
+    {
+        "id": "obsidian-expand-bullet",
+        "name": "Expand Bullet",
+        "author": "Boninall",
+        "description": "Transform bullet content into note.",
+        "repo": "Quorafind/Obsidian-Expand-Bullet"
+    },
+    {
+        "id": "dbfolder",
+        "name": "DB Folder",
+        "author": "RafaelGB",
+        "description": "Folder with the capability to store and retrieve data from a folder like database.",
+        "repo": "RafaelGB/obsidian-db-folder"
+    },
+    {
+        "id": "obsidian-advanced-codeblock",
+        "name": "Advanced Codeblock",
+        "author": "Lijyze",
+        "description": "Add additional features to code blocks.",
+        "repo": "lijyze/obsidian-advanced-codeblock"
+    },
+    {
+        "id": "booksidian-plugin",
+        "name": "Booksidian",
+        "author": "Micha Brugger",
+        "description": "Access your Goodreads shelves.",
+        "repo": "MichaBrugger/booksidian_plugin"
+    },
+    {
+        "id": "simple-dice-roller",
+        "name": "Simple Dice Roller",
+        "author": "yeeshue99",
+        "description": "Simulate and average dice formulas.",
+        "repo": "yeeshue99/SimpleDiceRoller"
+    },
+    {
+        "id": "obsidian-camera",
+        "name": "Camera",
+        "author": "Aldrin Jenson",
+        "description": "Create and save snaps or video recordings.",
+        "repo": "aldrinjenson/obsidian-camera"
+    },
+    {
+        "id": "obsidian-user-plugins",
+        "name": "User Plugins",
+        "author": "mnowotnik",
+        "description": "Use js files or snippets to code your own quick and dirty plugins.",
+        "repo": "mnowotnik/obsidian-user-plugins"
+    },
+    {
+        "id": "obsidian-timestamp-notes",
+        "name": "Timestamp Notes",
+        "author": "Julian Grunauer",
+        "description": "Side-by-side notetaking with videos. Annotate your notes with timestamps to directly control the video and remember where each note comes from.",
+        "repo": "juliang22/ObsidianTimestampNotes"
+    },
+    {
+        "id": "linkify",
+        "name": "Linkify",
+        "author": "Matthew Chan",
+        "description": "Convert matching text into links.",
+        "repo": "matthewhchan/linkify"
+    },
+    {
+        "id": "braincache",
+        "name": "braincache",
+        "author": "XSPGMike",
+        "description": "Create braincache flashcards.",
+        "repo": "XSPGMike/braincache_obsidian"
+    },
+    {
+        "id": "obsidian-share-as-gist",
+        "name": "Share as Gist",
+        "author": "timrogers",
+        "description": "Share a note as a GitHub.com Gist.",
+        "repo": "timrogers/obsidian-share-as-gist"
+    },
+    {
+        "id": "code-block-plugin",
+        "name": "Code Block",
+        "author": "Patrik Lindefors",
+        "description": "Convert text into code blocks with automatic language detection.",
+        "repo": "paddan/code-block-plugin"
+    },
+    {
+        "id": "obsidian-google-lookup",
+        "name": "Google Calendar and Contacts Lookup",
+        "author": "ntawileh",
+        "description": "Import contact and calendar event information from your Google account.",
+        "repo": "ntawileh/obsidian-google-lookup"
+    },
+    {
+        "id": "obsidian-stack-overflow",
+        "name": "Stack Overflow Answers",
+        "description": "Copy and paste Stack Overflow answers.",
+        "author": "bramses",
+        "repo": "bramses/obsidian-stack-overflow"
+    },
+    {
+        "id": "obsidian-redirect",
+        "name": "Redirect",
+        "author": "Jacob Levernier",
+        "description": "Facilitate management of especially non-Markdown files, by allowing aliases to be set on any file.",
+        "repo": "jglev/obsidian-redirect"
+    },
+    {
+        "id": "zotero-bridge",
+        "name": "Zotero Bridge",
+        "author": "Shmavon Gazanchyan",
+        "description": "Integrate with Zotero through ZotServer.",
+        "repo": "vanakat/zotero-bridge"
+    },
+    {
+        "id": "wielder",
+        "name": "Wielder",
+        "author": "victorb",
+        "description": "Run Clojure/ClojureScript inside your notes.",
+        "repo": "victorb/obsidian-wielder"
+    },
+    {
+        "id": "obsidian-to-notion",
+        "name": "Share to Notion",
+        "author": "Easychris",
+        "description": "Share files to Notion with the Notion API.",
+        "repo": "EasyChris/obsidian-to-notion"
+    },
+    {
+        "id": "obsidian-image-gallery",
+        "name": "Image Gallery",
+        "author": "Luca Orio",
+        "description": "A zero setup masonry image gallery for Obsidian.",
+        "repo": "lucaorio/obsidian-image-gallery"
+    },
+    {
+        "id": "obsidian-thumbnails",
+        "name": "Thumbnails",
+        "author": "Michael Harris",
+        "description": "Insert YouTube thumbnails into your notes.",
+        "repo": "Meikul/obsidian-thumbnails"
+    },
+    {
+        "id": "obsidian-table-to-csv-exporter",
+        "name": "Table to CSV Exporter",
+        "author": "Stefan Wolfrum",
+        "description": "Export tables from a pane in reading mode into CSV files.",
+        "repo": "metawops/obsidian-table-to-csv-export"
+    },
+    {
+        "id": "obsidian-task-progress-bar",
+        "name": "Task Progress Bar",
+        "author": "Boninall",
+        "description": "A task progress bar for tasks.",
+        "repo": "Quorafind/Obsidian-Task-Progress-Bar"
+    },
+    {
+        "id": "scroll-speed",
+        "name": "Scroll Speed",
+        "author": "Florian Ludewig",
+        "description": "Change the scroll speed.",
+        "repo": "flolu/obsidian-scroll-speed"
+    },
+    {
+        "id": "obsidian-translator",
+        "name": "Translator",
+        "author": "Haifeng Lu",
+        "description": "Translate selected text.",
+        "repo": "luhaifeng666/obsidian-translator"
+    },
+    {
+        "id": "obsidian-echarts",
+        "name": "echarts",
+        "author": "windily-cloud && Cuman",
+        "description": "Render echarts.",
+        "repo": "cumany/obsidian-echarts"
+    },
+    {
+        "id": "obsidian-diagrams-net",
+        "name": "Diagrams.net",
+        "author": "Jens M Gleditsch",
+        "description": "Enable diagrams.net (previously draw.io) type diagrams, with the diagrams.net embedded editor.",
+        "repo": "jensmtg/obsidian-diagrams-net"
+    },
+    {
+        "id": "obsidian-weread-plugin",
+        "name": "Weread",
+        "description": "Sync Tencent Weread highlights and annotations.",
+        "author": "hank zhao",
+        "repo": "zhaohongxuan/obsidian-weread-plugin"
+    },
+    {
+        "id": "zotero-link",
+        "name": "Zotero Link",
+        "author": "Shmavon Gazanchyan",
+        "description": "Insert link to a Zotero item.",
+        "repo": "vanakat/zotero-link"
+    },
+    {
+        "id": "obsidian-golinks",
+        "name": "GoLinks",
+        "author": "David Brownman (@xavdid)",
+        "description": "Render go/links as clickable links.",
+        "repo": "xavdid/obsidian-golinks"
+    },
+    {
+        "id": "habit-tracker",
+        "name": "Habit Tracker",
+        "author": "David Moeller",
+        "description": "Display the Habits of a calendar week.",
+        "repo": "Narsail/habit-tracker-obsidian"
+    },
+    {
+        "id": "typing-transformer-obsidian",
+        "name": "Typing Transformer",
+        "author": "aptend",
+        "description": "Improved, configurable auto formatting as typing.",
+        "repo": "aptend/typing-transformer-obsidian"
+    },
+    {
+        "id": "obsidian-list-callouts",
+        "name": "List Callouts",
+        "author": "mgmeyers",
+        "description": "Create simple callouts in lists.",
+        "repo": "mgmeyers/obsidian-list-callouts"
+    },
+    {
+        "id": "obsidian-text-expander-js",
+        "name": "Inline Scripts",
+        "author": "Jonathan Heard",
+        "description": "Type text shortcuts which are then replaced with JavaScript generated text.",
+        "repo": "jon-heard/obsidian-inline-scripts"
+    },
+    {
+        "id": "metadata-menu",
+        "name": "Metadata Menu",
+        "author": "mdelobelle",
+        "description": "For data quality enthusiasts and Dataview users: access and manage the metadata of your notes.",
+        "repo": "mdelobelle/metadatamenu"
+    },
+    {
+        "id": "obsidian-plugin-time-diff",
+        "name": "TimeDiff",
+        "author": "Grzegorz Dominiczak",
+        "description": "Calculate and displays diff in hours and minutes between two dates in `timediff` Markdown block.",
+        "repo": "dominiczaq/obsidian-plugin-time-diff"
+    },
+    {
+        "id": "obsidian-trim-whitespace",
+        "name": "Trim Whitespace",
+        "author": "Zack Lovatt",
+        "description": "Trim unnecessary whitespace.",
+        "repo": "zlovatt/obsidian-trim-whitespace"
+    },
+    {
+        "id": "ninja-cursor",
+        "name": "Ninja Cursor",
+        "author": "vorotamoroz",
+        "description": "Enhance cursor visibility.",
+        "repo": "vrtmrz/ninja-cursor"
+    },
+    {
+        "id": "cmdr",
+        "name": "Commander",
+        "author": "Johnny and phibr0",
+        "description": "Customize your workspace by adding commands everywhere, create macros and supercharge your mobile toolbar.",
+        "repo": "phibr0/obsidian-commander"
+    },
+    {
+        "id": "obsidian-attendance",
+        "name": "Attendance",
+        "author": "Tiim",
+        "description": "Take attendance directly inside of your notes.",
+        "repo": "Tiim/obsidian-attendance"
+    },
+    {
+        "id": "OA-file-hider",
+        "name": "File Hider",
+        "author": "Oliver Akins",
+        "description": "Hide files and folders from the file explorer.",
+        "repo": "Oliver-Akins/file-hider"
+    },
+    {
+        "id": "obsidian-path-finder",
+        "name": "Path Finder",
+        "author": "jerrywcy",
+        "description": "Find all paths between two notes and render them as graph or text.",
+        "repo": "jerrywcy/obsidian-path-finder"
+    },
+    {
+        "id": "obsidian-focus-plugin",
+        "name": "Focus and Highlight",
+        "author": "BO YI TSAI",
+        "description": "Highlight and focus on the currently selected heading.",
+        "repo": "nagi1999a/obsidian-focus-plugin"
+    },
+    {
+        "id": "obsidian-file-cooker",
+        "name": "File Cooker",
+        "author": "iuian",
+        "description": "Deal batch notes from search results,current file, or Dataview query string.",
+        "repo": "ivaneye/obsidian-files-cooker"
+    },
+    {
+        "id": "hard-breaks",
+        "name": "Hard Breaks",
+        "author": "B\u00f6rge Kiss",
+        "description": "Turn soft line breaks in Markdown into hard line breaks.",
+        "repo": "bkis/obsidian-hard-breaks"
+    },
+    {
+        "id": "open-related-url",
+        "name": "Open Related Url",
+        "author": "Dan Pickett",
+        "description": "Open URLs found in a note's YAML frontmatter.",
+        "repo": "dpickett/open-related-url"
+    },
+    {
+        "id": "podnotes",
+        "name": "PodNotes",
+        "author": "Christian B. B. Houmann",
+        "description": "Write notes on podcasts with ease.",
+        "repo": "chhoumann/PodNotes"
+    },
+    {
+        "id": "obsidian-meeting-notes",
+        "name": "Meeting notes",
+        "author": "Tim Hiller",
+        "description": "Automatically create meeting notes in a specified folder.",
+        "repo": "TimHi/obsidian-meeting-notes"
+    },
+    {
+        "id": "obsidian-plugin-tagged-documents-viewer",
+        "name": "Tagged Documents Viewer",
+        "author": "Marcus Geduld",
+        "description": "Open a modal with scrollable content of all documents that contain a specific tag or tags.",
+        "repo": "mgeduld/obsidian-tagged-documents-viewer"
+    },
+    {
+        "id": "simple-note-review",
+        "name": "Simple Note Review",
+        "author": "dartungar",
+        "description": "Simple, customizable plugin for easy note review, resurfacing and repetition.",
+        "repo": "dartungar/obsidian-simple-note-review"
+    },
+    {
+        "id": "better-inline-fields",
+        "name": "Better Inline Fields",
+        "author": "David Sarman",
+        "description": "Enhance Dataview-style inline fields.",
+        "repo": "dsarman/better-inline-fields"
+    },
+    {
+        "id": "no-dupe-leaves",
+        "name": "No Dupe Leaves",
+        "author": "Simon Cambier",
+        "description": "Don't reopen notes that are already open.",
+        "repo": "scambier/obsidian-no-dupe-leaves"
+    },
+    {
+        "id": "obsidian-open-file-by-magic-date",
+        "name": "Open File by Magic Date",
+        "author": "simplgy",
+        "description": "Define a hotkey and Moment.js pattern for the file that is most important to you (eg: your daily/weekly/monthly note).",
+        "repo": "SimplGy/obsidian-open-file-by-magic-date"
+    },
+    {
+        "id": "obsidian-heading-shifter",
+        "name": "Heading Shifter",
+        "author": "kasahala",
+        "description": "Easily Shift and Change Markdown headings.",
+        "repo": "k4a-l/obsidian-heading-shifter"
+    },
+    {
+        "id": "obsidian-group-snippets",
+        "name": "Group Snippets",
+        "author": "Mara-Li",
+        "description": "Create folder of snippets to activate them in one click!",
+        "repo": "Mara-Li/obsidian-group-snippets"
+    },
+    {
+        "id": "obsidian-raindrop-highlights",
+        "name": "Raindrop Highlights",
+        "author": "kaiiiz",
+        "description": "Sync your Raindrop.io highlights.",
+        "repo": "kaiiiz/obsidian-raindrop-highlights-plugin"
+    },
+    {
+        "id": "obisidian-note-linker",
+        "name": "Note Linker",
+        "author": "Alexander Weichart",
+        "description": "Automatically find and create new links between notes.",
+        "repo": "AlexW00/obsidian-note-linker"
+    },
+    {
+        "id": "obsidian-dashing-cursor",
+        "name": "Dashing Cursor",
+        "author": "Shukai Ni",
+        "description": "Enable a dashing cursor that follows the page scroll.",
+        "repo": "9r0x/obsidian-dashing-cursor"
+    },
+    {
+        "id": "obsidian-quickshare",
+        "name": "QuickShare",
+        "author": "Maxime Cannoodt (@mcndt)",
+        "description": "Securely share your notes with one click. Notes are end-to-end encrypted. No API keys or configuration required.",
+        "repo": "mcndt/obsidian-quickshare"
+    },
+    {
+        "id": "rpg-manager",
+        "name": "RPG Manager",
+        "author": "Carlo Nicora",
+        "description": "Tabletop role playing game campaign manager.",
+        "repo": "carlonicora/obsidian-rpg-manager"
+    },
+    {
+        "id": "literate-haskell",
+        "name": "Literate Haskell",
+        "description": "Integrate .lhs files into your PKM.",
+        "author": "James Jensen",
+        "repo": "jajaperson/obsidian-literate-haskell"
+    },
+    {
+        "id": "embed-code-file",
+        "name": "Embed Code File",
+        "author": "Abdullah Almariah",
+        "description": "Embed code file from vault using code blocks.",
+        "repo": "almariah/embed-code-file"
+    },
+    {
+        "id": "obsidian-bulk-rename-plugin",
+        "name": "Bulk Rename",
+        "author": "Oleg Lustenko",
+        "description": "Rename files based on a pattern.",
+        "repo": "OlegLustenko/obsidian-bulk-rename"
+    },
+    {
+        "id": "obsidian-agile-task-notes",
+        "name": "Agile Task Notes",
+        "author": "BoxThatBeat",
+        "description": "Import your tasks from your TFS (Azure or Jira) to take notes on them and make todo-lists!",
+        "repo": "BoxThatBeat/obsidian-agile-task-notes"
+    },
+    {
+        "id": "new-tab-default-page",
+        "name": "Default New Tab Page",
+        "author": "pseudometa",
+        "description": "Open a note of your choice when creating a new tab, like in the browser.",
+        "repo": "chrisgrieser/new-tab-default-page"
+    },
+    {
+        "id": "obsidian-open-in-other-editor",
+        "name": "Open In Other Editor",
+        "author": "Yekingyan",
+        "description": "Open current active file in gVim or VS Code.",
+        "repo": "yekingyan/obsidian-open-in-other-editor"
+    },
+    {
+        "id": "obsidian-simple-mention",
+        "name": "Simple Mention",
+        "author": "der-tobi",
+        "description": "Get highlighted mentions and mention suggestions. Find all occurrences of a mention.",
+        "repo": "der-tobi/obsidian-simple-mention"
+    },
+    {
+        "id": "obsidian-auto-hide",
+        "name": "Auto Hide",
+        "author": "skelato1",
+        "description": "Collapse sidebars when clicking on the editor/viewer panel.",
+        "repo": "skelato1/obsidian-auto-hide"
+    },
+    {
+        "id": "janitor",
+        "name": "Janitor",
+        "author": "Gabriele Cannata",
+        "description": "Perform cleanup tasks on your vault.",
+        "repo": "Canna71/obsidian-janitor"
+    },
+    {
+        "id": "script-launcher",
+        "name": "Script Launcher",
+        "author": "Alessandro Ruggiero",
+        "description": "Add scripts shortcuts on your bottom bar and launch them.",
+        "repo": "AlessandroRuggiero/script-launcher"
+    },
+    {
+        "id": "obsidian-party",
+        "name": "Party",
+        "author": "Shap Po",
+        "description": "An implementation of party.js. Create confetti, sparkles, and even custom effects in your notes!",
+        "repo": "shap-po/obsidian-party"
+    },
+    {
+        "id": "obsidian-day-and-night",
+        "name": "Day and Night",
+        "author": "Kevin Patel",
+        "description": "Automatically toggle themes between day theme and night theme on a set time schedule.",
+        "repo": "CyberT17/obsidian-day-and-night"
+    },
+    {
+        "id": "obsidian-tikzjax",
+        "name": "TikZJax",
+        "author": "artisticat1",
+        "description": "Render LaTeX and TikZ diagrams in your notes.",
+        "repo": "artisticat1/obsidian-tikzjax"
+    },
+    {
+        "id": "todoist-completed-tasks-plugin",
+        "name": "Todoist completed tasks",
+        "author": "Andrey Kulishov",
+        "description": "Add completed Todoist tasks to your notes.",
+        "repo": "Ledaryy/obsidian-todoist-completed-tasks"
+    },
+    {
+        "id": "quick-snippets-and-navigation",
+        "name": "Quick snippets and navigation",
+        "author": "@aciq",
+        "description": "Keyboard navigation up/down for headings\n- Configurable default code block and callout\n- Copy code block via keyboard shortcut.",
+        "repo": "ieviev/obsidian-keyboard-shortcuts"
+    },
+    {
+        "id": "google-calendar",
+        "name": "Google Calendar",
+        "author": "YukiGasai",
+        "description": "Interact with your Google Calendar.",
+        "repo": "YukiGasai/obsidian-google-calendar"
+    },
+    {
+        "id": "obsidian-copy-search-url",
+        "name": "Copy Search URL",
+        "author": "Carlo Zottmann",
+        "description": "Add a button to the search view to copy the search URL.",
+        "repo": "czottmann/obsidian-copy-search-url"
+    },
+    {
+        "id": "simple-time-tracker",
+        "name": "Super Simple Time Tracker",
+        "author": "Ellpeck",
+        "description": "Multi-purpose time trackers for your notes.",
+        "repo": "Ellpeck/ObsidianSimpleTimeTracker"
+    },
+    {
+        "id": "blockquote-levels",
+        "name": "Blockquote Levels",
+        "author": "Carlo Zottmann",
+        "description": "Add commands for increasing/decreasing the blockquote level of the current line or selection(s).",
+        "repo": "czottmann/obsidian-blockquote-levels"
+    },
+    {
+        "id": "custom-sort",
+        "name": "Custom File Explorer sorting",
+        "author": "SebastianMC",
+        "description": "Manual or automatic config-driven reordering and sorting of files and folders in File Explorer.",
+        "repo": "SebastianMC/obsidian-custom-sort"
+    },
+    {
+        "id": "obsidian-table-generator",
+        "name": "Table Generator",
+        "author": "Boninall",
+        "description": "Generate Markdown tables quickly like Typora.",
+        "repo": "Quorafind/Obsidian-Table-Generator"
+    },
+    {
+        "id": "aosr",
+        "name": "Aosr",
+        "author": "linanwx",
+        "description": "Another Obsidian spaced repetition. Use flashcards to review and remember knowledge.",
+        "repo": "linanwx/aosr"
+    },
+    {
+        "id": "obsidian-meta-bind-plugin",
+        "name": "Meta Bind",
+        "author": "Moritz Jung",
+        "description": "Make your notes interactive with inline input fields, metadata displays, and buttons.",
+        "repo": "mProjectsCode/obsidian-meta-bind-plugin"
+    },
+    {
+        "id": "microblog-publish-plugin",
+        "name": "Micro.publish",
+        "author": "Otavio Cordeiro",
+        "description": "Publish notes to Micro.blog.",
+        "repo": "otaviocc/obsidian-microblog"
+    },
+    {
+        "id": "obsidian-sakana-widget",
+        "name": "Sakana Widget",
+        "author": "Boninall",
+        "description": "Add the Sakana! widget.",
+        "repo": "Quorafind/obsidian-sakana-widget"
+    },
+    {
+        "id": "obsidian-min-width",
+        "name": "Min Width",
+        "author": "doitian",
+        "description": "Set the Minimum Width of the Active Pane.",
+        "repo": "doitian/obsidian-min-width"
+    },
+    {
+        "id": "onyx-boox-extractor",
+        "name": "Onyx Boox Annotation & Highlight Extractor",
+        "description": "Extract annotations and highlights files exported from Onyx Boox tablets, and convert them to reference, literature and permanent notes fitting to the Zettelkasten method.",
+        "author": "Akos Balasko",
+        "repo": "akosbalasko/Onyx-Boox-Annotation-Highlight-Extractor"
+    },
+    {
+        "id": "chronology",
+        "name": "Chronology",
+        "author": "Gabriele Cannata",
+        "description": "A calendar and a timeline of the note's creation and modification.",
+        "repo": "Canna71/obsidian-chronology"
+    },
+    {
+        "id": "obsidian-toggle-list",
+        "name": "ToggleList",
+        "author": "Lite C",
+        "description": "Toggle the checklist states (paragraph/list/checklist/custom styles).",
+        "repo": "thingnotok/obsidian-toggle-list"
+    },
+    {
+        "id": "squiggle",
+        "name": "Squiggle",
+        "author": "Jesse Hoogland",
+        "description": "Probabilistic estimation with Squiggle in your notes.",
+        "repo": "jqhoogland/obsidian-squiggle"
+    },
+    {
+        "id": "obsidian-theme-toggler",
+        "name": "Theme Toggler",
+        "author": "larsmagnus",
+        "description": "Toggle light or dark mode separately for each tab.",
+        "repo": "larsmagnus/obsidian-theme-toggler"
+    },
+    {
+        "id": "influx",
+        "name": "Influx",
+        "author": "Jens M Gleditsch",
+        "description": "A bullet journaling plugin that aggregates a terse stream of backlinked clippings in the footer of notes.",
+        "repo": "jensmtg/influx"
+    },
+    {
+        "id": "obsidian-week-planner",
+        "name": "Week Planner",
+        "description": "Define commands for creating planning documents and moving tasks between them.",
+        "author": "Ralf Wirdemann",
+        "repo": "rwirdemann/obsidian-week-planner"
+    },
+    {
+        "id": "obsidian-html-plugin",
+        "name": "HTML Reader",
+        "author": "Nuthrash",
+        "description": "Open .html and .htm files.",
+        "repo": "nuthrash/obsidian-html-plugin"
+    },
+    {
+        "id": "mathlinks",
+        "name": "MathLinks",
+        "author": "Zhaoshen Zhai",
+        "description": "Render MathJax in your links.",
+        "repo": "zhaoshenzhai/obsidian-mathlinks"
+    },
+    {
+        "id": "note-synchronizer",
+        "name": "Note Synchronizer",
+        "author": "Songchen Tan",
+        "description": "Synchronize your notes to other note-based software like Anki, following more strictly the principles of Zettelkasten and treating each file as a note.",
+        "repo": "tansongchen/obsidian-note-synchronizer"
+    },
+    {
+        "id": "url-namer",
+        "name": "URL Namer",
+        "author": "zfei",
+        "description": "Retrieve the HTML title of web pages to name external links.",
+        "repo": "zfei/obsidian-url-namer"
+    },
+    {
+        "id": "obsidian-douban-plugin",
+        "name": "Douban",
+        "author": "Wanxp",
+        "description": "Import movies/books/musics/notes/games info data from Douban.",
+        "repo": "Wanxp/obsidian-douban"
+    },
+    {
+        "id": "insert-unsplash-image",
+        "name": "Image Inserter",
+        "author": "Ray Hao",
+        "description": "Help users easily search and insert images to editors from Unsplash.",
+        "repo": "cloudy9101/obsidian-image-inserter"
+    },
+    {
+        "id": "keyboard-analyzer",
+        "name": "Keyboard Analyzer",
+        "author": "cogscides",
+        "description": "See and analyse your keyboard hotkeys and shortcuts.",
+        "repo": "cogscides/obsidian-keyboard-analyzer"
+    },
+    {
+        "id": "obsidian-plugin-update-tracker",
+        "name": "Plugin Update Tracker",
+        "author": "Steven Swartz",
+        "description": "Know when installed plugins have updates and evaluate the risk of upgrading.",
+        "repo": "swar8080/obsidian-plugin-update-tracker"
+    },
+    {
+        "id": "update-relative-links",
+        "name": "Update Relative Links",
+        "author": "val",
+        "description": "Update relative links.",
+        "repo": "val3344/obsidian-update-relative-links"
+    },
+    {
+        "id": "readavocado-sync",
+        "name": "Readavocado Sync",
+        "author": "Cyrus Zhang",
+        "description": "Sync your Readavocado highlights.",
+        "repo": "innneang/obsidian-readavocado-sync"
+    },
+    {
+        "id": "repeat-plugin",
+        "name": "Repeat",
+        "author": "Andre Perunicic",
+        "description": "Review notes using periodic or spaced repetition.",
+        "repo": "prncc/obsidian-repeat-plugin"
+    },
+    {
+        "id": "actions-uri",
+        "name": "Actions URI",
+        "author": "Carlo Zottmann",
+        "description": "Add additional `x-callback-url` endpoints to the app for common actions \u2014 it's a clean, super-charged addition to Obsidian URI.",
+        "repo": "czottmann/obsidian-actions-uri"
+    },
+    {
+        "id": "obsidian-projects",
+        "name": "Projects",
+        "description": "Manage and visualize notes for project management.",
+        "author": "Marcus Olsson",
+        "repo": "marcusolsson/obsidian-projects"
+    },
+    {
+        "id": "obsidian-dynamic-background",
+        "name": "Dynamic Background",
+        "author": "Samuel Song",
+        "description": "Adding dynamic background effects to the editor.",
+        "repo": "samuelsong70/obsidian-dynamic-background"
+    },
+    {
+        "id": "obsidian-note-content-pusher",
+        "name": "Note Content Pusher",
+        "author": "Henry Gustafson",
+        "description": "Prepend or append specified content to a note (existing or new) without opening another pane.",
+        "repo": "lizard-heart/obsidian-note-content-pusher"
+    },
+    {
+        "id": "tag-summary-plugin",
+        "name": "Tag Summary",
+        "author": "J.D Gauchat",
+        "description": "Create summaries with paragraphs or blocks of text that share the same tag(s).",
+        "repo": "macrojd/tag-summary"
+    },
+    {
+        "id": "obsidian-alias-from-heading",
+        "name": "Alias from heading",
+        "author": "Chris Basham",
+        "description": "Implicitly add an alias matching the first heading in a document.",
+        "repo": "basham/obsidian-alias-from-heading"
+    },
+    {
+        "id": "obsidian-ocr",
+        "name": "OCR",
+        "author": "Jonas Mohr",
+        "description": "Use optical character recognition to search for text in you images and PDFs.",
+        "repo": "MohrJonas/obsidian-ocr"
+    },
+    {
+        "id": "obsidian-gitlab-issues",
+        "name": "GitLab Issues",
+        "author": "Ben Roberts",
+        "description": "Import Gitlab issues.",
+        "repo": "benr77/obsidian-gitlab-issues"
+    },
+    {
+        "id": "obsidian-account-linker",
+        "name": "Account Linker",
+        "author": "qwegat",
+        "description": "Describe external service accounts in the frontmatter.",
+        "repo": "qwegat/Obsidian-Account-Linker"
+    },
+    {
+        "id": "symbols-prettifier",
+        "name": "Symbols Prettifier",
+        "author": "Florian Woelki",
+        "description": "Prettify the symbols with actual symbols you commonly type, like arrows.",
+        "repo": "FlorianWoelki/obsidian-symbols-prettifier"
+    },
+    {
+        "id": "obsidian-mtg",
+        "name": "MtG",
+        "author": "omardelarosa",
+        "description": "Manage Magic: The Gathering decks and card lists as notes.",
+        "repo": "omardelarosa/obsidian-mtg"
+    },
+    {
+        "id": "obsidian-markdown-file-suffix",
+        "name": "Addional Markdown suffix (.mdx/.svx).",
+        "author": "swissmation.com",
+        "description": "Use additional files like .mdx / .svx as if they were Markdown.",
+        "repo": "git-no/obsidian-markdown-file-suffix"
+    },
+    {
+        "id": "editing-toolbar",
+        "name": "Editing Toolbar",
+        "author": "Cuman",
+        "description": "The Editing Toolbar is modified from cMenu, which provides more powerful customization settings and has many built-in editing commands to be a MS Word-like toolbar editing experience.",
+        "repo": "cumany/obsidian-editing-toolbar"
+    },
+    {
+        "id": "floating-toc",
+        "name": "Floating TOC",
+        "author": "curtgrimes modified by Cuman",
+        "description": "A floating directory that hovers a widget of the current directory on the notes page.",
+        "repo": "cumany/obsidian-floating-toc-plugin"
+    },
+    {
+        "id": "obsidian-checkbox3states-plugin",
+        "name": "Checkbox 3 states",
+        "author": "Renaud H\u00e9luin @ NovaGa\u00efa",
+        "description": "A third state to checkbox list.",
+        "repo": "hrenaud/obsidian-checkbox3states-plugin"
+    },
+    {
+        "id": "status-bar-quote",
+        "name": "Status Bar Quote",
+        "description": "Show your favorite quote in the status bar.",
+        "author": "Jinu",
+        "repo": "yesjinu/StatusBarQuote"
+    },
+    {
+        "id": "qmd-as-md-obsidian",
+        "name": "qmd as md",
+        "author": "Daniel Borek",
+        "description": "View files with .qmd extension. QMD files contain a combination of Markdown and executable code cells and are a format supported by Quarto open source publishing system.",
+        "repo": "danieltomasz/qmd-as-md-obsidian"
+    },
+    {
+        "id": "obsidian-to-flomo",
+        "name": "Share to Flomo",
+        "author": "Xiaoyu Li",
+        "description": "Quickly share content to Flomo.",
+        "repo": "metal-young/obsidian-to-flomo"
+    },
+    {
+        "id": "obsidian-things3-sync",
+        "name": "Things3 Sync",
+        "author": "royx",
+        "description": "Sync between Obsidian and Things3. Supports multi-language, tags and dates.",
+        "repo": "royxue/obsidian-things3-sync"
+    },
+    {
+        "id": "mathpad",
+        "name": "Mathpad",
+        "author": "Gabriele Cannata",
+        "description": "Computer algebra system and calculator.",
+        "repo": "Canna71/obsidian-mathpad"
+    },
+    {
+        "id": "list-style",
+        "name": "Ordered List Style",
+        "author": "erykwalder",
+        "description": "Set ordered list style inline. Alphabetic lists, Roman numeral lists, etc.",
+        "repo": "erykwalder/obsidian-list-style"
+    },
+    {
+        "id": "obsidian-trash-explorer",
+        "name": "Trash Explorer",
+        "author": "Per Mortensen",
+        "description": "Restore and delete files from the Obsidian .trash folder.",
+        "repo": "proog/obsidian-trash-explorer"
+    },
+    {
+        "id": "vika-sync",
+        "name": "Vika Sync",
+        "author": "romantic-black",
+        "description": "Sync your note to Vika.",
+        "repo": "romantic-black/obsidain-vika-sync"
+    },
+    {
+        "id": "obsidian-new-note-new-window",
+        "name": "New Note New Window",
+        "author": "Pedro Reyes",
+        "description": "Easily open new notes in a floating window.",
+        "repo": "Pr0dt0s/new-note-new-window"
+    },
+    {
+        "id": "obsidian-awesome-flashcard",
+        "name": "Awesome Flashcard",
+        "author": "AwesomeDog",
+        "description": "Handy Anki integration.",
+        "repo": "AwesomeDog/obsidian-awesome-flashcard"
+    },
+    {
+        "id": "obsidian-daily-note-outline",
+        "name": "Daily Note Outline",
+        "author": "iiz",
+        "description": "Add a custom view which shows outline of multiple daily notes with headings, links, tags and list items.",
+        "repo": "iiz00/obsidian-daily-note-outline"
+    },
+    {
+        "id": "edit-gemini",
+        "name": "Edit Gemini",
+        "author": "Basil_Mori",
+        "description": "Edit and create .gmi files.",
+        "repo": "Basil-Mori/obsidian-edit-gemini"
+    },
+    {
+        "id": "obsidian-pretty-bibtex",
+        "name": "Pretty BibTeX",
+        "author": "Sandro Figo",
+        "description": "Show raw BibTeX bibliography entries in a prettier way.",
+        "repo": "sandrofigo/obsidian-pretty-bibtex"
+    },
+    {
+        "id": "frontmatter-links",
+        "name": "Frontmatter Links",
+        "author": "Dion Tryban (Trikzon)",
+        "description": "Render links in a note's frontmatter as links.",
+        "repo": "Trikzon/obsidian-frontmatter-links"
+    },
+    {
+        "id": "obsidian-scroll-to-top-plugin",
+        "name": "Scroll to Top",
+        "author": "cloudhao1999",
+        "description": "Add a button to scroll to the top of the current note.",
+        "repo": "cloudhao1999/obsidian-scroll-to-top-plugin"
+    },
+    {
+        "id": "obsidian-old-note-admonitor",
+        "name": "Old Note Admonitor",
+        "description": "Show warnings if the note has not been updated for over specific days.",
+        "author": "tadashi-aikawa",
+        "repo": "tadashi-aikawa/obsidian-old-note-admonitor"
+    },
+    {
+        "id": "obsidian-export-image",
+        "name": "Export Image",
+        "author": "Zhou Hua",
+        "description": "Easily convert your article to image.",
+        "repo": "zhouhua/obsidian-export-image"
+    },
+    {
+        "id": "page-gallery",
+        "name": "Page Gallery",
+        "description": "Create an embeddable gallery based on selected page contents.",
+        "author": "Nathan Clark",
+        "repo": "tokenshift/obsidian-page-gallery"
+    },
+    {
+        "id": "obsidian42-strange-new-worlds",
+        "name": "Strange New Worlds",
+        "description": "Reveal networked thought and the strange new worlds created by your vault.",
+        "author": "TfTHacker",
+        "repo": "TfTHacker/obsidian42-strange-new-worlds"
+    },
+    {
+        "id": "obsidian-dynbedded",
+        "name": "Dynbedded",
+        "description": "Dynamic embeds.",
+        "author": "Marcus Breiden",
+        "repo": "MMoMM-org/obsidian-dynbedded"
+    },
+    {
+        "id": "copy-document-as-html",
+        "name": "Copy document as HTML",
+        "description": "Copy the current document to clipboard as HTML, including images.",
+        "author": "mvdkwast",
+        "repo": "mvdkwast/obsidian-copy-as-html"
+    },
+    {
+        "id": "obsidian-chorded-hotkeys",
+        "name": "Chorded Hotkeys",
+        "description": "Type multiple letters at the same time to trigger text insertion, template insertion, or command execution.",
+        "author": "Trey Connor Meyers",
+        "repo": "ConnorMeyers/obsidian-chorded-hotkeys"
+    },
+    {
+        "id": "obsidian-dirtreeist",
+        "name": "Dirtreeist",
+        "author": "kasahala",
+        "description": "Render a directory Structure Diagram from a Markdown lists in codeblock.",
+        "repo": "k4a-l/obsidian-dirtreeist"
+    },
+    {
+        "id": "obsidian-handlebars",
+        "name": "Handlebars Template",
+        "author": "Sean Quinlan",
+        "description": "Add support for Handlebars template blocks in notes.",
+        "repo": "sbquinlan/obsidian-handlebars"
+    },
+    {
+        "id": "3d-graph",
+        "name": "3D Graph",
+        "author": "Alexander Weichart",
+        "description": "Add a 3D graph view.",
+        "repo": "AlexW00/obsidian-3d-graph"
+    },
+    {
+        "id": "obsidian-relation-pane",
+        "name": "Relation Pane",
+        "author": "mottox2",
+        "description": "Display a panel that summarize relations between notes.",
+        "repo": "mottox2/obsidian-relation-pane"
+    },
+    {
+        "id": "obsidian-rapid-notes",
+        "name": "Rapid Notes",
+        "description": "Create and place notes quickly in specific folders based on predefined prefixes.",
+        "author": "valteriomon",
+        "repo": "valteriomon/obsidian-rapid-notes"
+    },
+    {
+        "id": "emo-uploader",
+        "name": "Emo",
+        "author": "yaleiyale",
+        "description": "Upload images to hosting platforms, or files to GitHub and embed them as Markdown file/image links. ",
+        "repo": "yaleiyale/obsidian-emo-uploader"
+    },
+    {
+        "id": "deepl",
+        "name": "DeepL",
+        "author": "Till Friebe",
+        "description": "Translate selected text into more than 25 languages with DeepL.",
+        "repo": "friebetill/obsidian-deepl"
+    },
+    {
+        "id": "obsidian-quran-lookup",
+        "name": "Quran Lookup",
+        "author": "Abu Ibrahim",
+        "description": "Easily add Quran verses and translations.",
+        "repo": "abuibrahim2/quranlookup"
+    },
+    {
+        "id": "sigma",
+        "name": "Sigma",
+        "description": "Use notes as calculation sheets.",
+        "author": "monesga",
+        "repo": "monesga/obsidian-sigma"
+    },
+    {
+        "id": "better-reading-mode",
+        "name": "Better Reading Mode",
+        "author": "Boninall",
+        "description": "Enable bionic reading mode in Live Preview mode.",
+        "repo": "Quorafind/Obsidian-Better-Reading-Mode"
+    },
+    {
+        "id": "obsidian-new-bullet-with-time",
+        "name": "New Bullet With Time",
+        "author": "Boninall",
+        "description": "Automatically add the current time to new bullet lines.",
+        "repo": "Quorafind/Obsidian-New-Bullet-With-Time"
+    },
+    {
+        "id": "obsidian-md-to-jira",
+        "name": "Markdown to Jira Converter",
+        "author": "muckmuck",
+        "description": "Convert notes or selections to Jira markup and vice versa.",
+        "repo": "muckmuck96/obsidian-md-to-jira"
+    },
+    {
+        "id": "obsidian-achievements",
+        "name": "Achievements",
+        "author": "Zachatoo",
+        "description": "Add achievements to Obsidian.",
+        "repo": "Zachatoo/obsidian-achievements"
+    },
+    {
+        "id": "obsidian-code-preview",
+        "name": "Code Preview",
+        "author": "Hank",
+        "description": "Code block preview by file path.",
+        "repo": "zjhcn/obsidian-code-preview"
+    },
+    {
+        "id": "obsidian-toggle-meta-yaml-plugin",
+        "name": "Toggle Meta Yaml",
+        "author": "hua",
+        "description": "Toggle metadata YAML.",
+        "repo": "hua03/obsidian-toggle-meta-yaml-plugin"
+    },
+    {
+        "id": "obsidian-smart-links",
+        "name": "Smart Links",
+        "author": "David Lynch",
+        "description": "Automatically detect strings using regular expressions and turn them into links in reading view. Useful for stock symbols, issue tracking, etc.",
+        "repo": "kemayo/obsidian-smart-links"
+    },
+    {
+        "id": "daily-notes-editor",
+        "name": "Daily Notes Editor",
+        "author": "boninall",
+        "description": "Edit daily notes in one page (inline), which works similar to Roam Research's default daily note view.",
+        "repo": "Quorafind/Obsidian-Daily-Notes-Editor"
+    },
+    {
+        "id": "bpmn-plugin",
+        "name": "BPMN",
+        "author": "joleaf",
+        "description": "Enable viewing BPMN diagrams using bpmn-js.",
+        "repo": "joleaf/obsidian-bpmn-plugin"
+    },
+    {
+        "id": "obsidian-image-layouts",
+        "name": "Image Layouts",
+        "author": "Luke Chadwick",
+        "description": "Add beautiful image layouts to your notes.",
+        "repo": "vertis/obsidian-image-layouts"
+    },
+    {
+        "id": "obsidian-asciimath",
+        "name": "asciimath",
+        "author": "widcardw",
+        "description": "Add asciimath support.",
+        "repo": "widcardw/obsidian-asciimath"
+    },
+    {
+        "id": "double-click-tab",
+        "name": "Double Click Tab",
+        "author": "Boninall",
+        "description": "Modify the default behavior when you double click on the tab title, like close tab.",
+        "repo": "Quorafind/Obsidian-Double-Click-Tab"
+    },
+    {
+        "id": "scrybble.ink",
+        "name": "Scrybble",
+        "author": "Streamsoft",
+        "description": "Synchronize highlights from your ReMarkable tablet.",
+        "repo": "Azeirah/scrybble"
+    },
+    {
+        "id": "auto-glossary",
+        "name": "Auto Glossary",
+        "author": "Ennio Italiano",
+        "description": "Automatically create a glossary of files, an index of files, or both.",
+        "repo": "ennioitaliano/obsidian-auto-glossary"
+    },
+    {
+        "id": "samepage",
+        "name": "SamePage",
+        "description": "Official SamePage client, the intra tool-for-thought protocol.",
+        "author": "SamePage",
+        "repo": "samepage-network/obsidian-samepage"
+    },
+    {
+        "id": "numerals",
+        "name": "Numerals",
+        "author": "RyanC",
+        "description": "Turn any code block into an advanced calculator. Evaluate math expressions on each line of a code block, including units, currency, and optional TeX rendering.",
+        "repo": "gtg922r/obsidian-numerals"
+    },
+    {
+        "id": "obsidian-plugin-dynamodb",
+        "name": "AWS DynamoDB",
+        "author": "Lee Nattress",
+        "description": "Query AWS DynamoDB and render tables inside documents.",
+        "repo": "leenattress/obsidian-plugin-dynamodb"
+    },
+    {
+        "id": "hidden-folder-obsidian",
+        "name": "Hidden Folder",
+        "author": "ptrsvltns",
+        "description": "Hidden Folder.",
+        "repo": "ptrsvltns/hidden-folder-obsidian"
+    },
+    {
+        "id": "make-md",
+        "name": "MAKE.md",
+        "description": "Make.md brings you features that supercharges Obsidian. Sort your files in custom order and add file icons using Spaces. Edit inline embeds with Flow Editor. And style your text and add new Markdown blocks without writing Markdown using Maker Mode.",
+        "author": "MAKE.md",
+        "repo": "Make-md/makemd"
+    },
+    {
+        "id": "obsidian-markdown-export-plugin",
+        "name": "Markdown export",
+        "description": "Export Markdown to a package, including images.",
+        "author": "bingryan",
+        "repo": "bingryan/obsidian-markdown-export-plugin"
+    },
+    {
+        "id": "sync-graph-settings",
+        "name": "Sync Graph Settings",
+        "author": "Xallt",
+        "description": "Sync global graph settings (like color groups) to local graphs.",
+        "repo": "Xallt/sync-graph-settings"
+    },
+    {
+        "id": "writing",
+        "name": "Writing",
+        "author": "johackim",
+        "description": "Write and format your next book.",
+        "repo": "johackim/obsidian-writing"
+    },
+    {
+        "id": "obsidian-transcription",
+        "name": "Transcription",
+        "author": "djmango (Sulaiman Ghori)",
+        "description": "Create high-quality transcriptions via Whisper from Markdown linked audio files.",
+        "repo": "djmango/obsidian-transcription"
+    },
+    {
+        "id": "obsidian-mindmap-nextgen",
+        "name": "Mindmap Nextgen",
+        "author": "VeroCloud Pty Ltd (original by James Lynch)",
+        "description": "Preview notes as Markmap mind maps.",
+        "repo": "james-tindal/obsidian-mindmap-nextgen"
+    },
+    {
+        "id": "obsidian-link-opener",
+        "name": "External Link Opener",
+        "description": "Open external links using a modal or a tab.",
+        "author": "zorazrr",
+        "repo": "zorazrr/obsidian-link-opener"
+    },
+    {
+        "id": "obsidian-clipper",
+        "name": "Clipper",
+        "author": "John Christopher",
+        "description": "Capture highlights from the web.",
+        "repo": "jgchristopher/obsidian-clipper"
+    },
+    {
+        "id": "obsidian-prozen",
+        "name": "ProZen",
+        "author": "Moskvitin",
+        "description": "Enter Zen mode to focus on writing. The plugin expands current tab to full screen removing everything but content.",
+        "repo": "cmoskvitin/obsidian-prozen"
+    },
+    {
+        "id": "obsidian-aggregator",
+        "name": "Aggregator",
+        "author": "SErAphLi",
+        "description": "Gather information from files, and make a summary in the file.",
+        "repo": "Seraphli/obsidian-aggregator"
+    },
+    {
+        "id": "obsidian-autoscroll",
+        "name": "Autoscroll",
+        "author": "Petr Nazarov",
+        "description": "Automatically scroll down the content with the provided speed.",
+        "repo": "petr-nazarov/obsidian-autoscroll"
+    },
+    {
+        "id": "obsidian-stylist",
+        "name": "Stylist",
+        "author": "ixth",
+        "description": "Add classes and styles on Markdown blocks.",
+        "repo": "ixth/obsidian-stylist"
+    },
+    {
+        "id": "obsidian-dataset-aid",
+        "name": "Text Dataset Aid",
+        "author": "Conner Ohnesorge",
+        "description": "Create personal datasets for fine-tuning language models.",
+        "repo": "conneroisu/Text-Dataset-Aid-Plugin"
+    },
+    {
+        "id": "chord-lyrics",
+        "name": "Chord Lyrics",
+        "author": "nevernotmove",
+        "description": "Display chord names over lyrics. Supports line wrapping, section headers and auto-detection.",
+        "repo": "nevernotmove/obsidian-chordlyrics"
+    },
+    {
+        "id": "crumbs-obsidian",
+        "name": "Crumbs",
+        "author": "Tony Grosinger",
+        "description": "Breadcrumb navigation.",
+        "repo": "tgrosinger/crumbs-obsidian"
+    },
+    {
+        "id": "d2-obsidian",
+        "name": "D2",
+        "description": "Official D2 plugin. D2 is a modern diagram scripting language that turns text to diagrams.",
+        "author": "Terrastruct",
+        "repo": "terrastruct/d2-obsidian"
+    },
+    {
+        "id": "translate",
+        "name": "Translate",
+        "author": "Fevol",
+        "description": "Translate text and notes with Google Translate, DeepL, Azure, and more.",
+        "repo": "Fevol/obsidian-translate"
+    },
+    {
+        "id": "dmn-plugin",
+        "name": "DMN",
+        "author": "joleaf",
+        "description": "Enable viewing DMNs using dmn-js.",
+        "repo": "joleaf/obsidian-dmn-plugin"
+    },
+    {
+        "id": "obsidian-fuzzytag",
+        "name": "FuzzyTag",
+        "description": "Fuzzy match autocomplete tags in frontmatter.",
+        "author": "Adrian",
+        "repo": "adriandersen/obsidian-fuzzytag"
+    },
+    {
+        "id": "obsidian-project-garden",
+        "name": "Project Garden",
+        "author": "Ben Goosman",
+        "description": "See all your projects in one place.",
+        "repo": "bgoosman/obsidian-project-garden"
+    },
+    {
+        "id": "workona-to-obsidian",
+        "name": "Workona Import",
+        "author": "Holmes555",
+        "description": "Import Workona resources through generated JSON file.",
+        "repo": "Holmes555/workona-to-obsidian"
+    },
+    {
+        "id": "obsidian-readlater",
+        "name": "Read Later",
+        "author": "Gabriele Cannata",
+        "description": "Synch web pages to Markdown and integrate with read-it-later apps (Pocket, Instapaper).",
+        "repo": "Canna71/obsidian-readlater"
+    },
+    {
+        "id": "surfing",
+        "name": "Surfing",
+        "author": "Boninall",
+        "description": "Surf the net like a web browser.",
+        "repo": "PKM-er/Obsidian-Surfing"
+    },
+    {
+        "id": "obsidian-toggle-case",
+        "name": "Toggle Case",
+        "author": "automattech",
+        "description": "Set a hotkey to toggle between `lowercase` `UPPERCASE` and `Title Case`.",
+        "repo": "MatthewAlner/obsidian-toggle-case"
+    },
+    {
+        "id": "open-gate",
+        "name": "Open Gate",
+        "author": "DuocNV",
+        "description": "Embed any website to Obsidian, from now all, you have anything you need in one place.",
+        "repo": "nguyenvanduocit/obsidian-open-gate"
+    },
+    {
+        "id": "canvas-presentation",
+        "name": "Canvas Presentation",
+        "description": "Display cards based on sequence.",
+        "author": "Boninall",
+        "repo": "Quorafind/Obsidian-Canvas-Presentation"
+    },
+    {
+        "id": "obsidian-paste-as-html",
+        "name": "Paste As HTML",
+        "author": "maotong06",
+        "description": "Paste As HTML, Keep the original CSS style. Paste from web browser.",
+        "repo": "maotong06/obsidian-paste-as-html-plugin"
+    },
+    {
+        "id": "file-forgetting-curve-obsidian",
+        "name": "File Forgetting Curve",
+        "author": "ptrsvltns",
+        "description": "File Forgetting Curve.",
+        "repo": "ptrsvltns/file-forgetting-curve-obsidian"
+    },
+    {
+        "id": "obsidian-basetag",
+        "name": "Base Tag Renderer",
+        "author": "Darren Kuro",
+        "description": "Render the basename of tags in preview mode.",
+        "repo": "darrenkuro/obsidian-basetag"
+    },
+    {
+        "id": "todo-sort",
+        "name": "Todo sort",
+        "description": "Sort todos by completion status.",
+        "author": "Ryan Gomba",
+        "repo": "ryangomba/obsidian-todo-sort"
+    },
+    {
+        "id": "keyshots",
+        "name": "Keyshots",
+        "description": "Add classic hotkey/shortcuts commands from popular IDEs like Visual Studio Code or JetBrains Family.",
+        "author": "KrazyManJ",
+        "repo": "KrazyManJ/obsidian-keyshots"
+    },
+    {
+        "id": "obsidian-wordy",
+        "name": "Wordy",
+        "author": "nqthqn",
+        "description": "Thesaurus, Rhymes and more using the Datamuse API. Find related words easily.",
+        "repo": "nqthqn/obsidian-wordy"
+    },
+    {
+        "id": "obsidian-extlnkhelper-plugin",
+        "name": "External Link Helper",
+        "author": "Jhonghee Park",
+        "description": "Makie inserting external links easier to your notes.",
+        "repo": "nakalsio/obsidian-danpung"
+    },
+    {
+        "id": "obsidian-local-images-plus",
+        "name": "Local images plus",
+        "author": "catalysm, aleksey-rezvov, Sergei Korneev",
+        "description": "A reincarnation of Local Images to download images in Markdown notes to local storage.",
+        "repo": "Sergei-Korneev/obsidian-local-images-plus"
+    },
+    {
+        "id": "google-photos",
+        "name": "Google Photos",
+        "author": "Alan Grainger",
+        "description": "Google Photos integration.",
+        "repo": "alangrainger/obsidian-google-photos"
+    },
+    {
+        "id": "obsidian-wakatime",
+        "name": "WakaTime",
+        "description": "Automatic time tracking and metrics generated from your usage activity.",
+        "author": "WakaTime",
+        "repo": "wakatime/obsidian-wakatime"
+    },
+    {
+        "id": "text-extractor",
+        "name": "Text Extractor",
+        "description": "A (companion) plugin to facilitate the extraction of text from images (OCR) and PDFs.",
+        "author": "Simon Cambier",
+        "repo": "scambier/obsidian-text-extractor"
+    },
+    {
+        "id": "obsidian-review-notes-plugin",
+        "name": "Review Notes",
+        "author": "tjandy98",
+        "description": "Show recently modified and newly created files.",
+        "repo": "tjandy98/obsidian-review-notes-plugin"
+    },
+    {
+        "id": "gpt3-notes",
+        "name": "GPT Notes",
+        "author": "micahke",
+        "description": "Generate notes on any subject using OpenAI's GPT-3.5 and GPT-4 language models.",
+        "repo": "micahke/obsidian-gpt3-notes"
+    },
+    {
+        "id": "obsidian-audio-notes",
+        "name": "Audio Notes",
+        "author": "Jason Maldonis",
+        "description": "Create notes for podcasts and audio files, and automatically generate transcripts while listening so you can quickly take notes on the best parts of the podcast.",
+        "repo": "jjmaldonis/obsidian-audio-notes"
+    },
+    {
+        "id": "obsidian-checklist-reset",
+        "name": "Checklist Reset",
+        "author": "Luke Hansford",
+        "description": "Add a command to reset the state of any checklists in a document.",
+        "repo": "lhansford/obsidian-checklist-reset"
+    },
+    {
+        "id": "mermaid-tools",
+        "name": "Mermaid Tools",
+        "author": "dartungar",
+        "description": "Improved Mermaid.js experience: visual toolbar with common elements and more.",
+        "repo": "dartungar/obsidian-mermaid"
+    },
+    {
+        "id": "boost-link-suggestions",
+        "name": "Boost Link Suggestions",
+        "author": "Jacob Levernier",
+        "description": "Alternative inline link suggester that orders results by link count and manual boosts.",
+        "repo": "jglev/obsidian-boost-link-suggestions"
+    },
+    {
+        "id": "webpage-html-export",
+        "name": "Webpage HTML Export",
+        "author": "Nathan George",
+        "description": "Export html from single files, canvas pages, or whole vaults. Direct access to the exported HTML files allows you to publish your digital garden anywhere. Focuses on flexibility, features, and style parity.",
+        "repo": "KosmosisDire/obsidian-webpage-export"
+    },
+    {
+        "id": "obsidian-file-color",
+        "name": "File Color",
+        "author": "ecustic",
+        "description": "Set colors on folders and files in the file tree.",
+        "repo": "ecustic/obsidian-file-color"
+    },
+    {
+        "id": "hugo-preview-obsidian",
+        "name": "Hugo preview",
+        "author": "fzdwx",
+        "description": "Preview your Hugo site.",
+        "repo": "fzdwx/hugo-preview-obsidian"
+    },
+    {
+        "id": "file-chucker",
+        "name": "File Chucker",
+        "description": "Quickly move a file to a new or existing folder, then open the next file.",
+        "author": "Ken Lim",
+        "repo": "kenlim/file-chucker-plugin"
+    },
+    {
+        "id": "hints-plugin",
+        "name": "Hints Flow",
+        "description": "Save data directly to Obsidian with specified template. Capture from Telegram, WhatsApp, Slack, Email, SMS, Raycast and more.",
+        "author": "Hints",
+        "repo": "slpbx/obsidian-plugin"
+    },
+    {
+        "id": "quote-share",
+        "name": "Quote Share",
+        "author": "DuocNV",
+        "description": "Easily generate beautiful gradient images from text and share them on social media.",
+        "repo": "nguyenvanduocit/quote-share"
+    },
+    {
+        "id": "canvas-randomnote",
+        "name": "Canvas Random Note",
+        "description": "Add random notes from your vault to the canvas.",
+        "author": "jmilldotdev",
+        "repo": "jmilldotdev/obsidian-canvas-randomnote"
+    },
+    {
+        "id": "spoiler-block-obsidian",
+        "name": "Spoiler Block",
+        "author": "AllJavi",
+        "description": "Hide information until you want to reveal it.",
+        "repo": "AllJavi/spoiler-block-obsidian"
+    },
+    {
+        "id": "terminal",
+        "name": "Terminal",
+        "description": "Integrate consoles, shells, and terminals.",
+        "author": "polyipseity",
+        "repo": "polyipseity/obsidian-terminal"
+    },
+    {
+        "id": "obsidian-contacts",
+        "name": "Contacts",
+        "description": "Manage and organize contacts.",
+        "author": "vbeskrovnov",
+        "repo": "vbeskrovnov/obsidian-contacts"
+    },
+    {
+        "id": "obsidian-vega",
+        "name": "Vega Visualizations",
+        "author": "Justin Kim",
+        "description": "Create highly-customizable data visualizations like line charts and scatter plots using Vega or Vega-Lite.",
+        "repo": "Some-Regular-Person/obsidian-vega"
+    },
+    {
+        "id": "link-nodes-in-canvas",
+        "name": "Link Nodes in Canvas",
+        "description": "Add edges between notes in Canvas based on their links.",
+        "author": "Boninall",
+        "repo": "Quorafind/Obsidian-Link-Nodes-In-Canvas"
+    },
+    {
+        "id": "canvas-css-class",
+        "name": "Canvas CSS class",
+        "description": "Add a CSS class to the canvas, but also other attributes.",
+        "author": "Mara-Li",
+        "repo": "Mara-Li/obsidian-canvas-css-class"
+    },
+    {
+        "id": "smart-connections",
+        "name": "Smart Connections",
+        "description": "Chat with your notes & see links to related content with AI embeddings. Use local models or 100+ via APIs like Claude, Gemini, ChatGPT & Llama 3",
+        "author": "Brian Petro",
+        "repo": "brianpetro/obsidian-smart-connections"
+    },
+    {
+        "id": "short-internal-links-to-headings",
+        "name": "Short links",
+        "description": "Display short internal links to files, notes, headings, and blocks.",
+        "author": "Scott Moore",
+        "repo": "scottwillmoore/obsidian-short-links"
+    },
+    {
+        "id": "obsidian-hyphenation",
+        "name": "Hyphenation",
+        "description": "Enable justified text and hyphenation.",
+        "author": "7596ff",
+        "repo": "7596ff/obsidian-hyphenation"
+    },
+    {
+        "id": "s3-attachments-storage",
+        "name": "S3 attachments storage",
+        "author": "TechTheAwesome",
+        "description": "Storage and retrieval of media attachments on S3 compatible services.",
+        "repo": "TechTheAwesome/obsidian-s3"
+    },
+    {
+        "id": "order-list",
+        "name": "Order List",
+        "author": "Henry Gustafson",
+        "description": "Add 'Order selected list' command to take the selected list and order it by the number at the end.",
+        "repo": "lizard-heart/obsidian-order-list-plugin"
+    },
+    {
+        "id": "obsidian-audio-player",
+        "name": "Audio Player",
+        "author": "noonesimg",
+        "description": "Audio player with background playback, bookmarks and wave visualiser instead of the default HTML5 audio.",
+        "repo": "noonesimg/obsidian-audio-player"
+    },
+    {
+        "id": "obsidian-task-marker",
+        "name": "Task Marker",
+        "author": "wenlzhang",
+        "description": "Change task status and append text with hotkeys and context menu. Create, complete, cancel and mark tasks, cycle among configured task statuses, and append text (automatically).",
+        "repo": "wenlzhang/obsidian-task-marker"
+    },
+    {
+        "id": "weekly-review",
+        "name": "Weekly Review",
+        "author": "Brandon Boswell",
+        "description": "Open all the files you have created in the last week.",
+        "repo": "brandonkboswell/weekly-review"
+    },
+    {
+        "id": "obsidian-pending-notes",
+        "name": "Pending notes",
+        "author": "Ulises Santana",
+        "description": "Search links without notes in your vault.",
+        "repo": "ulisesantana/obsidian-pending-notes"
+    },
+    {
+        "id": "email-block-plugin",
+        "name": "Email Block",
+        "author": "joleaf",
+        "description": "Render an email code block.",
+        "repo": "joleaf/obsidian-email-block-plugin"
+    },
+    {
+        "id": "code-emitter",
+        "name": "Code Emitter",
+        "author": "YISH",
+        "description": "Allow code blocks to be executed interactively in a sandbox like Jupyter notebooks. Supported language Rust, Kotlin, Python, JavaScript, TypeScript, etc.",
+        "repo": "mokeyish/obsidian-code-emitter"
+    },
+    {
+        "id": "obsidian-plugin-groups",
+        "name": "Plugin Groups",
+        "description": "Manage your Plugins with groups: Enable & disable multiple plugins at once or delay their startup to speed up your Obsidian start up time.",
+        "author": "Mocca101",
+        "repo": "Mocca101/obsidian-plugin-groups"
+    },
+    {
+        "id": "obsidian-ivre-plugin",
+        "name": "IVRE",
+        "description": "Grab data from IVRE and bring it into your notes.",
+        "author": "The IVRE contributors",
+        "repo": "ivre/obsidian-ivre-plugin"
+    },
+    {
+        "id": "obsidian-canvas-conversation",
+        "name": "Canvas Conversation",
+        "description": "Create a canvas conversation using ChatGPT.",
+        "author": "Andr\u00e9 Baltazar",
+        "repo": "AndreBaltazar8/obsidian-canvas-conversation"
+    },
+    {
+        "id": "image-captions",
+        "name": "Image Captions",
+        "author": "Alan Grainger",
+        "description": "Add captions to images with inline Markdown and link support. The caption format is compatible with the Commonmark spec and other Markdown applications.",
+        "repo": "alangrainger/obsidian-image-captions"
+    },
+    {
+        "id": "tor2e-statblocks",
+        "name": "The One Ring 2E Statblocks",
+        "author": "Michael Hansen",
+        "description": "Render NPC and adversary statblocks for The One Ring 2E roleplaying game.",
+        "repo": "modality/obsidian-the-one-ring-2e-statblocks"
+    },
+    {
+        "id": "reference-map",
+        "name": "Reference Map",
+        "author": "Anoop K. Chandran",
+        "description": "Reference and citation map for literature review and discovery.",
+        "repo": "anoopkcn/obsidian-reference-map"
+    },
+    {
+        "id": "khoj",
+        "name": "Khoj",
+        "author": "Khoj AI",
+        "description": "An AI personal assistant for your digital brain.",
+        "repo": "khoj-ai/khoj"
+    },
+    {
+        "id": "obsidian-custom-file-extensions-plugin",
+        "name": "Custom File Extensions and Types",
+        "author": "MeepTech",
+        "description": "Simple and modular control over what views open what file extensions from the app settings.",
+        "repo": "MeepTech/obsidian-custom-file-extensions-plugin"
+    },
+    {
+        "id": "incremental-id",
+        "name": "Incremental ID",
+        "author": "Adrian Karwowski",
+        "description": "Generate Jira-like IDs for each note.",
+        "repo": "adziok/obsidian-incremental-id"
+    },
+    {
+        "id": "canvas-mindmap",
+        "name": "Canvas Mindmap",
+        "author": "Boninall",
+        "description": "Make your canvas work like a mindmap.",
+        "repo": "Quorafind/Obsidian-Canvas-MindMap"
+    },
+    {
+        "id": "link-exploder",
+        "name": "Link Exploder",
+        "author": "Ben Hughes",
+        "description": "Link Exploder creates a canvas from a note, embedding it's incoming (i.e. backlinks) and outgoing links onto the canvas (as well as the their linked notes).",
+        "repo": "benhughes/obsidian-link-exploder"
+    },
+    {
+        "id": "cycle-in-sidebar",
+        "name": "Cycle In Sidebar",
+        "author": "Houcheng",
+        "description": "Hotkeys to cycle through tabs in the left or right sidebars.",
+        "repo": "houcheng/obsidian-cycle-in-sidebar-plugin"
+    },
+    {
+        "id": "adamantine-pick",
+        "name": "Adamantine Pick",
+        "author": "Urist McMiner",
+        "description": "Embeddable Pikchr diagrams renderer.",
+        "repo": "notlibrary/obsidian-adamantine-pick"
+    },
+    {
+        "id": "antidote-grammar-checker-integration",
+        "name": "Antidote Grammar Checker Integration",
+        "author": "Heziode",
+        "description": "Unofficial integration of Antidote, a powerful English and French grammar checker.",
+        "repo": "Heziode/obsidian-antidote"
+    },
+    {
+        "id": "s3-image-uploader",
+        "name": "S3 Image Uploader",
+        "description": "Self-host images on AWS S3.",
+        "author": "jvsteiner",
+        "repo": "jvsteiner/s3-image-uploader"
+    },
+    {
+        "id": "canvas-filter",
+        "name": "Canvas Filter",
+        "author": "Ivan Koshelev",
+        "description": "Filter Canvas to only show items of specific color, tags or only connected to currently selected node.",
+        "repo": "IKoshelev/Obsidian-Canvas-Filter"
+    },
+    {
+        "id": "note-aliases",
+        "name": "Note aliases",
+        "author": "Pulsovi",
+        "description": "Manage aliases of notes.",
+        "repo": "pulsovi/obsidian-note-aliases"
+    },
+    {
+        "id": "obs-text-wrapper",
+        "name": "Text Wrapper",
+        "author": "smx0",
+        "description": "Quickly wrap selected text with HTML tags by using a shortcut or from the command palette.",
+        "repo": "smx0/obs-text-wrapper"
+    },
+    {
+        "id": "kill-and-yank",
+        "name": "Kill and Yank",
+        "author": "INOUE Takuya",
+        "description": "Enable kill and yank (like Emacs) in the editor.",
+        "repo": "inouetakuya/obsidian-kill-and-yank"
+    },
+    {
+        "id": "double-colon-conceal",
+        "name": "Double Colon Conceal",
+        "description": "Display double colon (i.e. Dataview inline fields) as a single colon for more natural reading experience.",
+        "author": "Michal Srch",
+        "repo": "msrch/obsidian-double-colon-conceal"
+    },
+    {
+        "id": "grappling-hook",
+        "name": "Grappling Hook",
+        "author": "pseudometa",
+        "description": "Blazingly fast file switching to bookmarked files. For people for whom using the Quick Switcher still takes too much time.",
+        "repo": "chrisgrieser/grappling-hook"
+    },
+    {
+        "id": "ytranscript",
+        "name": "YTranscript",
+        "author": "\u0141ukasz Strz\u0119pek",
+        "description": "Easily fetch transcription for any YouTube video.",
+        "repo": "lstrzepek/obsidian-yt-transcript"
+    },
+    {
+        "id": "habit-calendar",
+        "name": "Habit Calendar",
+        "author": "Hedonihilist",
+        "description": "Monthly Habit Calendar for DataviewJS. Render a calendar inside DataviewJS code block, showing your habit status within a month.",
+        "repo": "hedonihilist/obsidian-habit-calendar"
+    },
+    {
+        "id": "console",
+        "name": "Console Markdown",
+        "author": "Daniel Ellermann",
+        "description": "Render console commands and their output.",
+        "repo": "dellermann/obsidian-console"
+    },
+    {
+        "id": "quip",
+        "name": "Quip",
+        "author": "sblakey",
+        "description": "Commands to publish notes to Quip.com.",
+        "repo": "sblakey/obsidian-quip"
+    },
+    {
+        "id": "custom-classes",
+        "name": "Custom Classes",
+        "description": "Add your own HTML classes to chosen Markdown elements directly from your notes.",
+        "author": "Lila Rest",
+        "repo": "LilaRest/obsidian-custom-classes"
+    },
+    {
+        "id": "babashka",
+        "name": "Babashka",
+        "description": "Evaluate Clojure(Script) code blocks in Babashka.",
+        "author": "Filipe Silva",
+        "repo": "filipesilva/obsidian-babashka"
+    },
+    {
+        "id": "dmn-eval",
+        "name": "DMN Eval",
+        "author": "joleaf",
+        "description": "Enable evaluating/executing DMNs.",
+        "repo": "joleaf/obsidian-dmn-eval-plugin"
+    },
+    {
+        "id": "restore-tab-key",
+        "name": "Restore Tab Key",
+        "author": "jerrymk",
+        "description": "Restore tab key behavior: tab key inserts a tab, the way it should be.",
+        "repo": "jrymk/restore-tab-key"
+    },
+    {
+        "id": "obsidian-omnivore",
+        "name": "Omnivore",
+        "description": "Import your saved Omnivore articles and highlights.",
+        "author": "Omnivore",
+        "repo": "omnivore-app/obsidian-omnivore"
+    },
+    {
+        "id": "inbox",
+        "name": "Inbox",
+        "author": "Zachatoo",
+        "description": "Show in app notification on startup if there is data to process in the \"inbox\" note.",
+        "repo": "Zachatoo/obsidian-inbox"
+    },
+    {
+        "id": "text-progress-bar",
+        "name": "Text Progress Bar",
+        "author": "Michael Adams",
+        "description": "Display low-fi text progress bars in your notes.",
+        "repo": "michaeladams/obsidian-text-progress-bar"
+    },
+    {
+        "id": "reading-comments",
+        "name": "Reading comments",
+        "author": "BumbrT",
+        "description": "Create inline comments while you read books or articles. Comments could be grouped hierarchically by tags.",
+        "repo": "BumbrT/obsidian-reading-comments"
+    },
+    {
+        "id": "progressbar",
+        "name": "ProgressBar",
+        "author": "Wei Zhang",
+        "description": "Render CodeBlock into a progress bar based on time or manually.",
+        "repo": "zwpaper/obsidian-progressbar"
+    },
+    {
+        "id": "kindle-csv-converter",
+        "name": "Kindle CSV Converter",
+        "description": "Import your Kindle notes in .csv format.",
+        "author": "Alvaro Cas",
+        "repo": "alvaro-cas/kindle-csv-converter-obsidian"
+    },
+    {
+        "id": "material-symbols",
+        "name": "Material Symbols",
+        "author": "Cristoph Berane",
+        "description": "Add Google's Material Symbols (outlined).",
+        "repo": "cberane/obsidian-material-symbols"
+    },
+    {
+        "id": "unicode-search",
+        "name": "Unicode Search",
+        "description": "Search and insert Unicode characters into your editor.",
+        "author": "BambusControl",
+        "repo": "BambusControl/obsidian-unicode-search"
+    },
+    {
+        "id": "awesome-reader",
+        "name": "Awesome Reader",
+        "author": "AwesomeDog",
+        "description": "Add support for multiple ebook formats. Remember reading progress and create notes from the table of contents.",
+        "repo": "AwesomeDog/obsidian-awesome-reader"
+    },
+    {
+        "id": "latex-algorithms",
+        "name": "LaTeX Algorithms",
+        "author": "SamZhang02",
+        "description": "Facilitate writing algorithm blocks in LaTeX.",
+        "repo": "SamZhang02/obsidian-latex-algorithms"
+    },
+    {
+        "id": "heading-level-indent",
+        "name": "Heading Level Indent",
+        "description": "Indenting content under headers based on their level.",
+        "author": "svonjoi",
+        "repo": "svonjoi/obsidian-heading-level-indent"
+    },
+    {
+        "id": "open-files-with-commands",
+        "name": "Open files with commands",
+        "description": "Create commands that only open one file at the time and that can be used with the commander plugin.",
+        "author": "Lost Paul",
+        "repo": "LostPaul/ob-open-files-with-commands"
+    },
+    {
+        "id": "no-empty-windows",
+        "name": "No Empty Windows",
+        "description": "Close the window with cmd+W on macOS when the last tab is closed.",
+        "author": "L Fahn-Lai",
+        "repo": "popscallion/obsidian-no-empty-windows"
+    },
+    {
+        "id": "marp",
+        "name": "Marp",
+        "description": "Create slide decks in Markdown with Marp.",
+        "author": "JichouP",
+        "repo": "JichouP/obsidian-marp-plugin"
+    },
+    {
+        "id": "o2",
+        "name": "O2",
+        "description": "Convert Obsidian Markdown syntax to other Markdown platforms such as Jekyll.",
+        "author": "haril song",
+        "repo": "songkg7/o2"
+    },
+    {
+        "id": "create-note-in-folder",
+        "name": "Create Note in Folder",
+        "author": "Mara-Li",
+        "description": "Add commands to create a note in a specific folder.",
+        "repo": "Mara-Li/obsidian-create-note-in-folder"
+    },
+    {
+        "id": "apple-books-highlights",
+        "name": "Apple Books Highlights",
+        "author": "Atif Afzal",
+        "description": "Sync your Apple Books highlights automatically.",
+        "repo": "atfzl/obsidian-apple-books-plugin"
+    },
+    {
+        "id": "msg-handler",
+        "name": "MSG Handler",
+        "description": "Easily display and search MSG files from Outlook in your vault.",
+        "author": "Ozan Tellioglu",
+        "repo": "ozntel/obsidian-msg-handler"
+    },
+    {
+        "id": "obsidoom",
+        "name": "ObsiDOOM",
+        "author": "twibiral",
+        "description": "Play DOOM and many other retro games in Obsidian. You can also play Prince of Persia, Mortal Combat, GTA, Sim City, and Need for Speed.",
+        "repo": "twibiral/ObsiDOOM"
+    },
+    {
+        "id": "aw-watcher-obsidian",
+        "name": "ActivityWatch",
+        "author": "Grimmauld",
+        "description": "Integrate with ActivityWatch to allow detailed tracking of time spent in Obsidian.",
+        "repo": "LordGrimmauld/aw-watcher-obsidian"
+    },
+    {
+        "id": "mixa",
+        "name": "Mixa",
+        "author": "Mixa Team",
+        "description": "Publish your notes and blog posts with Mixa.",
+        "repo": "mixasite/obsidian-mixa"
+    },
+    {
+        "id": "vextab",
+        "name": "Vextab",
+        "author": "Luis Guzman",
+        "description": "Render guitar tablature and music notation using Vextab.",
+        "repo": "luigman/obsidian-vextab"
+    },
+    {
+        "id": "callout-manager",
+        "name": "Callout Manager",
+        "description": "Easily create and customize callouts.",
+        "author": "eth-p",
+        "repo": "eth-p/obsidian-callout-manager"
+    },
+    {
+        "id": "awesome-image",
+        "name": "Awesome Image",
+        "author": "AwesomeDog",
+        "description": "One-stop solution for image management and viewing.",
+        "repo": "AwesomeDog/obsidian-awesome-image"
+    },
+    {
+        "id": "callout-integrator",
+        "author": "Cleoche",
+        "name": "Callout Integrator",
+        "description": "Integrate long blocks of text into callouts.",
+        "repo": "Cleoche/obsidian-callout-integrator"
+    },
+    {
+        "id": "emoji-magic",
+        "name": "Emoji Magic",
+        "author": "simplgy",
+        "description": "Easily add emoji, with a powerful keyword search.",
+        "repo": "SimplGy/obsidian-emoji-magic"
+    },
+    {
+        "id": "optimize-canvas-connections",
+        "name": "Optimize Canvas Connections",
+        "author": "F\u00e9lix Ch\u00e9nier",
+        "description": "Declutter a canvas by reconnecting notes using their nearest edges.",
+        "repo": "felixchenier/obsidian-optimize-canvas-connections"
+    },
+    {
+        "id": "home-tab",
+        "name": "Home tab",
+        "author": "Renso",
+        "description": "A browser-like search tab for your local files.",
+        "repo": "olrenso/obsidian-home-tab"
+    },
+    {
+        "id": "chatgpt-md",
+        "name": "ChatGPT MD",
+        "author": "Bram Adams",
+        "description": "A (nearly) seamless integration of ChatGPT into Obsidian.",
+        "repo": "bramses/chatgpt-md"
+    },
+    {
+        "id": "open-weather",
+        "name": "OpenWeather",
+        "description": "Return the current weather from OpenWeather in a configurable string format.",
+        "author": "willasm",
+        "repo": "willasm/obsidian-open-weather"
+    },
+    {
+        "id": "emoji-titler",
+        "name": "Emoji Titler",
+        "description": "Easily insert an emoji in the title using a keyboard shortcut.",
+        "author": "Hyeonseo Nam",
+        "repo": "HyeonseoNam/obsidian-emoji-titler"
+    },
+    {
+        "id": "perilous-writing",
+        "name": "Perilous Writing",
+        "description": "Write continuously\u2014or lose all progress.",
+        "author": "Sameer Ismail",
+        "repo": "sameersismail/obsidian-perilous-writing"
+    },
+    {
+        "id": "ibook",
+        "name": "ibook",
+        "description": "Export your Apple iBook highlights and annotations into your vault.",
+        "author": "bingryan",
+        "repo": "bingryan/obsidian-ibook-plugin"
+    },
+    {
+        "id": "floating-highlights",
+        "name": "Floating Highlights",
+        "author": "Karthik S Raju",
+        "description": "Adding animations to focus more on the highlights as you scroll down while in reading mode.",
+        "repo": "KarthikRaju391/obsidian-float"
+    },
+    {
+        "id": "zen",
+        "name": "Zen",
+        "author": "Maxymillion",
+        "description": "Add a focus mode.",
+        "repo": "Maxymillion/zen"
+    },
+    {
+        "id": "fantasy-content-generator",
+        "name": "Fantasy Content Generator",
+        "author": "Gregory-Jagermeister",
+        "description": "A fantasy content generator for all your TTRPG and world-building needs.",
+        "repo": "Gregory-Jagermeister/Fantasy-Content-Generator"
+    },
+    {
+        "id": "tasks-calendar-wrapper",
+        "name": "Tasks Calendar Wrapper",
+        "author": "zhuwenq",
+        "description": "Simple wrapper for Tasks Calendar and Tasks Timeline.",
+        "repo": "Leonezz/obsidian-tasks-calendar-wrapper"
+    },
+    {
+        "id": "awesome-brain-manager",
+        "name": "Awesome Brain Manager",
+        "description": "A toolkit that tries to solve all the trivial problems most people usually encounter.",
+        "author": "Juck",
+        "repo": "JuckZ/awesome-brain-manager"
+    },
+    {
+        "id": "open-in-new-tab",
+        "name": "Open In New Tab",
+        "author": "patleeman",
+        "description": "Open files in new tabs.",
+        "repo": "patleeman/obsidian-open-in-new-tab"
+    },
+    {
+        "id": "commando-command-repeater",
+        "name": "Commando",
+        "description": "Enable repeated calls of a command using defined or per-invocation values.",
+        "author": "qaptoR",
+        "repo": "qaptoR/Commando"
+    },
+    {
+        "id": "file-publisher",
+        "name": "File Publisher",
+        "description": "Publish a file to a given POST API.",
+        "author": "Devin Sackett",
+        "repo": "yiglas/obsidian-file-publisher"
+    },
+    {
+        "id": "global-search-and-replace",
+        "name": "Global Search and Replace",
+        "author": "Mahmoud Fawzy Khalil",
+        "description": "Search and replace in all vault files.",
+        "repo": "MahmoudFawzyKhalil/obsidian-global-search-and-replace"
+    },
+    {
+        "id": "image-upload-toolkit",
+        "name": "Image Upload Toolkit",
+        "description": "Upload local images embedded in Markdown to remote store and export Markdown with image public URL for publishing to static site. Currently, it supports Imgur, Aliyun OSS, ImageKit and AWS S3.",
+        "author": "Addo Zhang",
+        "repo": "addozhang/obsidian-image-upload-toolkit"
+    },
+    {
+        "id": "gene-ai",
+        "name": "Gene \ud83e\uddec",
+        "author": "Matiss Jurevics",
+        "description": "Generate text using the OpenAI API.",
+        "repo": "MatissJurevics/Gene-AI"
+    },
+    {
+        "id": "latex-to-unicode",
+        "name": "LaTeX to Unicode converter",
+        "description": "Convert LaTeX commands into unicode sequences.",
+        "author": "fjdu",
+        "repo": "fjdu/obsidian-latex-unicode"
+    },
+    {
+        "id": "nl-syntax-highlighting",
+        "name": "Natural Language Syntax Highlighting",
+        "description": "Highlight adjectives, nouns, adverbs, verbs, and conjunctions in the editor.",
+        "author": "artisticat",
+        "repo": "artisticat1/nl-syntax-highlighting"
+    },
+    {
+        "id": "focus-active-sentence",
+        "name": "Focus Active Sentence",
+        "description": "Highlight the sentence the cursor is currently resting on.",
+        "author": "artisticat",
+        "repo": "artisticat1/focus-active-sentence"
+    },
+    {
+        "id": "journal-review",
+        "name": "Journal Review",
+        "author": "Kageetai",
+        "description": "Review your daily notes on their anniversaries, like \"what happened today last year\".",
+        "repo": "Kageetai/obsidian-plugin-journal-review"
+    },
+    {
+        "id": "brainframe",
+        "name": "Brainframe",
+        "description": "Tools to make Obsidian more into our second brains.",
+        "author": "pedersen",
+        "repo": "pedersen/obsidian-brainframe"
+    },
+    {
+        "id": "gemmy",
+        "name": "Gemmy",
+        "description": "Obsidian Unhelper. 2023 April Fool's plugin brought to you by Obsidian.",
+        "author": "Obsidian",
+        "repo": "ericaxu/gemmy"
+    },
+    {
+        "id": "source-code-note",
+        "name": "Source Code Note",
+        "description": "Organize source code note easily.",
+        "author": "Waiting",
+        "repo": "waiting0324/obsidian-code-note"
+    },
+    {
+        "id": "jelly-snippets",
+        "name": "Jelly Snippets",
+        "author": "Spencer Gouw",
+        "description": "A simple text snippets plugin.",
+        "repo": "rabirabirara/obsidian-jelly-snippets"
+    },
+    {
+        "id": "prioritize",
+        "name": "Prioritize",
+        "author": "EloiMusk",
+        "description": "Prioritize your tasks and notes.",
+        "repo": "EloiMusk/obsidian-prio-plugin"
+    },
+    {
+        "id": "tiddlywiki-import-export",
+        "name": "Import/Export TiddlyWiki",
+        "author": "Lucas Bordeau",
+        "description": "Import and export TiddlyWiki notes.",
+        "repo": "lucasbordeau/obsidian-tiddlywiki"
+    },
+    {
+        "id": "float-search",
+        "name": "Floating Search",
+        "author": "Boninall",
+        "description": "Search text by using Obsidian default search view.",
+        "repo": "Quorafind/Obsidian-Float-Search"
+    },
+    {
+        "id": "avatar",
+        "name": "Avatar",
+        "description": "Display an avatar image in your notes.",
+        "author": "froehlichA",
+        "repo": "froehlichA/obsidian-avatar"
+    },
+    {
+        "id": "meld-build",
+        "name": "Meld Build",
+        "description": "Write and execute (sandboxed) JavaScript to render templates, query DataView and create dynamic notes.",
+        "author": "meld-cp",
+        "repo": "meld-cp/obsidian-build"
+    },
+    {
+        "id": "page-properties",
+        "name": "Page Properties",
+        "author": "Anton Bualkh",
+        "description": "Add page properties similar to Logseq.",
+        "repo": "necauqua/obsidian-page-properties"
+    },
+    {
+        "id": "testing-vault",
+        "name": "Testing Vault",
+        "description": "Randomized vault generator with links between notes, frontmatter, tags, orphan and leaf notes.",
+        "author": "Michael Pedersen",
+        "repo": "pedersen/obsidian-testing-vault"
+    },
+    {
+        "id": "x86-flow-graphing",
+        "name": "x86 Assembly Flow Graphing",
+        "author": "icebear",
+        "description": "Convert well formatted x86 assembly into appropriate flow graphs using Obsidian canvases.",
+        "repo": "dwolfe884/obsidian-x86-flow-graph"
+    },
+    {
+        "id": "oz-calendar",
+        "name": "OZ Calendar",
+        "description": "View your notes in Calendar using any YAML key with a date.",
+        "author": "Ozan Tellioglu",
+        "repo": "ozntel/oz-calendar"
+    },
+    {
+        "id": "tasks-to-omnifocus",
+        "name": "Send Tasks to OmniFocus",
+        "description": "Extract tasks from the current note and create them in OmniFocus.",
+        "author": "Henry Gustafson",
+        "repo": "lizard-heart/obsidian-to-omnifocus"
+    },
+    {
+        "id": "ai-commander",
+        "name": "AI Commander",
+        "author": "Simon Yang",
+        "description": "Generate audio transcripts, images, and text in context of PDF attachments or web search results using OpenAI and Bing API.",
+        "repo": "yzh503/obsidian-aicommander-plugin"
+    },
+    {
+        "id": "pseudocode-in-obs",
+        "name": "Pseudocode",
+        "author": "Yaotian Liu",
+        "description": "Render LaTeX-style pseudocode inside a code block.",
+        "repo": "ytliu74/obsidian-pseudocode"
+    },
+    {
+        "id": "advanced-merger",
+        "name": "Advanced Merger",
+        "author": "Anto Kein\u00e4nen",
+        "description": "Merge a folder of notes for easier export.",
+        "repo": "antoKeinanen/obsidian-advanced-merger"
+    },
+    {
+        "id": "unfilled-stats-highlighter",
+        "name": "Unfilled Stats Highlighter",
+        "description": "Streamline your stat/habit tracking process by automatically identifying and prefixing unfilled stats, making them easier to spot and fill out.",
+        "author": "Zachary Hynes",
+        "repo": "White7292/obsidian-hd-unfilled-stats-highlighter"
+    },
+    {
+        "id": "gpt-assistant",
+        "name": "GPT Assistant",
+        "description": "Use a GPT-3 based model on your notes and get personalized answers from your knowledge base.",
+        "author": "M7mdisk",
+        "repo": "M7mdisk/obsidian-gpt"
+    },
+    {
+        "id": "companion",
+        "name": "Companion",
+        "author": "rizerphe",
+        "description": "Autocomplete with AI, including ChatGPT, through a copilot-like interface.",
+        "repo": "rizerphe/obsidian-companion"
+    },
+    {
+        "id": "get-stock-information",
+        "name": "Get Stock Information",
+        "description": "Take a stock symbol and returns a callout block with the latest stock information.",
+        "author": "Mike Jongbloet",
+        "repo": "mikejongbloet/obsidian-get-stock-information"
+    },
+    {
+        "id": "frontmatter-alias-display",
+        "name": "Frontmatter Alias Display",
+        "author": "muhammadv-i",
+        "description": "Show frontmatter aliases as display names in the File Explorer.",
+        "repo": "muhammadv-i/obsidian-frontmatter-alias-display"
+    },
+    {
+        "id": "character-insertion",
+        "name": "Character Insertion",
+        "description": "Insert a specified symbol under the cursor.",
+        "author": "TakamiChie",
+        "repo": "TakamiChie/Obsidian_CharacterInsertionPlugin"
+    },
+    {
+        "id": "whisper",
+        "name": "Whisper",
+        "author": "Nik Danilov",
+        "description": "Speech-to-text using OpenAI Whisper.",
+        "repo": "nikdanilov/whisper-obsidian-plugin"
+    },
+    {
+        "id": "colorful-note-borders",
+        "name": "Colorful Note Borders",
+        "description": "Add customizable colorful borders to notes based on folder location or frontmatter metadata, enhancing visual organization.",
+        "author": "rusi",
+        "repo": "rusi/obsidian-colorful-note-borders"
+    },
+    {
+        "id": "code-files",
+        "name": "Code Files",
+        "author": "Lukas Bach",
+        "description": "Edit code files with VS Code's powerful Monaco Editor.",
+        "repo": "lukasbach/obsidian-code-files"
+    },
+    {
+        "id": "flashcard-learning",
+        "name": "Flashcard Learning",
+        "author": "Ga\u00e9tan Muck",
+        "description": "Improved flashcard learning system.",
+        "repo": "gaetanmuck/obsidian-flashcard-learning"
+    },
+    {
+        "id": "any-block",
+        "name": "AnyBlock",
+        "author": "LincZero",
+        "description": "Take any fragment as a block and render it into multiple effects. You can select a section by list/heading/table/quote/codeBlock/markdown-it-container(`:::`), and turn into table/tabs/dir/cards/column/mindmap/mermaid/PlantUML/markmap/timeLine/jsonChart/nodeTree and more.",
+        "repo": "LincZero/obsidian-any-block"
+    },
+    {
+        "id": "wucai-highlights-official",
+        "name": "WuCai highlights Official",
+        "description": "Sync WuCai highlights into your notes.",
+        "author": "\u5e0c\u679c\u58f3\u4e94\u5f69",
+        "repo": "makediff/obsidian-wucai"
+    },
+    {
+        "id": "file-order",
+        "name": "File Order",
+        "description": "Use number-prefixes in your file names to define a custom order, and drag-and-drop the files to update that order.",
+        "author": "lukasbach",
+        "repo": "lukasbach/obsidian-file-order"
+    },
+    {
+        "id": "tab-rotator",
+        "name": "Tab Rotator",
+        "author": "Steven Jin",
+        "description": "Rotate opened files to the left or right with a specified interval.",
+        "repo": "autohub7/obsidian-tab-rotator"
+    },
+    {
+        "id": "bulkopen-selected-links",
+        "name": "Bulk open selected links",
+        "author": "Steven Jin",
+        "description": "Easily open all selected links in edit mode.",
+        "repo": "autohub7/obsidian-open-selected-links"
+    },
+    {
+        "id": "bbawj-semantic-search",
+        "name": "Semantic Search",
+        "author": "bbawj",
+        "description": "Semantic search for files using OpenAI's text embeddings.",
+        "repo": "bbawj/obsidian-semantic-search"
+    },
+    {
+        "id": "select-current-line",
+        "name": "Select current line",
+        "author": "Gokul",
+        "description": "Select the current line where the cursor is placed. Press 'ESC' key to select.",
+        "repo": "gokulk16/select-current-line-plugin"
+    },
+    {
+        "id": "wikipedia-search",
+        "name": "Wikipedia Search",
+        "author": "StrangeGirlMurph",
+        "description": "Search, link and open Wikipedia/Wiki articles.",
+        "repo": "StrangeGirlMurph/obsidian-wikipedia-search"
+    },
+    {
+        "id": "vim-toggle",
+        "name": "Vim Toggle",
+        "description": "Toggle Vim on/off and customize toggling behavior.",
+        "author": "Conner Ohnesorge",
+        "repo": "conneroisu/vim-toggle"
+    },
+    {
+        "id": "draw-harada-method",
+        "name": "Draw Harada Method",
+        "author": "yildbs",
+        "description": "Draw the harada method. Create your own 1 goal, 8 plans, and 64 actions!",
+        "repo": "yildbs/obsidian-harada-method-plugin"
+    },
+    {
+        "id": "marp-slides",
+        "name": "Marp Slides",
+        "description": "Create Marp presentations.",
+        "author": "Samuele Cozzi",
+        "repo": "samuele-cozzi/obsidian-marp-slides"
+    },
+    {
+        "id": "flomo-importer",
+        "name": "Flomo Importer",
+        "description": "Make Flomo memos to motes.",
+        "author": "Jialu Y",
+        "repo": "jia6y/flomo-to-obsidian"
+    },
+    {
+        "id": "tolino-notes-import",
+        "name": "Tolino notes Importer",
+        "author": "juergenbr",
+        "description": "Import notes from a Tolino E-Reader.",
+        "repo": "juergenbr/obsidian-tolino-notes-import"
+    },
+    {
+        "id": "codeblock-customizer",
+        "name": "Codeblock Customizer",
+        "author": "mugiwara",
+        "description": "Customize your code blocks in editing, and reading mode as well.",
+        "repo": "mugiwara85/CodeblockCustomizer"
+    },
+    {
+        "id": "auto-classifier",
+        "name": "Auto Classifier",
+        "author": "Hyeonseo Nam",
+        "description": "Automatically classify tag from your notes using ChatGPT API. It analyze your note (It can be title, frontmatter, content or selected area) and automatically insert tag where you set.",
+        "repo": "HyeonseoNam/auto-classifier"
+    },
+    {
+        "id": "ai-assistant",
+        "name": "AI Assistant",
+        "author": "Quentin Grail",
+        "description": "AI Assistant.",
+        "repo": "qgrail/obsidian-ai-assistant"
+    },
+    {
+        "id": "cron",
+        "name": "Cron",
+        "author": "Callum Loh",
+        "description": "Simple CRON / scheduler to regularly run user scripts or commands.",
+        "repo": "cdloh/obsidian-cron"
+    },
+    {
+        "id": "tray",
+        "name": "Tray",
+        "author": "dragonwocky",
+        "description": "Run Obsidian from the system tray for customisable window management and global quick notes.",
+        "repo": "dragonwocky/obsidian-tray"
+    },
+    {
+        "id": "dynamic-timetable",
+        "name": "Dynamic Timetable",
+        "description": "Calculate the estimated time of completion from the estimated time of the task and dynamically create a timetable.",
+        "author": "L7Cy",
+        "repo": "L7Cy/obsidian-dynamic-timetable"
+    },
+    {
+        "id": "obsidian-soomda",
+        "name": "Soomda",
+        "author": "Michael Lee",
+        "description": "Quickly hide your sidebars.",
+        "repo": "michaellee/soomda"
+    },
+    {
+        "id": "quickly",
+        "name": "Quickly",
+        "author": "Sparsh Yadav",
+        "description": "Quickly navigate and create notes through OS shortcut keys.",
+        "repo": "tmfelwu/obsidian-inbox"
+    },
+    {
+        "id": "hk-code-block",
+        "name": "HK Code Block",
+        "author": "Heekang Park",
+        "description": "Improve the display of code blocks in reading view with titles, line numbers, line highlights, and more.",
+        "repo": "HeekangPark/obsidian-hk-code-block"
+    },
+    {
+        "id": "link-range",
+        "name": "Link Range",
+        "author": "Ryan Mellmer",
+        "description": "Add ranged wikilink support.",
+        "repo": "rmellmer/obsidian-link-range"
+    },
+    {
+        "id": "ring-a-secretary",
+        "name": "Ring a secretary",
+        "author": "vorotamoroz",
+        "description": "Yet another ChatGPT-powered digital secretary.",
+        "repo": "vrtmrz/ring-a-secretary"
+    },
+    {
+        "id": "latex-matrices",
+        "name": "LaTeX Matrices",
+        "author": "Daniele Susino",
+        "description": "Speed up LaTeX matrices writing.",
+        "repo": "Deltekk/Obsidian-Latex-Matrices"
+    },
+    {
+        "id": "smart-rename",
+        "name": "Smart Rename",
+        "author": "mnaoumov",
+        "description": "Rename notes keeping previous title in existing links.",
+        "repo": "mnaoumov/obsidian-smart-rename"
+    },
+    {
+        "id": "folder-notes",
+        "name": "Folder notes",
+        "description": "Create notes within folders that can be accessed without collapsing the folder, similar to the functionality offered in Notion.",
+        "author": "Lost Paul",
+        "repo": "LostPaul/obsidian-folder-notes"
+    },
+    {
+        "id": "pocketbook-cloud-highlight-importer",
+        "name": "Pocketbook Cloud Highlight Importer",
+        "author": "Lena Br\u00fcder",
+        "description": "Import notes and highlights from your Pocketbook Cloud account.",
+        "repo": "lenalebt/obsidian-pocketbook-cloud-highlight-importer"
+    },
+    {
+        "id": "pivotal-tracker-integration",
+        "name": "Pivotal Tracker Integration",
+        "description": "Pull stories, bugs, chores from Pivotal Tracker.",
+        "author": "jondeates",
+        "repo": "jonnydeates/obsidian-pivotal-tracker-integration-plugin"
+    },
+    {
+        "id": "file-diff",
+        "name": "File Diff",
+        "author": "Till Friebe",
+        "description": "View the differences between two files with merge options.",
+        "repo": "friebetill/obsidian-file-diff"
+    },
+    {
+        "id": "text2anki-openai",
+        "name": "text2anki-openai",
+        "author": "Mani Batra",
+        "description": "Use OpenAI to generate flashcards from text and add them to Anki.",
+        "repo": "manibatra/obsidian-text2anki-openai"
+    },
+    {
+        "id": "ultimate-todoist-sync",
+        "name": "Ultimate Todoist Sync",
+        "description": "Todoist task synchronization.",
+        "author": "HeroBlackInk",
+        "repo": "HeroBlackInk/ultimate-todoist-sync-for-obsidian"
+    },
+    {
+        "id": "reading-view-enhancer",
+        "name": "Reading View Enhancer",
+        "author": "Galacsh",
+        "description": "Use arrow keys to navigate between text blocks and fold/unfold elements.",
+        "repo": "Galacsh/obsidian-reading-view-enhancer"
+    },
+    {
+        "id": "crossbow",
+        "name": "Crossbow",
+        "description": "Find backlinks in your notes.",
+        "author": "shoedler",
+        "repo": "shoedler/crossbow"
+    },
+    {
+        "id": "google-keep-import",
+        "name": "Google Keep Import",
+        "author": "Dale de Silva",
+        "description": "Import Google Keep backup json files and their attachments. Can also be used to import other files.",
+        "repo": "daledesilva/obsidian_google-keep-import"
+    },
+    {
+        "id": "image-ocr",
+        "name": "Image OCR",
+        "description": "Run OCR on images and paste the result in the description.",
+        "author": "kaffarell",
+        "repo": "kaffarell/obsidian-tesseract-ocr"
+    },
+    {
+        "id": "gpt-liteinquirer",
+        "name": "GPT-LiteInquirer",
+        "description": "Experience OpenAI ChatGPT assistance, drafting content without interrupting your creative flow.",
+        "author": "ittuann",
+        "repo": "ittuann/obsidian-gpt-liteinquirer-plugin"
+    },
+    {
+        "id": "loom",
+        "name": "Loom",
+        "author": "celeste",
+        "description": "A recursively branching interface to GPT-3 and other language models.",
+        "repo": "cosmicoptima/loom"
+    },
+    {
+        "id": "links",
+        "name": "Links",
+        "author": "MiiKey",
+        "description": "Manipulate links.",
+        "repo": "mii-key/obsidian-links"
+    },
+    {
+        "id": "confluence-integration",
+        "name": "Confluence Integration",
+        "author": "andymac4182",
+        "description": "Publish Markdown content to Atlassian Confluence. It supports some Obsidian Markdown extensions for richer content.",
+        "repo": "markdown-confluence/obsidian-integration"
+    },
+    {
+        "id": "copilot",
+        "name": "Copilot",
+        "author": "Logan Yang",
+        "description": "A ChatGPT Copilot.",
+        "repo": "logancyang/obsidian-copilot"
+    },
+    {
+        "id": "github-issue-augmentation",
+        "name": "GitHub Issue Augmentation",
+        "author": "samprintz",
+        "description": "Augment GitHub issue IDs.",
+        "repo": "samprintz/obsidian-issue-augmentation-plugin"
+    },
+    {
+        "id": "persistent-links",
+        "name": "Persistent Links",
+        "author": "Ivan Lednev",
+        "description": "Automatically repair internal links to blocks and headings when moving them between files.",
+        "repo": "ivan-lednev/obsidian-persistent-links"
+    },
+    {
+        "id": "personal-assistant",
+        "name": "Personal Assistant",
+        "author": "edony",
+        "description": "Streamline workflows within Obsidian, managing memos, formatted records, callouts, frontmatter, local graph, themes and plugins with just one command.",
+        "repo": "edonyzpc/personal-assistant"
+    },
+    {
+        "id": "aprils-automatic-timelines",
+        "name": "April's Automatic Timelines",
+        "author": "April Gras",
+        "description": "Simple timeline generator for story tellers.",
+        "repo": "April-Gras/obsidian-auto-timelines"
+    },
+    {
+        "id": "ai-mentor",
+        "name": "AI Mentor",
+        "description": "Meet your open source AI mentor. Ask questions, get answers, and learn new things.",
+        "author": "clementpoiret",
+        "repo": "clementpoiret/ai-mentor"
+    },
+    {
+        "id": "game-search",
+        "name": "Game Search",
+        "description": "Help insert game metadata into game notes or vaults, optionally sync with Steam Library and Wishlist",
+        "author": "calvin",
+        "repo": "CMorooney/obsidian-game-search-plugin"
+    },
+    {
+        "id": "linked-data-vocabularies",
+        "name": "Linked Data Vocabularies",
+        "author": "kometenstaub",
+        "description": "Add Library of Congress Subject Headings (LCSH) as metadata to your notes.",
+        "repo": "kometenstaub/linked-data-vocabularies"
+    },
+    {
+        "id": "linked-data-helper",
+        "name": "Linked Data Helper",
+        "author": "kometenstaub",
+        "description": "Prepare data needed by Linked Data Vocabularies.",
+        "repo": "kometenstaub/linked-data-helper"
+    },
+    {
+        "id": "show-diff",
+        "name": "Show Diff",
+        "author": "Ivan Lednev",
+        "description": "Render Git diffs in your notes.",
+        "repo": "ivan-lednev/obsidian-automatic-changelog"
+    },
+    {
+        "id": "markdoc",
+        "name": "Markdoc",
+        "author": "Maciej Jur",
+        "description": "Basic support for Markdoc files.",
+        "repo": "kamoshi/obsidian-markdoc"
+    },
+    {
+        "id": "colored-text",
+        "name": "Colored Text",
+        "author": "Erinc Ayaz",
+        "description": "Color the selected texts.",
+        "repo": "erincayaz/obsidian-colored-text"
+    },
+    {
+        "id": "slide-note",
+        "name": "Slide Note",
+        "author": "Jinyan Xu",
+        "description": "Conveniently take notes on PDF course slides.",
+        "repo": "Phantom1003/obsidian-slide-note"
+    },
+    {
+        "id": "chem",
+        "name": "Chem",
+        "author": "Acylation",
+        "description": "Providing chemistry supports. Rendering SMILES strings into chemistry structures.",
+        "repo": "Acylation/obsidian-chem"
+    },
+    {
+        "id": "last-modified-timestamp-in-status-bar",
+        "name": "Last Modified Timestamp in Status Bar",
+        "author": "Yustynn",
+        "description": "Dynamic display of file modification timestamp in the status bar.",
+        "repo": "Yustynn/obsidian-last-modified-timestamp-in-status-bar"
+    },
+    {
+        "id": "askify-obsidian-sync",
+        "name": "Askify Sync",
+        "author": "Kishlay Raj",
+        "description": "Syncing between Obsidian and Askify.",
+        "repo": "helloworldkr/Askify-Obsidian-Sync"
+    },
+    {
+        "id": "android-nomedia",
+        "name": "Android nomedia",
+        "author": "JakeisAwesome",
+        "description": "Hide media from your vault on Android devices by adding the 'nomedia' file to each folder.",
+        "repo": "calomancer/android.nomedia"
+    },
+    {
+        "id": "custom-state-for-task-list",
+        "name": "Custom State for Task List",
+        "author": "Okami Wong",
+        "description": "Add custom states to task list items.",
+        "repo": "OkamiWong/obsidian-custom-state-for-task-list"
+    },
+    {
+        "id": "fuzzy-chinese-pinyin",
+        "name": "Fuzzy Chinese Pinyin",
+        "description": "Fuzzy search using Chinese Pinyin.",
+        "author": "lazyloong",
+        "repo": "lazyloong/obsidian-fuzzy-chinese"
+    },
+    {
+        "id": "auto-template-trigger",
+        "name": "Auto Template Trigger",
+        "author": "Numeroflip",
+        "description": "Automatically prompt for a template, when creating a note.",
+        "repo": "numeroflip/obsidian-auto-template-prompt"
+    },
+    {
+        "id": "ketcher",
+        "name": "Ketcher",
+        "author": "Yulei Chen",
+        "description": "View or draw chemical structures and reactions using Ketcher.",
+        "repo": "yuleicul/obsidian-ketcher"
+    },
+    {
+        "id": "open-plugin-settings",
+        "name": "Open Plugin Settings",
+        "author": "Mara-Li",
+        "description": "Create a command to open a specified plugin settings.",
+        "repo": "Mara-Li/obsidian-open-settings"
+    },
+    {
+        "id": "mathlive",
+        "name": "MathLive",
+        "author": "Dan Zilberman",
+        "description": "Faster and more intuitive MathJax editing using MathLive.",
+        "repo": "danzilberdan/obsidian-mathlive"
+    },
+    {
+        "id": "auto-hide-cursor",
+        "name": "Auto Hide Cursor",
+        "author": "Mo Ismat",
+        "description": "Hide the cursor when scrolling and show it again when moving the mouse.",
+        "repo": "moismat/obsidian-auto-hide-cursor"
+    },
+    {
+        "id": "pubscale",
+        "name": "PubScale",
+        "author": "piriwata",
+        "description": "Seamlessly sync Markdown notes into PlanetScale tables.",
+        "repo": "piriwata/pubScale"
+    },
+    {
+        "id": "rofi-helper",
+        "name": "Rofi Helper",
+        "description": "Add a leaf ID parameter to the URI protocol for switching between open tabs with Rofi. A sample Rofi script is included.",
+        "author": "digitalsignalperson",
+        "repo": "digitalsignalperson/obsidian-rofi-helper"
+    },
+    {
+        "id": "mood-tracker",
+        "name": "Mood Tracker",
+        "author": "dartungar",
+        "description": "Track your moods & emotions easily. Visualize tracked history and browse the past entries.",
+        "repo": "dartungar/obsidian-mood-tracker"
+    },
+    {
+        "id": "plugin-manager",
+        "name": "Plugin Manager",
+        "description": "Extend plugin management.",
+        "author": "ohm-en",
+        "repo": "ohm-en/obsidian-plugin-manager"
+    },
+    {
+        "id": "better-mathjax",
+        "name": "Better MathJax",
+        "author": "GreasyCat",
+        "description": "Math autocompletion and customizable snippets.",
+        "repo": "greasycat/BetterMathjax"
+    },
+    {
+        "id": "ling-gloss",
+        "name": "Interlinear Glossing",
+        "description": "Format interlinear glosses used in linguistics texts.",
+        "author": "Mijyuoon",
+        "repo": "Mijyuoon/obsidian-ling-gloss"
+    },
+    {
+        "id": "brain",
+        "name": "brAIn",
+        "author": "lusob",
+        "description": "A ChatGPT powered chatbot specifically focused on question answering over your vault notes.",
+        "repo": "lusob/obsidian-brain"
+    },
+    {
+        "id": "sync-google-calendar",
+        "name": "Sync Google Calendar",
+        "author": "Dexin Qi",
+        "description": "Synchronize events from Google Calendar and manage them like tasks.",
+        "repo": "dexin-qi/obsidian-sync-calendar"
+    },
+    {
+        "id": "share-to-cubox",
+        "name": "Share to Cubox",
+        "description": "Share notes to Cubox.",
+        "author": "Redwinam",
+        "repo": "Redwinam/obsidian-cubox"
+    },
+    {
+        "id": "attachment-management",
+        "name": "Attachment Management",
+        "description": "Customize attachment path, auto-rename attachments, etc.",
+        "author": "trganda",
+        "repo": "trganda/obsidian-attachment-management"
+    },
+    {
+        "id": "chess-study",
+        "name": "Chess Study",
+        "author": "Christoph Lindst\u00e4dt",
+        "description": "A chess study helper and PGN viewer/editor.",
+        "repo": "chrislicodes/obsidian-chess-study"
+    },
+    {
+        "id": "lskypro-auto-upload",
+        "name": "Image To Lskypro",
+        "author": "NekouTarou",
+        "description": "Auto upload images from clipboard to Lskypro.",
+        "repo": "NekoTarou/lskypro-auto-upload"
+    },
+    {
+        "id": "dendron-tree",
+        "name": "Dendron Tree",
+        "author": "Levi Rizki Saputra",
+        "description": "Add tree for exploring Dendron note.",
+        "repo": "levirs565/obsidian-dendron-tree"
+    },
+    {
+        "id": "silicon",
+        "name": "Silicon AI",
+        "author": "deepfates",
+        "description": "Add some intelligence to your notes with Silicon AI.",
+        "repo": "deepfates/silicon"
+    },
+    {
+        "id": "mermaid-helper",
+        "name": "Mermaid.js Helper (OMH)",
+        "description": "Additional commands for mermaid.js workflow and more.",
+        "author": "Francesco Di Cursi",
+        "repo": "FrancescoDiCursi/Mermaid.js-Helper-OMH-plugin"
+    },
+    {
+        "id": "telegram-sync",
+        "name": "Telegram Sync",
+        "description": "Transfer messages and files from Telegram to Obsidian.",
+        "author": "soberhacker",
+        "repo": "soberhacker/obsidian-telegram-sync"
+    },
+    {
+        "id": "pieces-for-developers",
+        "name": "Pieces for Developers",
+        "description": "Streamline your coding workflow with powerful features for capturing, managing, translating, and enhancing code snippets. (Closed source)",
+        "author": "Pieces For Developers",
+        "repo": "pieces-app/obsidian-pieces"
+    },
+    {
+        "id": "blur",
+        "name": "Blur",
+        "description": "Create obfuscated blocks of text.",
+        "author": "@gapmiss",
+        "repo": "gapmiss/blur"
+    },
+    {
+        "id": "canvas-links",
+        "name": "Canvas Links",
+        "author": "aqav",
+        "description": "Add views to show \"outgoing links\" and \"backlinks\" of canvas in Obsidian.",
+        "repo": "aqav/obsidian-canvas-links"
+    },
+    {
+        "id": "hamsterbase",
+        "name": "HamsterBase Official",
+        "author": "HamsterBase",
+        "description": "Official HamsterBase integration.",
+        "repo": "hamsterbase/obsidian-hamsterbase"
+    },
+    {
+        "id": "todotxt",
+        "name": "TodoTxt",
+        "author": "Mark Grimes",
+        "description": "Manage Todo.txt files.",
+        "repo": "mvgrimes/obsidian-todotxt-plugin"
+    },
+    {
+        "id": "arcana",
+        "name": "Arcana",
+        "description": "Supercharge your note-taking through AI-powered insights and suggestions.",
+        "author": "A-F-V",
+        "repo": "A-F-V/obsidian-arcana"
+    },
+    {
+        "id": "auto-anki",
+        "name": "Auto Anki",
+        "author": "ad2969",
+        "description": "Using AI to automate card creation for Spaced Repetion in Anki.",
+        "repo": "ad2969/obsidian-auto-anki"
+    },
+    {
+        "id": "api-request",
+        "name": "APIRequest",
+        "author": "rooyca",
+        "description": "Request and retrieve data from APIs. The responses are delivered in a JSON format for easy integration with your notes.",
+        "repo": "Rooyca/obsidian-api-request"
+    },
+    {
+        "id": "link-with-alias",
+        "name": "Link with alias",
+        "author": "Pavel Vojtechovsky",
+        "description": "Create links and aliases in front matter of target document.",
+        "repo": "pvojtechovsky/obsidian-link-with-alias"
+    },
+    {
+        "id": "hackerone",
+        "name": "HackerOne",
+        "author": "neolex",
+        "description": "Fetch HackerOne bug reports.",
+        "repo": "Neolex-Security/obsidian-hackerone"
+    },
+    {
+        "id": "confluence-to-obsidian",
+        "name": "Confluence Import",
+        "author": "K",
+        "description": "Import Confluence space into your vault.",
+        "repo": "KkEi34/confluence-to-obsidian-plugin"
+    },
+    {
+        "id": "flashcards-llm",
+        "name": "Flashcards LLM",
+        "author": "Marco Pampaloni",
+        "description": "Use Large Language Models (such as ChatGPT) to automatically generate flashcards from your notes.",
+        "repo": "crybot/obsidian-flashcards-llm"
+    },
+    {
+        "id": "recipe-grabber",
+        "name": "Recipe Grabber",
+        "author": "seethroughdev",
+        "description": "Quickly grab the important contents of any online recipe.",
+        "repo": "seethroughdev/obsidian-recipe-grabber"
+    },
+    {
+        "id": "note-archiver",
+        "name": "Note archiver",
+        "author": "thenomadlad",
+        "description": "Tools to archive your notes in another folder.",
+        "repo": "thenomadlad/obsidian-note-archiver"
+    },
+    {
+        "id": "iconoir-icons",
+        "name": "Iconoir Icons",
+        "author": "@gapmiss",
+        "description": "Create and display customized SVG Iconoir icons.",
+        "repo": "gapmiss/iconoir-icons"
+    },
+    {
+        "id": "automatic-list-styles",
+        "name": "Automatic List Styles",
+        "author": "Max McGuire",
+        "description": "Automatically formats the styles of ordered lists, incrementing the list style for each layer.",
+        "repo": "WiseGuru/obsidian-automatic-list-styles"
+    },
+    {
+        "id": "shukuchi",
+        "name": "Shukuchi",
+        "author": "tadashi-aikawa",
+        "description": "Teleport to links (URL or internal link) and jump to their destinations.",
+        "repo": "tadashi-aikawa/shukuchi"
+    },
+    {
+        "id": "chat-stream",
+        "name": "Chat Stream",
+        "author": "Ryan P Smith",
+        "description": "Create branching GPT chats using canvas notes.",
+        "repo": "rpggio/obsidian-chat-stream"
+    },
+    {
+        "id": "blindfold-obsidian",
+        "name": "BlindFold",
+        "author": "my99n",
+        "description": "Fold text by making it completely hidden.",
+        "repo": "vzsky/blindfold-obsidian"
+    },
+    {
+        "id": "findoc",
+        "name": "Financial Doc",
+        "author": "Studio Webux",
+        "description": "Financial documentation and tracking using CSV format and Chart.js.",
+        "repo": "studiowebux/obsidian-findoc"
+    },
+    {
+        "id": "file-include",
+        "name": "File Include",
+        "author": "Till Hoffmann",
+        "description": "Include or embed files in Obsidian Markdown.",
+        "repo": "tillahoffmann/obsidian-file-include"
+    },
+    {
+        "id": "vault-chat",
+        "name": "Vault Chat",
+        "author": "Exo Ascension",
+        "description": "A ChatGPT bot trained on your vault notes. Ask your AI questions about your own thoughts and ideas!",
+        "repo": "exoascension/vault-chat"
+    },
+    {
+        "id": "mermaid-themes",
+        "name": "Mermaid Themes",
+        "description": "Alternate support for mermaid.js that supports theming and customization.",
+        "author": "jvsteiner",
+        "repo": "jvsteiner/mermaid-themes"
+    },
+    {
+        "id": "background-image",
+        "name": "Background Image",
+        "description": "Specify a remote URL as the background image, and a few settings to tweak the experience.",
+        "author": "shmolf",
+        "repo": "shmolf/obsidian-editor-background"
+    },
+    {
+        "id": "html-server",
+        "name": "Html Server",
+        "author": "Pr0dt0s",
+        "description": "Spin up a local http server to access your vault via a web browser.",
+        "repo": "Pr0dt0s/obsidian-html-server"
+    },
+    {
+        "id": "obsidian-importer",
+        "name": "Importer",
+        "author": "Obsidian",
+        "description": "Import data from Notion, Evernote, Apple Notes, Microsoft OneNote, Google Keep, Bear, Roam, and HTML files.",
+        "repo": "obsidianmd/obsidian-importer"
+    },
+    {
+        "id": "cloudinary",
+        "name": "Cloudinary",
+        "description": "Upload content (images, videos, audio) to Cloudinary and insert (copy or drag both) them into your notes.",
+        "author": "Uday Samsani, Jordan Handy",
+        "repo": "uday-samsani/obsidian-cloudinary"
+    },
+    {
+        "id": "flowershow",
+        "name": "Flowershow",
+        "author": "Rufus Pollock",
+        "description": "Publish notes with Flowershow.",
+        "repo": "datopian/obsidian-flowershow"
+    },
+    {
+        "id": "movie-obsidian",
+        "name": "Movie",
+        "author": "Onur Ay\u00e7i\u00e7ek",
+        "description": "Search movies info and trailers.",
+        "repo": "onuraycicek/obsidian-movie"
+    },
+    {
+        "id": "markdown-link-space-encoder",
+        "name": "Markdown Link Space Encoder",
+        "author": "Ron Kosova",
+        "description": "Automatically encode spaces to %20 in Markdown-style links.",
+        "repo": "rkosova/obsidian-markdown-link-space-encoder"
+    },
+    {
+        "id": "bmo-chatbot",
+        "name": "BMO Chatbot",
+        "description": "Generate and brainstorm ideas while creating your notes using Large Language Models (LLMs) such as OpenAI's \"gpt-3.5-turbo\" and \"gpt-4\".",
+        "author": "Longy2k",
+        "repo": "longy2k/obsidian-bmo-chatbot"
+    },
+    {
+        "id": "supsub",
+        "name": "SupSub",
+        "author": "Wjgoarxiv",
+        "description": "Easily format superscripts and subscripts in your notes.",
+        "repo": "wjgoarxiv/obsidian-supsub"
+    },
+    {
+        "id": "typst",
+        "name": "Typst Renderer",
+        "author": "fenjalien",
+        "description": "Render `typst` code blocks and math blocks to images with Typst.",
+        "repo": "fenjalien/obsidian-typst"
+    },
+    {
+        "id": "ai-summary",
+        "name": "AI Notes Summary",
+        "author": "R. Ian Bull (irbull)",
+        "description": "Use OpenAI to generate a summary of referenced notes.",
+        "repo": "irbull/obsidian-ai-summary"
+    },
+    {
+        "id": "qatt",
+        "name": "Query all the things",
+        "description": "Execute SQL queries against your data in Obsidian and render it using templates.",
+        "author": "Sytone",
+        "repo": "sytone/obsidian-queryallthethings"
+    },
+    {
+        "id": "lilypond",
+        "name": "Lilypond",
+        "description": "Render Lilypond templates.",
+        "author": "DOT-ASTERISK",
+        "repo": "dot-asterisk-nl/obsidian-lilypond"
+    },
+    {
+        "id": "chemical-structure-renderer",
+        "name": "Chemical Structure Renderer",
+        "description": "Render chemical structures from SMILES strings into PNG or SVG format using Ketcher and Indigo Service.",
+        "author": "xaya1001",
+        "repo": "xaya1001/obsidian-Chemical-Structure-Renderer"
+    },
+    {
+        "id": "time-ruler",
+        "name": "Time Ruler",
+        "description": "A drag-and-drop time ruler combining the best of a task list and a calendar view (integrates with Tasks, Full Calendar, and Dataview).",
+        "author": "Joshua Tazman Reinier",
+        "repo": "joshuatazrein/obsidian-time-ruler"
+    },
+    {
+        "id": "logstravaganza",
+        "name": "Logstravaganza",
+        "author": "Carlo Zottmann",
+        "description": "A simple proxy for `console.*()` calls which copies log messages and uncaught exceptions to a note.",
+        "repo": "czottmann/obsidian-logstravaganza"
+    },
+    {
+        "id": "markdown-blogger",
+        "name": "Markdown Blogger",
+        "author": "Alexa Fazio",
+        "description": "Push Markdown notes to your local blog, portfolio, or static site. Works with Astro.js, Next.js, and any other framework configured to render Markdown pages.",
+        "repo": "afazio1/obsidian-markdown-blogger"
+    },
+    {
+        "id": "simple-rss",
+        "name": "Simple RSS",
+        "description": "Collect RSS articles into notes.",
+        "author": "Monnierant",
+        "repo": "monnierant/obsidian-simple-rss"
+    },
+    {
+        "id": "quick-links",
+        "name": "Quick Links",
+        "author": "Ian Fisher",
+        "description": "Create quick link shortcuts to Wikipedia and other sites",
+        "repo": "iafisher/obsidian-quick-links"
+    },
+    {
+        "id": "editor-width-slider",
+        "name": "Editor Width Slider",
+        "author": "@MugishoMp",
+        "description": "Customize Obsidian's editor width with a slider for a tailored editing experience.",
+        "repo": "MugishoMp/obsidian-editor-width-slider"
+    },
+    {
+        "id": "markdown-tree",
+        "name": "Markdown Tree",
+        "author": "carvah",
+        "description": "Create a beautiful and intuitive directory tree using Markdown-oriented code style using tabs, spaces and enters.",
+        "repo": "carvah/markdown-tree-plugin"
+    },
+    {
+        "id": "auto-front-matter",
+        "name": "Auto Front Matter",
+        "author": "conorzhong",
+        "description": "Auto update front matter.",
+        "repo": "conorzhong/obsidian-auto-front-matter"
+    },
+    {
+        "id": "emoji-tags-titler",
+        "name": "EmoTagsTitler",
+        "author": "Cyfine",
+        "description": "Add the emojis contained in the tags to the beginning of the note title.",
+        "repo": "Cyfine/EmoTagsTitler"
+    },
+    {
+        "id": "advanced-random-note",
+        "name": "Advanced Random Note",
+        "author": "Karsten Finderup Pedersen",
+        "description": "Create commands from custom queries to open random notes.",
+        "repo": "karstenpedersen/obsidian-advanced-random-note"
+    },
+    {
+        "id": "git-url",
+        "name": "Git Url",
+        "author": "khuongduy354",
+        "description": "Create a url to your file on your git remote repo.",
+        "repo": "khuongduy354/obsidian-git-url"
+    },
+    {
+        "id": "pf2-action-icons",
+        "name": "Pathfinder 2E Action Icons",
+        "author": "Thiago Coutinho",
+        "description": "Display Pathfinder 2E action icons.",
+        "repo": "thiagocoutinhor/pf2-action-icons"
+    },
+    {
+        "id": "badges",
+        "name": "Badges",
+        "author": "@gapmiss",
+        "description": "Add inline badges/callouts to notes.",
+        "repo": "gapmiss/badges"
+    },
+    {
+        "id": "readability-score",
+        "name": "Readability Score",
+        "author": "zuchka",
+        "description": "Score the readabilty of your writing using the Flesch Reading Ease (FRE) formula.",
+        "repo": "zuchka/obsidian-readability"
+    },
+    {
+        "id": "hide-folders",
+        "name": "Hide Folders",
+        "author": "JonasDoesThings",
+        "description": "Quickly toggle the visibility of specific folders in the file navigator based on configured names. Useful for hiding attachment folders.",
+        "repo": "JonasDoesThings/obsidian-hide-folders"
+    },
+    {
+        "id": "style-importer",
+        "name": "Style Importer",
+        "description": "Import a stylesheet from a URL into your snippets folder.",
+        "author": "Josh Rouwhorst",
+        "repo": "joshrouwhorst/style-importer"
+    },
+    {
+        "id": "apl-render",
+        "name": "APL Render",
+        "author": "my99n",
+        "description": "Render APL syntax.",
+        "repo": "vzsky/apl-obsidian"
+    },
+    {
+        "id": "guid-front-matter",
+        "name": "Add an ID to the front matter",
+        "author": "llimllib",
+        "description": "Add a globally unique ID to every Markdown document's frontmatter.",
+        "repo": "llimllib/obsidian-guid-plugin"
+    },
+    {
+        "id": "due-when",
+        "name": "Due When",
+        "author": "Andy Baxter",
+        "description": "Add shortcuts to insert due dates for end of this week or end of next week.",
+        "repo": "andrewbaxter439/due-when"
+    },
+    {
+        "id": "style-text",
+        "name": "Style Text",
+        "author": "Juanjo Arranz",
+        "description": "Apply custom CSS styles to selected text in your notes.",
+        "repo": "juanjoarranz/style-text-obsidian-plugin"
+    },
+    {
+        "id": "notes-dater",
+        "name": "Notes dater",
+        "author": "Paul Treanor",
+        "description": "Add created on and last updated on dates of the active note to the status bar.",
+        "repo": "paultreanor/notes-dater"
+    },
+    {
+        "id": "air-quotes",
+        "name": "Air Quotes",
+        "author": "Alan Grainger",
+        "description": "Search and insert quotes from a source text as you type.",
+        "repo": "alangrainger/obsidian-air-quotes"
+    },
+    {
+        "id": "vault-2-book",
+        "name": "Vault 2 Book",
+        "description": "Convert your notes to a book creating a single file containing all the notes linked.",
+        "author": "Mitra98t",
+        "repo": "Mitra98t/vault2book-plugin"
+    },
+    {
+        "id": "markdown-chords",
+        "name": "Markdown Chords",
+        "description": "Add musical chord notation and chord diagrams for stringed instruments (e.g. guitar) in Markdown. Supports chords in any Western scale/mode, including extended jazz chords.",
+        "author": "David Hunt",
+        "repo": "dnotes/obsidian-markdown-chords"
+    },
+    {
+        "id": "laws-of-form",
+        "name": "Laws of Form",
+        "author": "Kevin German",
+        "description": "Create, manage and display Laws of Form expressions like ((a)) (b) = a (b).",
+        "repo": "Kevger/obsidian-laws-of-form"
+    },
+    {
+        "id": "notes-sync-share",
+        "name": "Notes Sync Share",
+        "author": "Alt-er",
+        "description": "Sync and share (publish) your notes in your own private service.",
+        "repo": "Alt-er/obsidian-sync-share"
+    },
+    {
+        "id": "nai4obsidian",
+        "name": "NovelAI",
+        "author": "SGreen",
+        "description": "Generate text with NovelAI's models.",
+        "repo": "SalokinGreen/NAI4Obsidian"
+    },
+    {
+        "id": "password-protection",
+        "name": "Password Protection",
+        "description": "Lock and protect your private notes and diary with a password, no encrypt, no decrypt.",
+        "author": "Qing Li",
+        "repo": "qing3962/password-protection"
+    },
+    {
+        "id": "lds-scriptures-reference",
+        "name": "LDS Scriptures Reference",
+        "author": "pacokwon",
+        "description": "Easily insert references to LDS scriptures.",
+        "repo": "pacokwon/obsidian-lds-scriptures-plugin"
+    },
+    {
+        "id": "edit-history",
+        "name": "Edit History",
+        "description": "Keep an automatic edit history of your notes, review the history, diff against or restore previous edits.",
+        "author": "Antonio Tejada",
+        "repo": "antoniotejada/obsidian-edit-history"
+    },
+    {
+        "id": "memorization",
+        "name": "Memorization",
+        "author": "Joseph Cochran",
+        "description": "Generate study index notes using a spaced repetition algorithm (SM-2).",
+        "repo": "nwindian/Memorization-Plugin"
+    },
+    {
+        "id": "tinypng-image",
+        "name": "TinyPNG Image",
+        "author": "ckt1031",
+        "description": "Compress images using TinyPNG to save your storage.",
+        "repo": "ckt1031/obsidian-tinypng-plugin"
+    },
+    {
+        "id": "codestats",
+        "name": "Code::Stats",
+        "author": "MiskaMyasa",
+        "description": "Track your coding progress and earn XP for writing Markdown.",
+        "repo": "Miskamyasa/obsidian-codestats"
+    },
+    {
+        "id": "css-editor",
+        "name": "CSS Editor",
+        "author": "Zachatoo",
+        "description": "Edit CSS snippet files.",
+        "repo": "Zachatoo/obsidian-css-editor"
+    },
+    {
+        "id": "bulk-exporter",
+        "name": "Bulk Exporter",
+        "author": "symunona",
+        "description": "Filter, export notes from your vault using metadata into a customizable new structure.",
+        "repo": "symunona/obsidian-bulk-exporter"
+    },
+    {
+        "id": "code-styler",
+        "name": "Code Styler",
+        "author": "Mayuran Visakan",
+        "description": "Style codeblocks and inline code in reading view and editing view.",
+        "repo": "mayurankv/Obsidian-Code-Styler"
+    },
+    {
+        "id": "auto-hyperlink",
+        "name": "Auto Hyperlink",
+        "author": "take6",
+        "description": "Insert hyperlink according to user-defined rule.",
+        "repo": "take6/obsidian-plugin-auto-hyperlink"
+    },
+    {
+        "id": "colored-tags",
+        "name": "Colored Tags",
+        "author": "Pavel Frankov",
+        "description": "Colorize tags in different colors to visually distinguish them from each other. Colors of nested tags are mixed with parent tags. Text color contrast is automatically matched to comply with AA level WCAG 2.1.",
+        "repo": "pfrankov/obsidian-colored-tags"
+    },
+    {
+        "id": "markdown-sync-scroll",
+        "name": "Markdown Sync Scroll",
+        "author": "ProjectXero",
+        "description": "Allow two linked Markdown views to scroll synchronously.",
+        "repo": "XeroAlpha/markdown-sync-scroll"
+    },
+    {
+        "id": "ruled-template",
+        "name": "Ruled template",
+        "author": "YPetremann",
+        "description": "Use templates based on rules when creating a new file.",
+        "repo": "YPetremann/obsidian-ruled-template"
+    },
+    {
+        "id": "ai-tools",
+        "name": "AI Tools",
+        "author": "solderneer",
+        "description": "Adding powerful semantic search, generative answers, and other AI tools, using Supabase + OpenAI.",
+        "repo": "solderneer/obsidian-ai-tools"
+    },
+    {
+        "id": "oblogger",
+        "name": "oblogger",
+        "author": "loftTech",
+        "description": "Tag explorer and frontmatter logger.",
+        "repo": "lofttech/obsidian-oblogger"
+    },
+    {
+        "id": "simple-canvasearch",
+        "name": "Simple CanvaSearch",
+        "author": "ddalexb",
+        "description": "Quickly fuzzysearch notes, cards and their content and shift focus to them within the currently opened canvas.",
+        "repo": "ddalexb/obsidian-simple-canvasearch"
+    },
+    {
+        "id": "zettelgpt",
+        "name": "ZettelGPT",
+        "author": "Overraddit",
+        "description": "Effortlessly generate context-aware answers from ChatGPT, while maintaining a visually clear and organized conversation history.",
+        "repo": "OverRaddit/ZettelGPT"
+    },
+    {
+        "id": "invio",
+        "name": "Invio",
+        "author": "frontend-engineering",
+        "description": "Export docs as websites and deploy them to AWS S3 or compatible COS. Invio streamlines the process of publishing, enabling users to easily share their work online.",
+        "repo": "frontend-engineering/Invio"
+    },
+    {
+        "id": "periodic-para",
+        "name": "LifeOS",
+        "author": "YiBing Lin",
+        "description": "Life management system.",
+        "repo": "quanru/obsidian-lifeos"
+    },
+    {
+        "id": "source-scanner",
+        "name": "Source Scanner",
+        "author": "Gerrie Myburgh",
+        "description": "Scanner that extracts comments from source and places it in Markdown files.",
+        "repo": "gerrie-myburgh/source-scanner"
+    },
+    {
+        "id": "markdown-to-slack-message",
+        "name": "Markdown to Slack Message",
+        "description": "Convert a Markdown note to the Slack message blocks that enable you to send to Slack.",
+        "author": "Woongshik Choi",
+        "repo": "idreamer/markdown-to-slack-message"
+    },
+    {
+        "id": "micro-templates",
+        "name": "Micro templates",
+        "description": "Flexible embedded micro templates powered by Javascript functions.",
+        "author": "epszaw",
+        "repo": "epszaw/obsidian-micro-templates"
+    },
+    {
+        "id": "poker",
+        "name": "Poker",
+        "author": "James DiGioia",
+        "description": "Easily document and view your poker hands.",
+        "repo": "mAAdhaTTah/obsidian-poker"
+    },
+    {
+        "id": "color-palette",
+        "name": "Color Palette",
+        "author": "ALegendsTale",
+        "description": "Create and insert color palettes into your notes.",
+        "repo": "ALegendsTale/obsidian-color-palette"
+    },
+    {
+        "id": "link-tree",
+        "name": "Link Tree",
+        "author": "Joshua Tazman Reinier",
+        "description": "View file links and backlinks as a recursively expandable, filterable list with editable text, combining the structure of outliners like Dynalist & WorkFlowy with the flexibility of Obsidian.",
+        "repo": "joshuatazrein/obsidian-link-tree"
+    },
+    {
+        "id": "custom-list-character",
+        "name": "Custom list character",
+        "author": "Lilian POULIQUEN",
+        "description": "Choose the character to use when creating a bullet list between '-', '*' and '+'.",
+        "repo": "lilian-pouliquen/obsidian-custom-list-character"
+    },
+    {
+        "id": "ics",
+        "name": "ICS",
+        "author": "Cloud Atlas",
+        "description": "Add events from calendar ics on the web to daily notes on demand. Includes vdir support. Daily Planner, Templater and Dataview friendly.",
+        "repo": "cloud-atlas-ai/obsidian-ics"
+    },
+    {
+        "id": "fantasy-name",
+        "name": "Fantasy name generator",
+        "author": "Lukewh",
+        "description": "Insert a random fantasy name.",
+        "repo": "lukewh/fantasy-name"
+    },
+    {
+        "id": "tag-many",
+        "name": "TagMany",
+        "description": "Add the same tag(s) to multiple notes in a folder (optionally including subfolders) at once.",
+        "author": "Joshua Martius",
+        "repo": "joshua-martius/tagmany"
+    },
+    {
+        "id": "better-search-views",
+        "name": "Better Search Views",
+        "author": "Ivan Lednev",
+        "description": "Upgrade global search, backlinks and queries with outliner-like context trees.",
+        "repo": "ivan-lednev/better-search-views"
+    },
+    {
+        "id": "better-comment-toggle",
+        "name": "Better Comment Toggle",
+        "author": "Gino Valente",
+        "description": "Improved comment toggling.",
+        "repo": "MrGVSV/obsidian-better-comment-toggle"
+    },
+    {
+        "id": "mini-toolbar",
+        "name": "Mini Toolbar",
+        "author": "AidenLx & Boninall",
+        "description": "Mini context toolbar in editor.",
+        "repo": "quorafind/obsidian-mini-toolbar"
+    },
+    {
+        "id": "syncftp",
+        "name": "SyncFTP",
+        "description": "Connect to an SFTP and push/pull file changes to it.",
+        "author": "Alex Donnan",
+        "repo": "alex-donnan/SyncFTP"
+    },
+    {
+        "id": "obligator",
+        "name": "Obligator",
+        "author": "Dimitar Dimitrov",
+        "description": "A fully featured replacement for the built-in daily notes plugin. Obligator functions like a virtual bullet journal by copying over unchecked to-do items to your new daily note, along with adding any scheduled items you've set up.",
+        "repo": "Newbrict/obsidian-obligator"
+    },
+    {
+        "id": "fill-in-the-blank",
+        "name": "Fill in the Blank (FITB)",
+        "author": "Shawn McGee",
+        "description": "Use --magic-- to render inline text as blank line(s) instead.",
+        "repo": "mister-mcgee/obsidian-fill-in-the-blank"
+    },
+    {
+        "id": "inline-code-highlight",
+        "name": "InlineCodeHighlight",
+        "author": "Dimava",
+        "description": "Highlight inline `'md **code**` blocks as well as you do the ```md **big**``` ones.",
+        "repo": "Dimava/inline-code-highlight"
+    },
+    {
+        "id": "index-checker",
+        "name": "Index Checker",
+        "author": "Pavlo Deshko",
+        "description": "Make sure your index \"MOC\" files (notes or Canvas) contain all links they should contain.",
+        "repo": "pavloDeshko/obsidian-index-checker"
+    },
+    {
+        "id": "syncthing-integration",
+        "name": "Syncthing Integration",
+        "author": "LBF38",
+        "description": "Syncthing integration.",
+        "repo": "LBF38/obsidian-syncthing-integration"
+    },
+    {
+        "id": "runjs",
+        "name": "RunJS",
+        "author": "eoureo",
+        "description": "Run JavaScript code.",
+        "repo": "eoureo/obsidian-runjs"
+    },
+    {
+        "id": "touchbar-macros",
+        "name": "Touch Bar Macros",
+        "author": "Frostplexx",
+        "description": "Run custom macros from your Mac's Touch Bar.",
+        "repo": "frostplexx/obsidian-touchbar-macros"
+    },
+    {
+        "id": "obsidiosaurus",
+        "name": "Obsidiosaurus",
+        "author": "CIMSTA",
+        "description": "A bridge from your vault to Docusaurus.",
+        "repo": "CIMSTA/obsidiosaurus"
+    },
+    {
+        "id": "quail",
+        "name": "Quail",
+        "author": "Lyric",
+        "description": "Save, publish, delivery notes via Quail.ink as newsletters and blogs.",
+        "repo": "lyricat/obsidian-quail"
+    },
+    {
+        "id": "gtd-no-next-step",
+        "name": "GTD No Next Step",
+        "description": "Add a badge to Getting Things Done (GTD) \"project\" files with no defined next step.",
+        "author": "Tobias Davis",
+        "repo": "saibotsivad/obsidian-gtd-no-next-step"
+    },
+    {
+        "id": "safe-filename-linter",
+        "name": "Safe Filename Linter",
+        "author": "sneaky-foxes",
+        "description": "Lint filenames for invalid or troublesome characters.",
+        "repo": "sneaky-foxes/obsidian-safe-filename-linter"
+    },
+    {
+        "id": "copy-inline-code",
+        "name": "Copy Inline Code",
+        "author": "Ondrej Zavodny",
+        "description": "Easily copy the contents of an inline code element with a single click.",
+        "repo": "Alddar/obsidian-copy-inline-code-plugin"
+    },
+    {
+        "id": "at-people",
+        "name": "At People",
+        "description": "Use the familiar @ notation to cross link to people files in a people folder.",
+        "author": "Tobias Davis",
+        "repo": "saibotsivad/obsidian-at-people"
+    },
+    {
+        "id": "archwiki-reader",
+        "name": "ArchWiki Reader",
+        "author": "Lucy Gschwantner",
+        "description": "Read any ArchWiki page.",
+        "repo": "Jackboxx/archwiki-obsidian"
+    },
+    {
+        "id": "easy-bake",
+        "name": "Easy Bake",
+        "author": "mgmeyers",
+        "description": "Easily compile many notes down to a single file.",
+        "repo": "mgmeyers/obsidian-easy-bake"
+    },
+    {
+        "id": "yet-another-obsidian-synchronizer",
+        "name": "Yet Another Obsidian Synchronizer",
+        "author": "Mahyar Mirrashed",
+        "description": "Use Git to synchronize your vault contents across devices.",
+        "repo": "mahyarmirrashed/yaos"
+    },
+    {
+        "id": "finnish-spellcheck",
+        "name": "Finnish Spellcheck",
+        "author": "Anto Kein\u00e4nen",
+        "description": "Spellchecker for the Finnish language using Voikko. / Oikolukija suomenkielell\u00e4, joka hy\u00f6dynt\u00e4\u00e4 Voikkoa.",
+        "repo": "antoKeinanen/obsidian-finnish-spellcheck"
+    },
+    {
+        "id": "birthday-tracker",
+        "name": "Birthday-Tracker",
+        "author": "Marius W\u00f6rfel",
+        "description": "Keep track of all birthdays of your family and friends.",
+        "repo": "Raboro/Obsidian-Birthday-Tracker-Plugin"
+    },
+    {
+        "id": "lovely-mindmap",
+        "name": "Lovely-Mindmap",
+        "author": "shaun",
+        "description": "Build your own knowledge graph with smiles :-)",
+        "repo": "xincan1949/lovely-mindmap"
+    },
+    {
+        "id": "linkshelf",
+        "name": "LinkStowr",
+        "description": "Save links from your browser.",
+        "author": "Joel Sequeira",
+        "repo": "joelseq/obsidian-linkstowr"
+    },
+    {
+        "id": "modules",
+        "name": "Modules",
+        "description": "Load JavaScript and related languages like TypeScript modules from the vault and the Internet.",
+        "author": "polyipseity",
+        "repo": "polyipseity/obsidian-modules"
+    },
+    {
+        "id": "codeblock-tabs",
+        "name": "CodeBlock Tabs",
+        "author": "Jemin Mau",
+        "description": "Create tab group for contiguous code blocks.",
+        "repo": "JeminMau/Obsidian-CodeBlock-Tabs"
+    },
+    {
+        "id": "mdx",
+        "name": "MDX",
+        "author": "Yulei Chen",
+        "description": "Preview MDX in Obsidian, with support for Code Hike.",
+        "repo": "yuleicul/obsidian-mdx"
+    },
+    {
+        "id": "emacs-text-editor",
+        "name": "Emacs text editor",
+        "author": "Klojer",
+        "description": "Partial emulation of Emacs text editor.",
+        "repo": "Klojer/obsidian-emacs-text-editor"
+    },
+    {
+        "id": "waka_time_box",
+        "name": "Waka time box",
+        "author": "complexzeng",
+        "description": "Show daily coding activity from WakaTime.",
+        "repo": "simonla/obsidian_waka_box"
+    },
+    {
+        "id": "codename",
+        "name": "Codename",
+        "author": "dstack",
+        "description": "Solve the hardest problem: naming things.",
+        "repo": "dstack/obsidian-codename"
+    },
+    {
+        "id": "speech2text-helper",
+        "name": "Speech To Text Keyboard Helper",
+        "author": "mwoz123",
+        "description": "Make Google Speech to Text on Android available from the command palette.",
+        "repo": "mwoz123/speech-to-text-keyboard-helper"
+    },
+    {
+        "id": "uncheck-all",
+        "name": "Uncheck All",
+        "author": "Shahar Har-Shuv",
+        "description": "Uncheck all checkboxes in the current note using one command.",
+        "repo": "ShacharHarshuv/obsidian-uncheck-all"
+    },
+    {
+        "id": "voice",
+        "name": "Voice",
+        "author": "Chris Oguntolu",
+        "description": "Let your notes talk and speak to you and enhance your experience to effortlessly listen to your notes being read aloud and enjoy the power of sound, audio, and speech.",
+        "repo": "chrisurf/obsidian-voice"
+    },
+    {
+        "id": "cloze",
+        "name": "Cloze",
+        "author": "Vikki",
+        "description": "Convert highlights, underlines, bolded texts or any selected texts into clozes.",
+        "repo": "DearVikki/obsidian-cloze-plugin"
+    },
+    {
+        "id": "wikidata-importer",
+        "name": "Wikidata Importer",
+        "author": "Sam Rose",
+        "description": "Import data from Wikidata into your vault.",
+        "repo": "samwho/obsidian-wikidata-importer"
+    },
+    {
+        "id": "copilot-auto-completion",
+        "name": "Copilot auto completion",
+        "author": "Jordi Smit",
+        "description": "A highly configurable copilot-like auto-completion using the ChatGPT API.",
+        "repo": "j0rd1smit/obsidian-copilot-auto-completion"
+    },
+    {
+        "id": "unitade",
+        "name": "UNITADE.md",
+        "author": "Falcion",
+        "description": "Treat any file as any view, code editor and syntax highlighting, modals for creating and renaming files, assign views for files, unloading registries and many more for advanced work with non-markdown files.",
+        "repo": "Falcion/UNITADE.md"
+    },
+    {
+        "id": "python-scripter",
+        "name": "Python Scripter",
+        "author": "Nick Allison",
+        "description": "Run Python scripts directly as commands.",
+        "repo": "nickrallison/obsidian-python-scripter"
+    },
+    {
+        "id": "quicknote",
+        "name": "Quick note",
+        "author": "James Greenhalgh MBCS",
+        "description": "Create a quick note in a floating window (on command or by right-clicking the Obsidian app icon).",
+        "repo": "jamesgreenblue/obsidian-quicknote"
+    },
+    {
+        "id": "frontmatter-modified-date",
+        "name": "Update frontmatter modified date",
+        "author": "Alan Grainger",
+        "description": "Automatically update a frontmatter modified date field when the file is modified.",
+        "repo": "alangrainger/obsidian-frontmatter-modified-date"
+    },
+    {
+        "id": "multi-tag",
+        "name": "Multi Tag",
+        "author": "fez-github",
+        "description": "Add tags to multiple notes at once. Either right-click a folder, or select multiple notes and right-click the selection.",
+        "repo": "fez-github/obsidian-multi-tag"
+    },
+    {
+        "id": "zettelkasten-llm-tools",
+        "name": "Zettelkasten LLM Tools",
+        "author": "Karl Smith",
+        "description": "Zettelkasten note taking powered by Large Language Models (e.g. semantic search).",
+        "repo": "glovguy/obsidian-gpt-zettelkasten"
+    },
+    {
+        "id": "reflection",
+        "name": "Reflection",
+        "author": "Brandon Boswell",
+        "description": "Show daily and weekly notes from this day in years past.",
+        "repo": "brandonkboswell/reflection"
+    },
+    {
+        "id": "ai-research-assistant",
+        "name": "AI Research Assistant",
+        "author": "Interweb Alchemy",
+        "description": "A Prompt Engineering research utility for generative AI models like OpenAI's ChatGPT that facilitates archiving and searching conversations and live editing a conversation's context/memory.",
+        "repo": "InterwebAlchemy/obsidian-ai-research-assistant"
+    },
+    {
+        "id": "wallabag",
+        "name": "Wallabag",
+        "author": "H\u00fcseyin Zengin",
+        "description": "Sync your Wallabag articles.",
+        "repo": "huseyz/obsidian-wallabag"
+    },
+    {
+        "id": "red-pen",
+        "name": "Red Pen",
+        "author": "Lucas Melin",
+        "description": "Red Pen acts as a proofreader for your writing.",
+        "repo": "lucasmelin/red-pen"
+    },
+    {
+        "id": "zotero-sync-client",
+        "name": "Zotero Sync",
+        "author": "Frithjof Gressmann",
+        "description": "Zotero API client to sync your Zotero library into your vault.",
+        "repo": "frthjf/obsidian-zotero-sync-client"
+    },
+    {
+        "id": "harpoon",
+        "name": "Harpoon",
+        "author": "mask(developermask)",
+        "description": "Use shortcuts to manage and navigate your top four frequently-used files.",
+        "repo": "rodrez/obsidian-harpoon"
+    },
+    {
+        "id": "nostr-writer",
+        "name": "Nostr Writer",
+        "author": "James McGauran",
+        "description": "Publish your writing directly to Nostr.",
+        "repo": "jamesmagoo/nostr-writer"
+    },
+    {
+        "id": "image-converter",
+        "name": "Image Converter",
+        "author": "xRyul",
+        "description": "Convert, compress and resize images from one format to another by dragging and dropping or pasting into the note.",
+        "repo": "xryul/obsidian-image-converter"
+    },
+    {
+        "id": "data-entry",
+        "name": "Data Entry",
+        "author": "Wayne Van Son",
+        "description": "Create forms that save data simply; the data view of data entry.",
+        "repo": "waynevanson/data-entry-obsidian-plugin"
+    },
+    {
+        "id": "at-symbol-linking",
+        "name": "@ Symbol Linking",
+        "author": "Evan Bonsignori",
+        "description": "Link with @ (the at symbol). Can scope @ linking to a specific directory e.g. Contacts/",
+        "repo": "Ebonsignori/obsidian-at-symbol-linking"
+    },
+    {
+        "id": "attachment-manager",
+        "name": "Attachment Manager",
+        "author": "chenfeicqq",
+        "description": "Attachment Manager: Attachment folder name binding note name, automatically rename, automatically delete, show/hide.\n\u9644\u4ef6\u7ba1\u7406\u5668\uff1a\u9644\u4ef6\u6587\u4ef6\u5939\u540d\u79f0\u7ed1\u5b9a\u7b14\u8bb0\u540d\u3001\u81ea\u52a8\u91cd\u547d\u540d\u3001\u81ea\u52a8\u5220\u9664\u3001\u663e\u793a/\u9690\u85cf\u3002",
+        "repo": "chenfeicqq/obsidian-attachment-manager"
+    },
+    {
+        "id": "solve",
+        "name": "Solve",
+        "author": "Liam Riddell",
+        "description": "Your Math Maestro! Real-time calculations without AI (e.g. ChatGPT) fuss. From date magic ('Now + 20 days') to arithmetic flair ('10 + 5 / (2 * 2)'), your trusted sidekick in every note. More brilliance on the way!",
+        "repo": "LiamRiddell/obsidian-solve"
+    },
+    {
+        "id": "graph-nested-tags",
+        "name": "Nested tags graph",
+        "author": "drpilman",
+        "description": "Link nested tags in graph view.",
+        "repo": "drPilman/obsidian-graph-nested-tags"
+    },
+    {
+        "id": "youversion-linker",
+        "name": "YouVersion Linker",
+        "author": "Jaanonim",
+        "description": "Automatically link bible verses in your notes to YouVersion bible.",
+        "repo": "jaanonim/obsidian-youversion-linker"
+    },
+    {
+        "id": "checkbox-reorder",
+        "name": "Checkbox Reorder",
+        "author": "Erl-koenig",
+        "description": "Reorder completed checkboxes to the end of the according list.",
+        "repo": "Erl-koenig/obsidian-checkboxReorder"
+    },
+    {
+        "id": "gnome-terminal-loader",
+        "name": "Gnome Terminal Loader",
+        "author": "David Carmichael",
+        "description": "Sidebar action icons to quickly open the Gnome Terminal or to have the Gnome Terminal run a Python module.",
+        "repo": "CheeseCake87/gnome-terminal-loader"
+    },
+    {
+        "id": "media-sync",
+        "name": "Media Sync",
+        "author": "fnya",
+        "description": "Download images from the image URLs in notes and display the content.",
+        "repo": "fnya/media-sync"
+    },
+    {
+        "id": "auto-literature",
+        "name": "autoLiterature",
+        "author": "hucorz",
+        "description": "Assist you in taking notes for your literature.",
+        "repo": "hucorz/obsidian-autoLiterature"
+    },
+    {
+        "id": "local-backup",
+        "name": "Local Backup",
+        "author": "GC Chen",
+        "description": "Automatically creates a local backup of the vault.",
+        "repo": "cgcel/obsidian-local-backup"
+    },
+    {
+        "id": "chatgpt-definitions",
+        "name": "ChatGPT Definition",
+        "author": "julix14",
+        "description": "Let your AI assistant ChatGPT define words and concepts for you.",
+        "repo": "julix14/chatGPT-Obsidian"
+    },
+    {
+        "id": "postfix",
+        "name": "Postfix",
+        "author": "Bhagya Nirmaan Silva (@bhagyas)",
+        "description": "Use postfix completions to automatically format text.",
+        "repo": "bhagyas/obsidian-postfix-plugin"
+    },
+    {
+        "id": "typing-assistant",
+        "name": "Typing Assistant",
+        "author": "Jambo",
+        "description": "Support multiple shortcut menus to improve input efficiency.",
+        "repo": "Jambo2018/notion-assistant-plugin"
+    },
+    {
+        "id": "excalidraw-cn",
+        "name": "Excalidraw CN",
+        "author": "Korbin Zhao",
+        "description": "Excalidraw supporting Chinese hand write font by default.",
+        "repo": "korbinzhao/obsidian-excalidraw-cn-plugin"
+    },
+    {
+        "id": "battlesnake-viewer",
+        "name": "BattleSnake Board Viewer",
+        "author": "EnderInvader",
+        "description": "Render BattleSnake positions diagrams in note preview.",
+        "repo": "EnderInvader/battlesnake-viewer"
+    },
+    {
+        "id": "mtg-card-links",
+        "name": "MTG Card Links",
+        "author": "Aedan Smith",
+        "description": "Link to Magic the Gathering cards by enclosing the card name in square brackets.",
+        "repo": "aedans/mtg-card-links"
+    },
+    {
+        "id": "floccus-bookmarks-to-markdown",
+        "name": "Floccus Bookmarks to Markdown",
+        "author": "mddevils",
+        "description": "Import and convert your bookmarks from Floccus.",
+        "repo": "mddevils/floccus-bookmarks-to-markdown"
+    },
+    {
+        "id": "writeas-publisher",
+        "name": "Writeas Blog Publisher",
+        "author": "encima",
+        "description": "Publish notes to any write.as blogs you own.",
+        "repo": "encima/obsidian-writeas-plugin"
+    },
+    {
+        "id": "header-enhancer",
+        "name": "Header Enhancer",
+        "author": "Hobee Liu",
+        "description": "Level up your headers, customize your notes. Header Enhancer makes your notes header better and more useful.",
+        "repo": "HoBeedzc/obsidian-header-enhancer-plugin"
+    },
+    {
+        "id": "mlir-syntax-highlight",
+        "name": "MLIR Syntax Highlight",
+        "description": "Show syntax highlighing for MLIR in code blocks the editor.",
+        "author": "Lewuathe",
+        "repo": "Lewuathe/obsidian-mlir-syntax-highlight"
+    },
+    {
+        "id": "handwritten-notes",
+        "name": "Handwritten Notes",
+        "author": "FBarrCa",
+        "description": "Annotate PDFs and create handwritten notes inside your vault.",
+        "repo": "FBarrca/obsidian-handwritten-notes"
+    },
+    {
+        "id": "flashcard-gen",
+        "name": "Flashcard Generator",
+        "author": "ChloeDia",
+        "description": "Generate quizzes and questions from your notes.",
+        "repo": "chloedia/Obsidian_Quiz_Generator"
+    },
+    {
+        "id": "spreadsheets",
+        "name": "Spreadsheets",
+        "author": "Divam Gupta",
+        "description": "Create and edit advanced spreadsheets. Rich formatting, formulas, cells, filtering and more!",
+        "repo": "divamgupta/obsidian-spreadsheets"
+    },
+    {
+        "id": "ticktick",
+        "name": "TickTick",
+        "author": "Viduy Cheung",
+        "description": "Check and create tasks in TickTick.",
+        "repo": "viduycheung/ticktick-obsidian"
+    },
+    {
+        "id": "webdav-file-explorer",
+        "name": "Webdav File Explorer",
+        "author": "red0orange",
+        "description": "Explore your webdav files.",
+        "repo": "red0orange/obsidian-webdav-file-explorer"
+    },
+    {
+        "id": "sheets",
+        "name": "Sheets Extended",
+        "author": "NicoNekoru",
+        "description": "Vertical headers, merged cells, and custom CSS tables with Advanced Tables compatability.",
+        "repo": "NicoNekoru/obsidan-advanced-table-xt"
+    },
+    {
+        "id": "auto-journal",
+        "name": "Auto Journal",
+        "author": "Evan Bonsignori",
+        "description": "Opinionated journaling automation like daily notes but with backfills for the days when Obsidian wasn't opened.",
+        "repo": "Ebonsignori/obsidian-auto-journal"
+    },
+    {
+        "id": "nifty-links",
+        "name": "Nifty Links",
+        "author": "x-Ai",
+        "description": "Generate elegant, Notion-style rich link cards to enhance your note-taking experience.",
+        "repo": "x-Ai/obsidian-nifty-links"
+    },
+    {
+        "id": "exercises",
+        "name": "Exercises",
+        "author": "AlexCCavaco",
+        "description": "Create interactive exercises in your notes.",
+        "repo": "AlexCCavaco/obsidian-exercises"
+    },
+    {
+        "id": "math-booster",
+        "name": "LaTeX-like Theorem & Equation Referencer",
+        "author": "Ryota Ushio",
+        "description": "A powerful indexing & referencing system for theorems & equations in your vault. Bring LaTeX-like workflow into Obsidian with theorem environments, automatic equation numbering, and more.",
+        "repo": "RyotaUshio/obsidian-latex-theorem-equation-referencer"
+    },
+    {
+        "id": "file-explorer-plus",
+        "name": "File Explorer++",
+        "author": "kelszo",
+        "description": "Hide and pin files and folders in the file explorer using custom filters, such as wildcards and regex, based on their names, paths, and tags. Additionally, achieve the same with a single click in the file menu.",
+        "repo": "kelszo/obsidian-file-explorer-plus"
+    },
+    {
+        "id": "vox",
+        "name": "Vox",
+        "author": "vincentbavitz",
+        "description": "Intelligently transcribe and categorize your voice notes.",
+        "repo": "vincentbavitz/obsidian-vox"
+    },
+    {
+        "id": "github-embeds",
+        "name": "GitHub Embeds",
+        "author": "Gino Valente",
+        "description": "Embed GitHub issues, PRs, and code snippets.",
+        "repo": "MrGVSV/obsidian-github-embeds"
+    },
+    {
+        "id": "tenki",
+        "name": "Tenki",
+        "author": "HiroMike",
+        "description": "A simple weather display.",
+        "repo": "ms3056/Tenki"
+    },
+    {
+        "id": "tokei",
+        "name": "Tokei",
+        "author": "HiroMike",
+        "description": "A simple time and date display.",
+        "repo": "ms3056/Tokei"
+    },
+    {
+        "id": "codeblock-template",
+        "name": "Codeblock Template",
+        "author": "Super10",
+        "description": "Reuse content within code blocks, with the ability to use variables.",
+        "repo": "sylcool/obsidian-codeblock-template"
+    },
+    {
+        "id": "2hop-links-plus",
+        "name": "2Hop Links Plus",
+        "author": "Tokuhiro Matsuno, L7Cy",
+        "description": "Related links up to 2 hops away are displayed in a card format, allowing for easy browsing through connections between notes. Each card contains a preview of the corresponding note.",
+        "repo": "L7Cy/obsidian-2hop-links-plus"
+    },
+    {
+        "id": "custom-font-loader",
+        "name": "Custom Font Loader",
+        "author": "Amir Pourmand",
+        "description": "Customize your vault with any font you want (+ Support for Android and iOS).",
+        "repo": "pourmand1376/obsidian-custom-font"
+    },
+    {
+        "id": "pickly-page-blend",
+        "name": "Pickly PageBlend",
+        "author": "Dmitrii Mitrichev",
+        "description": "Publish your notes in one click.",
+        "repo": "dmitrichev/pickly-page-blend"
+    },
+    {
+        "id": "ai-editor",
+        "name": "AI Editor",
+        "description": "Elevate your workflow with customizable LLM actions.",
+        "author": "Zekun Shen",
+        "repo": "buszk/obsidian-ai-editor"
+    },
+    {
+        "id": "workbooks",
+        "name": "Workbooks",
+        "author": "Gabriele Cannata",
+        "description": "Work with spreadsheets inside your notes.",
+        "repo": "Canna71/obsidian-sheets"
+    },
+    {
+        "id": "day-planner-og",
+        "name": "Day Planner (OG)",
+        "author": "James Lynch (continued by Erin Schnabel)",
+        "description": "Day planning from a simple task list in a Markdown note (bare bones, preserves the features and behavior of the original plugin).",
+        "repo": "ebullient/obsidian-day-planner-og"
+    },
+    {
+        "id": "automatic-table-of-contents",
+        "name": "Automatic Table Of Contents",
+        "author": "Johan Satg\u00e9",
+        "description": "Create a table of contents in a note that updates itself when the note changes.",
+        "repo": "johansatge/obsidian-automatic-table-of-contents"
+    },
+    {
+        "id": "template-search-library",
+        "name": "Search Templates Library",
+        "author": "Pentchaff",
+        "description": "Save search templates for future re-use.",
+        "repo": "Pentchaff/obsidian-search-library"
+    },
+    {
+        "id": "vertical-tabs-view",
+        "name": "Vertical Tabs View",
+        "author": "hdykokd",
+        "description": "A vertical tabs view.",
+        "repo": "hdykokd/obsidian-vertical-tabs-view"
+    },
+    {
+        "id": "just-share-please",
+        "name": "Just Share Please",
+        "author": "Ellpeck",
+        "description": "Quickly and easily share individual notes online using an anonymized link. Also easy to self-host!",
+        "repo": "Ellpeck/ObsidianJustSharePlease"
+    },
+    {
+        "id": "potato-indexer",
+        "name": "Potato Indexer",
+        "author": "LoyalPotato",
+        "description": "Generate a content index based on your selection or the whole file.",
+        "repo": "LoyalPotato/potato-indexer"
+    },
+    {
+        "id": "typewriter-mode",
+        "name": "Typewriter Mode",
+        "description": "Typewriter scrolling, highlighting of the current line, dimming of unfocused paragraphs and more.",
+        "author": "Davis Riedel",
+        "repo": "davisriedel/obsidian-typewriter-mode"
+    },
+    {
+        "id": "js-engine",
+        "name": "JS Engine",
+        "author": "Moritz Jung",
+        "description": "Run JavaScript from within your notes.",
+        "repo": "mProjectsCode/obsidian-js-engine-plugin"
+    },
+    {
+        "id": "mononote",
+        "name": "Mononote",
+        "author": "Carlo Zottmann",
+        "description": "Ensure each note occupies only one tab. If a note is already open, its existing tab will be focussed instead of opening the same file in the current tab.",
+        "repo": "czottmann/obsidian-mononote"
+    },
+    {
+        "id": "cannoli",
+        "name": "Cannoli",
+        "author": "blindmansion",
+        "description": "Create and run LLM scripts in canvas.",
+        "repo": "DeabLabs/cannoli"
+    },
+    {
+        "id": "multiple-notes-outline",
+        "name": "Multiple Notes Outline",
+        "author": "iiz",
+        "description": "Add custom views which show outlines of multiple notes with headings, links, tags and list items.",
+        "repo": "iiz00/obsidian-multiple-notes-outline"
+    },
+    {
+        "id": "url-display",
+        "name": "URL Display",
+        "author": "Stephanie Lin",
+        "description": "Extract and display external URLs of the note.",
+        "repo": "lin-stephanie/obsidian-url-display"
+    },
+    {
+        "id": "change-case",
+        "name": "Change Case",
+        "author": "David Brockman",
+        "description": "Change the case (UPPER CASE, camelCase, snake_case, etc) of the current selection.",
+        "repo": "dbrockman/obsidian-change-case"
+    },
+    {
+        "id": "send-to-ghost",
+        "name": "Send to Ghost",
+        "author": "Southpaw1496",
+        "description": "Send and publish notes to your Ghost blog.",
+        "repo": "southpaw1496/obsidian-send-to-ghost"
+    },
+    {
+        "id": "content-linker",
+        "name": "Content Linker",
+        "author": "Medill-East",
+        "description": "Search and add bi-directional links to existing content.",
+        "repo": "Medill-East/obsidian-content-linker"
+    },
+    {
+        "id": "swiss-army-knife",
+        "name": "Swiss army knife",
+        "author": "mwoz123",
+        "description": "Collection of various utilities (e.g. duplicate empty line remover).",
+        "repo": "mwoz123/swiss-army-knife-obsidian"
+    },
+    {
+        "id": "share-to-notionnext",
+        "name": "Share to NotionNext",
+        "author": "EasyChris, jxpeng98",
+        "description": "Share files to any Notion database using the Notion API, originally created by EasyChris/obsidian-to-notion.",
+        "repo": "jxpeng98/obsidian-to-NotionNext"
+    },
+    {
+        "id": "inline-math",
+        "name": "No more flickering inline math",
+        "author": "Ryota Ushio",
+        "description": "Remove flickering inline math.",
+        "repo": "RyotaUshio/obsidian-inline-math"
+    },
+    {
+        "id": "expiration-date-tracker",
+        "name": "Expiration-Date-Tracker",
+        "author": "Marius W\u00f6rfel",
+        "description": "Keep track of all expiration dates, for example, for your groceries.",
+        "repo": "Raboro/obsidian-expiration-date-tracker-plugin"
+    },
+    {
+        "id": "eml-reader",
+        "name": "Email Reader",
+        "description": "A preview mode for embedded .eml files.",
+        "author": "Pulsovi",
+        "repo": "pulsovi/obsidian_eml_reader"
+    },
+    {
+        "id": "size-history",
+        "name": "Size History",
+        "author": "Piotr Borowski",
+        "description": "Admire the growth of your vault with a \"hand-drawn\" chart.",
+        "repo": "pbrw/obsidian-size-history"
+    },
+    {
+        "id": "zettelflow",
+        "name": "ZettelFlow",
+        "author": "RafaelGB",
+        "description": "Create and manage your notes in a Zettelkasten way via Canvas.",
+        "repo": "RafaelGB/Obsidian-ZettelFlow"
+    },
+    {
+        "id": "excel",
+        "name": "Excel",
+        "author": "ljcoder",
+        "description": "Create spreadsheets and easily embed them in Markdown.",
+        "repo": "ljcoder2015/obsidian-excel"
+    },
+    {
+        "id": "canvas-send-to-back",
+        "name": "Canvas Send to Back",
+        "author": "Zachatoo",
+        "description": "Move cards in canvas to the top or behind all other cards.",
+        "repo": "Zachatoo/obsidian-canvas-send-to-back"
+    },
+    {
+        "id": "sync-contacts-macos",
+        "name": "Sync Contacts on macOS",
+        "author": "Marcel Sch\u00f6ckel",
+        "description": "Sync your macOS contacts.",
+        "repo": "motschel123/Mac-Contact-Sync-Obsidian"
+    },
+    {
+        "id": "tag-page-md",
+        "name": "Tag Page",
+        "author": "Matthew Sumpter",
+        "description": "Dynamically generate and update tag-specific pages, offering a consolidated view of each tag's references across your vault.",
+        "repo": "mjsumpter/obsidian-tag-page"
+    },
+    {
+        "id": "contentful-publisher",
+        "name": "Contentful Publisher",
+        "author": "Ziya Fenn",
+        "description": "Manage your Contentful content.",
+        "repo": "ziyafenn/obsidian-contentful-publisher"
+    },
+    {
+        "id": "zotlit",
+        "name": "ZotLit",
+        "author": "AidenLx",
+        "description": "Integrate with Zotero, create literature notes, and insert citations from a Zotero library.",
+        "repo": "PKM-er/obsidian-zotlit"
+    },
+    {
+        "id": "text-transform",
+        "name": "Text Transform",
+        "author": "ipshing",
+        "description": "Add options to transform text to different casings using keyboard shortcuts.",
+        "repo": "ipshing/obsidian-text-transform"
+    },
+    {
+        "id": "copy-metadata",
+        "name": "Copy Metadata",
+        "author": "wenlzhang",
+        "description": "Copy file metadata, e.g., creation time, to clipboard. Insert copied metadata to file name.",
+        "repo": "wenlzhang/obsidian-copy-metadata"
+    },
+    {
+        "id": "text-conversions",
+        "name": "Text Conversions",
+        "author": "Juan D Frias",
+        "description": "Perform various text conversions on the selected text.",
+        "repo": "ironsigma/obsidian-text-conversions"
+    },
+    {
+        "id": "palta-note",
+        "name": "Palta Note",
+        "author": "Niket Shah (mrniket)",
+        "description": "Render Bhatkhande notation for Tabla.",
+        "repo": "mrniket/palta-obsidian-plugin"
+    },
+    {
+        "id": "qb-reader-parser",
+        "name": "QB Reader Parser",
+        "author": "Jacob Barta",
+        "description": "Automatically parse tossups from QB Reader into a format readable by the Obsidian_to_Anki plugin.",
+        "repo": "J-Barta/qb-reader-parser"
+    },
+    {
+        "id": "tags-overview",
+        "name": "Tags Overview",
+        "author": "Christian Wannerstedt",
+        "description": "An extended tags panel where tagged files can be easily viewed, filtered, and accessed.",
+        "repo": "christianwannerstedt/obsidian-tags-overview"
+    },
+    {
+        "id": "next-link",
+        "name": "Next Link",
+        "author": "Juan Luque",
+        "description": "Jump quickly between note links.",
+        "repo": "jdluque/next-link"
+    },
+    {
+        "id": "writing-goals",
+        "name": "Writing Goals",
+        "author": "James Lynch",
+        "description": "Set dynamic writing goals for your notes and folders.",
+        "repo": "lynchjames/obsidian-writing-goals"
+    },
+    {
+        "id": "auto-archive",
+        "name": "Auto Archive",
+        "author": "Shane Burke",
+        "description": "Automatically archive notes once they reach a certain age.",
+        "repo": "shanedonburke/obsidian-auto-archive"
+    },
+    {
+        "id": "cardify",
+        "name": "Cardify",
+        "author": "joshuakto",
+        "description": "Create links for blocks in a Markdown file and generate Markdown file for each link within a folder. Enabling drag-and-drop of cards onto canvas.",
+        "repo": "joshuakto/obsidian-cardify"
+    },
+    {
+        "id": "vocabulary-cards",
+        "name": "Vocabulary Cards",
+        "author": "Eugene Myazin",
+        "description": "An easy way to display vocabulary words as flashcards and as a list.",
+        "repo": "meniam/obsidian-vocabulary-cards"
+    },
+    {
+        "id": "calctex",
+        "name": "Calctex",
+        "author": "Mike",
+        "description": "Calculate LaTeX formulas.",
+        "repo": "Developer-Mike/calctex"
+    },
+    {
+        "id": "timetracker",
+        "name": "Timetracker",
+        "author": "Nils Dammenhayn",
+        "description": "A stopwatch whose value can be inserted in the editor with a hotkey.",
+        "repo": "hedgehog1833/obsidian-timetracker"
+    },
+    {
+        "id": "eleven-labs",
+        "name": "Eleven Labs",
+        "author": "Mark Charles",
+        "description": "Turn your notes into text-to-speech audio files with Eleven Labs.",
+        "repo": "veritas1/eleven-labs-obsidian-plugin"
+    },
+    {
+        "id": "digital-paper",
+        "name": "digital paper",
+        "author": "Daniel Fernandes",
+        "description": "turn off backspace and undo, just like writing with a pen on real paper.",
+        "repo": "danferns/digital-paper-obsidian-plugin"
+    },
+    {
+        "id": "merge-notes",
+        "name": "Merge Notes",
+        "author": "fnya",
+        "description": "Merge the selected notes.",
+        "repo": "fnya/merge-notes"
+    },
+    {
+        "id": "qiniu-image-uploader",
+        "name": "Qiniu Image Uploader",
+        "author": "Jade Zheng",
+        "description": "Upload images from your clipboard to qiniu.com and embed uploaded image to your note.",
+        "repo": "jianzs/obsidian-qiniu-image-uploader"
+    },
+    {
+        "id": "html-tabs",
+        "name": "HTML Tabs",
+        "author": "Patrick Tournet",
+        "description": "Create and render Tabs and tab panels in your notes.",
+        "repo": "ptournet/obsidian-html-tabs"
+    },
+    {
+        "id": "vscode-editor",
+        "name": "VSCode Editor",
+        "author": "Sun Xvming",
+        "description": "Edit Code Files like VSCode.",
+        "repo": "sunxvming/obsidian-vscode-editor"
+    },
+    {
+        "id": "anki-sync-plus",
+        "name": "AnkiSync+",
+        "author": "RochaG0",
+        "description": "Integration between Obsidian and Anki.",
+        "repo": "RochaG07/anki-sync-plus"
+    },
+    {
+        "id": "moviegrabber",
+        "name": "moviegrabber",
+        "author": "Leon Holtmeier",
+        "description": "Grab movie data from public APIs and transform it into notes that can be used with dataview and properties.",
+        "repo": "Superschnizel/Obsidian-Moviegrabber"
+    },
+    {
+        "id": "geocoding-properties",
+        "name": "Geocoding Properties",
+        "author": "Jose Elias Alvarez",
+        "description": "Insert address and location data from geocoding APIs as YAML properties.",
+        "repo": "jose-elias-alvarez/obsidian-geocoding-properties"
+    },
+    {
+        "id": "auto-tag",
+        "name": "Auto Tag",
+        "author": "Control Alt",
+        "description": "Easily generate relevant tags for your notes or selected text.",
+        "repo": "CtrlAltFocus/obsidian-plugin-auto-tag"
+    },
+    {
+        "id": "timer",
+        "name": "Timer",
+        "author": "Marius W\u00f6rfel",
+        "description": "Measure time.",
+        "repo": "Raboro/obsidian-timer-plugin"
+    },
+    {
+        "id": "oin-gotoheading",
+        "name": "Go To Heading",
+        "author": "join",
+        "description": "Quickly navigate between headings.",
+        "repo": "oin/obsidian-gotoheading"
+    },
+    {
+        "id": "gpg-crypt",
+        "name": "gpgCrypt",
+        "author": "Tjado M\u00e4cke",
+        "description": "Encrypt your notes using GPG. Supports smartcards for enhanced security! Keep your information safe and accessible only to you.",
+        "repo": "tejado/obsidian-gpgCrypt"
+    },
+    {
+        "id": "share-note",
+        "name": "Share Note",
+        "author": "Alan Grainger",
+        "description": "Instantly share/publish a note, with the full theme and content exactly like you see in Obsidian. Data is shared encrypted by default, and only you and the person you send it to have the key.",
+        "repo": "alangrainger/share-note"
+    },
+    {
+        "id": "todotxt-codeblocks",
+        "name": "TodoTxt Codeblocks",
+        "author": "Benjamin Nguyen",
+        "description": "Manage your tasks inside code blocks according to the Todo.txt specification.",
+        "repo": "benjamonnguyen/obsidian-todotxt-codeblocks"
+    },
+    {
+        "id": "screengarden-obsidian",
+        "name": "screen.garden",
+        "author": "screengarden, LLC",
+        "description": "A live collaboration, publishing, and web editing service for your PKM.",
+        "repo": "screendotgarden/screengarden-obsidian"
+    },
+    {
+        "id": "wrangle-todos",
+        "name": "TODO Wrangler",
+        "author": "Jeel Shah",
+        "description": "Wrangle your TODOs and put them at the bottom of the file.",
+        "repo": "jeel-shah/todo-wrangler"
+    },
+    {
+        "id": "fold-anywhere",
+        "name": "Fold Anywhere",
+        "author": "Boninall",
+        "description": "Set start and end marker, and then fold any text anywhere in live preview mode.",
+        "repo": "quorafind/obsidian-fold-anywhere"
+    },
+    {
+        "id": "file-property-enhancer",
+        "name": "File Property Enhancer",
+        "author": "Boninall",
+        "description": "Add icons to the file property, and customize the display of the file property.",
+        "repo": "quorafind/obsidian-file-property-enhancer"
+    },
+    {
+        "id": "collapse-node",
+        "name": "Collapse Node",
+        "author": "Boninall",
+        "description": "Collapse node in canvas.",
+        "repo": "quorafind/obsidian-collapse-node"
+    },
+    {
+        "id": "permalink-opener",
+        "name": "Permalink Opener",
+        "author": "@kepano",
+        "description": "Open URLs based on a permalink or slug in the note properties. Useful with static site generator such as Jekyll, Hugo, Eleventy, etc.",
+        "repo": "kepano/obsidian-permalink-opener"
+    },
+    {
+        "id": "idorecall",
+        "name": "iDoRecall",
+        "author": "dbhandel",
+        "description": "Create recalls from your notes.",
+        "repo": "iDoRecall/idorecall"
+    },
+    {
+        "id": "recipe-view",
+        "name": "Recipe view",
+        "author": "lachholden",
+        "description": "View your notes as interactive recipe cards while you cook.",
+        "repo": "lachholden/obsidian-recipe-view"
+    },
+    {
+        "id": "modalforms",
+        "name": "Modal forms",
+        "author": "Danielo Rodriguez",
+        "description": "Define forms for capturing data that you will be able to open from anywhere you can run JavaScript.",
+        "repo": "danielo515/obsidian-modal-form"
+    },
+    {
+        "id": "table-checkboxes",
+        "name": "Markdown table checkboxes",
+        "author": "DylanGiesberts",
+        "description": "Add support for stateful checkboxes inside Markdown tables.",
+        "repo": "DylanGiesberts/obsidian-table-checkboxes"
+    },
+    {
+        "id": "image2latex",
+        "name": "Image2LaTEX",
+        "author": "Hugo Persson",
+        "description": "Convert your images with math to LaTeX code.",
+        "repo": "Hugo-Persson/obsidian-ocrlatex"
+    },
+    {
+        "id": "tag-breakdown-generator",
+        "name": "Tag Breakdown Generator",
+        "author": "Hananoshika Yomaru",
+        "description": "Break down nested tags into multiple parent tags.",
+        "repo": "HananoshikaYomaru/obsidian-tag-generator"
+    },
+    {
+        "id": "reclipped-official",
+        "name": "ReClipped Official",
+        "author": "ReClipped",
+        "description": "Official ReClipped integration.",
+        "repo": "tech-reclipped/ReClipped-Obsidian-Official"
+    },
+    {
+        "id": "ollama",
+        "name": "Ollama",
+        "description": "Enable the usage of Ollama within your notes.",
+        "author": "hinterdupfinger",
+        "repo": "hinterdupfinger/obsidian-ollama"
+    },
+    {
+        "id": "lunar-calendar",
+        "name": "Lunar Calendar",
+        "author": "OSmile",
+        "description": "\u4e00\u4e2a\u652f\u6301\u519c\u5386\u7684\u65e5\u5386",
+        "repo": "WHG555/lunar-calendar"
+    },
+    {
+        "id": "mini-vimrc",
+        "name": "Mini Vimrc",
+        "author": "Felipe M.",
+        "description": "Add Vim keybindings via .vimrc",
+        "repo": "cabra-arretado/mini-vimrc-obsidian"
+    },
+    {
+        "id": "file-tree-generator",
+        "name": "File Tree Generator",
+        "author": "Unarray",
+        "description": "Generate a file tree using callouts.",
+        "repo": "Unarray/FileTreeGenerator"
+    },
+    {
+        "id": "treefocus",
+        "name": "TreeFocus",
+        "author": "iOSonntag",
+        "description": "Highlight, dim & style your files & folders in the file explorer (navigation) based on predefined or custom rules.",
+        "repo": "iOSonntag/obsidian-plugin-treefocus"
+    },
+    {
+        "id": "halo",
+        "name": "Halo",
+        "author": "Ryan Wang",
+        "description": "Publish content to Halo sites.",
+        "repo": "halo-sigs/obsidian-halo"
+    },
+    {
+        "id": "sets",
+        "name": "Sets",
+        "author": "Gabriele Cannata",
+        "description": "Create, edit and search sets of notes like Notion or AnyType DBs.",
+        "repo": "Canna71/obsidian-sets"
+    },
+    {
+        "id": "homework-manager",
+        "name": "Homework Manager",
+        "author": "Kadison McLellan",
+        "description": "Keep track of homework through a to-do list.",
+        "repo": "KadisonM/obsidian-homework-plugin"
+    },
+    {
+        "id": "typing",
+        "name": "Typing",
+        "author": "Nikita Konodyuk",
+        "description": "Customizable note types.",
+        "repo": "konodyuk/obsidian-typing"
+    },
+    {
+        "id": "magic-calendar",
+        "name": "MagicCalendar",
+        "author": "Vaccarini Lorenzo",
+        "description": "Leverage natural language processing techniques to find calendar events in Markdown notes, seamlessly synchronizing them with a calendar of choice.",
+        "repo": "Vaccarini-Lorenzo/MagicCalendar"
+    },
+    {
+        "id": "rescuetime",
+        "name": "RescueTime",
+        "author": "Tatsuya Hayashi",
+        "description": "View your RescueTime data.",
+        "repo": "Tatz884/RescueTime-Obsidian"
+    },
+    {
+        "id": "chat-with-bard",
+        "name": "Gemini AI Assistant",
+        "author": "Artel250",
+        "description": "A Google Gemini integration, completely for free.",
+        "repo": "Artel250/Obsidian-Gemini-Assistant"
+    },
+    {
+        "id": "tracker-plus",
+        "name": "Tracker+",
+        "author": "GreaterThan (original by pyrochlore)",
+        "description": "Track and visualize data from your notes. Works with Tracker Markdown.",
+        "repo": "greater-than/Obsidian-Tracker-Plus"
+    },
+    {
+        "id": "timeline-view",
+        "name": "Timeline View",
+        "author": "b.camphart",
+        "description": "Display your notes in a timeline, based on a given property.",
+        "repo": "b-camphart/timeline-view"
+    },
+    {
+        "id": "auto-filename",
+        "name": "Auto Filename",
+        "author": "rcsaquino",
+        "description": "Automatically rename files on the go based on the first x characters of files.",
+        "repo": "rcsaquino/obsidian-auto-filename"
+    },
+    {
+        "id": "csv-codeblock",
+        "name": "CSV Codeblock",
+        "author": "elrindir",
+        "description": "Render code blocks with CSV format.",
+        "repo": "elrindir/obsidian-csv-codeblock"
+    },
+    {
+        "id": "discord-message-formatter",
+        "name": "Discord Message Formatter",
+        "author": "Emile Durkheim",
+        "description": "Automatically format messages from Discord when you copy-paste them in a note.",
+        "repo": "Emile-Durkheim/obsidian_discord_formatter"
+    },
+    {
+        "id": "frontmatter-generator",
+        "name": "Frontmatter generator",
+        "description": "Generate frontmatter for your notes from JSON and JavaScript.",
+        "author": "Hananoshika Yomaru",
+        "repo": "HananoshikaYomaru/Obsidian-Frontmatter-Generator"
+    },
+    {
+        "id": "tistory-publisher",
+        "name": "Tistory Publisher",
+        "author": "bekurin",
+        "description": "Easily publish a note to Tistory.",
+        "repo": "bekurin/tistory-publisher"
+    },
+    {
+        "id": "auto-reading-mode",
+        "name": "Auto Reading Mode",
+        "author": "Kelvin Cao",
+        "description": "Automatically switches previously opened Markdown pages into reading mode.",
+        "repo": "kelvinc6/auto-reading-mode"
+    },
+    {
+        "id": "studier",
+        "name": "Studier",
+        "description": "Create quizzes for your notes and learn better.",
+        "author": "Alvaro Cas",
+        "repo": "alvaro-cas/studier-obsidian"
+    },
+    {
+        "id": "mochi-cards-pro",
+        "name": "Mochi Cards Pro",
+        "author": "Hayden Carpenter",
+        "description": "Create flashcards on Mochi.cards using the API provided by Mochi's Pro subscription.",
+        "repo": "xHayden/obsidian-mochi-cards-pro"
+    },
+    {
+        "id": "daily-note-pinner",
+        "name": "Daily Note Pinner",
+        "author": "LukeMT",
+        "description": "Pin the daily note of the present day. Unpin all daily notes of past and future days.",
+        "repo": "lukemt/obsidian-daily-note-pinner"
+    },
+    {
+        "id": "moon-server-publisher",
+        "name": "Moon server publisher",
+        "author": "Roman Provazn\u00edk",
+        "description": "Publish your notes directly to Moon server instance.",
+        "repo": "Dzoukr/MoonServerObsidianPlugin"
+    },
+    {
+        "id": "improved-random-note",
+        "name": "Improved Random Note",
+        "author": "ShockThunder",
+        "description": "Improved interaction with the knowledge base in so-called wandering mode by opening specific Random Notes.",
+        "repo": "ShockThunder/improved-random-note"
+    },
+    {
+        "id": "json-table",
+        "name": "JSON table",
+        "author": "Dario Baumberger",
+        "description": "Simply switch between JSON and tables. Generate a table from a JSON string or a URL (which returns JSON) in your notes. Generate JSON from a table in your notes.",
+        "repo": "dario-baumberger/obsidian-json-table"
+    },
+    {
+        "id": "abbreviations",
+        "name": "Abbreviations expander",
+        "author": "Yann POMIE (WoodenMaiden)",
+        "description": "Easily create abbreviations that will be expanded after hitting `Space`.",
+        "repo": "WoodenMaiden/obsidian-abbreviations"
+    },
+    {
+        "id": "jira-linker",
+        "name": "Jira Linker",
+        "author": "Steven Zilberberg",
+        "description": "Quickly format a Jira issue tag as a link to you Jira instance.",
+        "repo": "srz2/obsidian-jira-linker"
+    },
+    {
+        "id": "remove-empty-folders",
+        "name": "Remove Empty Folders",
+        "author": "fnya",
+        "description": "Easily remove empty folders.",
+        "repo": "fnya/remove-empty-folders"
+    },
+    {
+        "id": "archive-to-single-note",
+        "name": "Archive/trash to single note",
+        "author": "mwoz123",
+        "description": "Create single file archive/trash and merge(archive) old notes with it.",
+        "repo": "mwoz123/archive-to-single-note"
+    },
+    {
+        "id": "metal-archives",
+        "name": "Metal Archives (Unofficial)",
+        "author": "Vincenzo Caputo",
+        "description": "Create notes about metal bands and album from Metal Archives.",
+        "repo": "vincenzocaputo/obsidian-metal-archives-plugin"
+    },
+    {
+        "id": "gladdis",
+        "name": "Gladdis",
+        "author": "Aur\u00e9lien St\u00e9b\u00e9",
+        "description": "Gladdis (Generative Language Artificial Dedicated & Diligent Intelligence System) - it's an AI chatbot.",
+        "repo": "AurelienStebe/Gladdis"
+    },
+    {
+        "id": "md-image-caption",
+        "name": "Markdown Image Caption",
+        "author": "Hananoshika Yomaru",
+        "description": "Generate Markdown-based image captions.",
+        "repo": "HananoshikaYomaru/obsidian-image-caption"
+    },
+    {
+        "id": "fountain-editor",
+        "name": "Fountain Editor",
+        "author": "Chuang Caleb",
+        "description": "Fountain (screenplay) syntax highlighting in the editor.",
+        "repo": "chuangcaleb/obsidian-fountain-editor"
+    },
+    {
+        "id": "title-generator",
+        "name": "Title Generator",
+        "author": "Jascha Ephraim",
+        "description": "Quickly and easily title your notes using OpenAI's GPT-3.5.",
+        "repo": "jaschaephraim/obsidian-title-generator"
+    },
+    {
+        "id": "remotely-secure",
+        "name": "Remotely Sync",
+        "author": "sboesen",
+        "description": "Security fixes for the remotely-save unofficial plugin allowing users to synchronize notes between local device and the cloud service. Not backwards compatible.",
+        "repo": "sboesen/remotely-sync"
+    },
+    {
+        "id": "inline-encrypter",
+        "name": "Inline Encrypter",
+        "author": "Alexander Cheryomukhin",
+        "description": "Encrypt secrets in your notes.",
+        "repo": "solargate/obsidian-inline-encrypter"
+    },
+    {
+        "id": "scholar",
+        "name": "Scholar",
+        "author": "Shannon Shen",
+        "description": "Manage research library and streamline research workflow.",
+        "repo": "lolipopshock/obsidian-scholar"
+    },
+    {
+        "id": "hexo-auto-updater",
+        "name": "Hexo Auto updater",
+        "author": "Zhenjia Zhou",
+        "description": "Monitor changes in your vault, and automatically commit and push them to your Hexo blog repository.",
+        "repo": "lifeodyssey/obsidian-hexo-auto-update"
+    },
+    {
+        "id": "favorite-note",
+        "name": "Favorite Note",
+        "author": "Mahmudul Hasan",
+        "description": "Mark your note as favorite.",
+        "repo": "mahmudz/obsidian-favorite-plugin"
+    },
+    {
+        "id": "canvas-llm-extender",
+        "name": "Canvas LLM Extender",
+        "author": "Pasi Saarinen",
+        "description": "Let the OpenAI LLM / GPT add nodes to your canvas for you.",
+        "repo": "phasip/obsidian-canvas-llm-extender"
+    },
+    {
+        "id": "teleprompter",
+        "name": "Teleprompter",
+        "author": "Lumetrium",
+        "description": "Teleprompter window for live presentations and video production.",
+        "repo": "lumetrium/obsidian-teleprompter"
+    },
+    {
+        "id": "backlink-cache",
+        "name": "Backlink Cache",
+        "author": "mnaoumov",
+        "description": "Store backlink cache to speed up `app.metadataCache.getBacklinksForFile`.",
+        "repo": "mnaoumov/obsidian-backlink-cache"
+    },
+    {
+        "id": "enhance-youtube-links",
+        "name": "Enhance YouTube Links",
+        "author": "GitSum",
+        "description": "Get metadata from a YouTube video.",
+        "repo": "Git-Sum/obsidian-enhance-youtube-links"
+    },
+    {
+        "id": "sync-to-xlog",
+        "name": "sync-to-xlog",
+        "author": "Otto_J",
+        "description": "Push notes to xlog.app.",
+        "repo": "Otto-J/sync-to-xlog"
+    },
+    {
+        "id": "global-markdown-encrypt",
+        "name": "Global Markdown Encryption",
+        "author": "shlemiel",
+        "description": "In-memory AES256-GCM Markdown encryption.",
+        "repo": "shlemiel/globaloe"
+    },
+    {
+        "id": "tag-project-odaimoko",
+        "name": "Tag Project",
+        "author": "Odaimoko",
+        "description": "A Project Management Tool: Tag tasks everywhere, Manage in One page.",
+        "repo": "Odaimoko/tag-project"
+    },
+    {
+        "id": "multi-properties",
+        "name": "Multi Properties",
+        "author": "fez-github",
+        "description": "Add properties to multiple notes at once. Either right-click a folder or select multiple notes and right-click the selection.",
+        "repo": "fez-github/obsidian-multi-properties"
+    },
+    {
+        "id": "nothing",
+        "name": "Nothing",
+        "author": "pseudometa",
+        "description": "Add a no-op command to disable hotkeys.",
+        "repo": "chrisgrieser/obsidian-nothing"
+    },
+    {
+        "id": "slackify-note",
+        "name": "Slackify Note",
+        "author": "Jeremy Overman",
+        "description": "Convert a note to Slack-compliant Markdown.",
+        "repo": "jeremyoverman/obsidian-slackify-note"
+    },
+    {
+        "id": "timestamp-link",
+        "name": "Timestamp Link",
+        "author": "wenlzhang",
+        "description": "Copy timestamped links to blocks, headings and notes.",
+        "repo": "wenlzhang/obsidian-timestamp-link"
+    },
+    {
+        "id": "keyword-highlighter",
+        "name": "Keyword Highlighter",
+        "author": "Marcel Goldammer",
+        "description": "Automatically highlight specified keywords within your notes for enhanced visibility and quick reference.",
+        "repo": "marcel-goldammer/obsidian-keyword-highlighter"
+    },
+    {
+        "id": "zhongwen-block",
+        "name": "Zhongwen Block",
+        "author": "Kodai Matsumoto",
+        "description": "Code blocks with features for Chinese learners.",
+        "repo": "0918nobita/obsidian-zhongwen-block"
+    },
+    {
+        "id": "vocabulary-highlighter",
+        "name": "Vocabulary Highlighter",
+        "author": "eatgrass",
+        "description": "Hightlight vocabulary based on the word frequency.",
+        "repo": "eatgrass/obsidian-vocab-highlighter"
+    },
+    {
+        "id": "zettelkasten-outliner",
+        "name": "Zettelkasten Outliner",
+        "author": "Tyler Suzuki Nelson",
+        "description": "A list representation for your Zettelkasten.",
+        "repo": "tylersuzukinelson/zettelkasten-outliner"
+    },
+    {
+        "id": "quick-tagger",
+        "name": "Quick Tagger",
+        "author": "Gorkycreator",
+        "description": "Add and remove tags quickly. Tag search results, bulk tag, and add dedicated buttons/commands for your favorites!",
+        "repo": "Gorkycreator/obsidian-quick-tagger"
+    },
+    {
+        "id": "editor-autofocus",
+        "name": "Editor Autofocus",
+        "author": "Mgussekloo",
+        "description": "Autofocus the editor when opening a new file.",
+        "repo": "mgussekloo/obsidian-editor-autofocus"
+    },
+    {
+        "id": "note-batcher",
+        "name": "Note Batcher",
+        "author": "MrAnyx",
+        "description": "Create all unresolvered links with a single click.",
+        "repo": "MrAnyx/obsidian-note-batcher"
+    },
+    {
+        "id": "automatic-tags",
+        "name": "Automatic Tags",
+        "author": "Jamalam",
+        "description": "Add tags to new notes automatically based on their path.",
+        "repo": "Jamalam360/obsidian-automatic-tags"
+    },
+    {
+        "id": "epub-importer",
+        "name": "Epub Importer",
+        "author": "aoout",
+        "description": "Import EPUB files as Markdown.",
+        "repo": "aoout/obsidian-epub-importer"
+    },
+    {
+        "id": "spotify-link",
+        "name": "Spotify Link",
+        "author": "Studio Webux",
+        "description": "Include the song you're currently listening to in your note.",
+        "repo": "studiowebux/obsidian-spotify-link"
+    },
+    {
+        "id": "barcode-generator",
+        "name": "Barcode Generator",
+        "author": "noxonad",
+        "description": "Generate customizable barcodes into your notes.",
+        "repo": "noxonad/obsidian-barcode-generator"
+    },
+    {
+        "id": "file-index",
+        "name": "File Index",
+        "author": "Steffo",
+        "description": "Create a metadata file about the files present in the Vault.",
+        "repo": "Steffo99/obsidian-file-index"
+    },
+    {
+        "id": "notes-merger",
+        "name": "Notes Merger",
+        "author": "Nika Lopusna",
+        "description": "Merge notes into a single Markdown document based on index Markdown file.",
+        "repo": "niffka/notes-merger"
+    },
+    {
+        "id": "file-cleaner-redux",
+        "name": "File Cleaner Redux",
+        "author": "husjon",
+        "description": "Help you to clean empty files and unused attachments in the vault.",
+        "repo": "husjon/obsidian-file-cleaner-redux"
+    },
+    {
+        "id": "edit-mdx",
+        "name": "Edit MDX",
+        "author": "Tim Peters",
+        "description": "Edit and create .mdx files.",
+        "repo": "timppeters/obsidian-edit-mdx"
+    },
+    {
+        "id": "random-numbers-generator",
+        "name": "Random Number Generator",
+        "author": "iRewiewer",
+        "description": "Insert a random number.",
+        "repo": "iRewiewer/obsidian-random-numbers-generator-plugin"
+    },
+    {
+        "id": "short-tab-name",
+        "name": "short tab name",
+        "author": "Shumpei Tanaka",
+        "description": "Set tab name to short for UID user.",
+        "repo": "shumpei-tanaka/obsidian-short-tab-name"
+    },
+    {
+        "id": "run",
+        "name": "Run",
+        "author": "Hananoshika Yomaru",
+        "description": "Generate Markdown from dataview query and JavaScript.",
+        "repo": "HananoshikaYomaru/obsidian-run"
+    },
+    {
+        "id": "blockier",
+        "name": "Blockier",
+        "author": "blorbb",
+        "description": "Extra block editing utilities.",
+        "repo": "blorbb/obsidian-blockier"
+    },
+    {
+        "id": "colored-tags-wrangler",
+        "name": "Colored Tags Wrangler",
+        "author": "AnnaSasDev",
+        "description": "Assign colors to tags. Has integrations with other plugins, like Kanban.",
+        "repo": "code-of-chaos/obsidian-colored_tags_wrangler"
+    },
+    {
+        "id": "ghcat-reminder",
+        "name": "GChat Reminder",
+        "author": "Anil Erdogan",
+        "description": "Send notifications to Google Chat Webhook based on due dates in tasks.",
+        "repo": "anil-e/obsidian_gchat_plugin"
+    },
+    {
+        "id": "ical",
+        "name": "iCal",
+        "author": "Andrew Brereton",
+        "description": "Scan your vault for tasks that contain dates. Create an iCalendar file and store it in your vault or on Gist. You can then show this calendar in any iCal-compatible client such as Outlook, Google Calendar, Apple Calendar, etc.",
+        "repo": "andrewbrereton/obsidian-to-ical-plugin"
+    },
+    {
+        "id": "desci",
+        "name": "Desci",
+        "author": "Taylor Hulsmans",
+        "description": "Web3, IPFS, and Desci integrations.",
+        "repo": "Obsidian-Desci/Obsidian-Desci"
+    },
+    {
+        "id": "arena",
+        "name": "Are.na unofficial",
+        "author": "0xroko",
+        "description": "Save Are.na blocks as notes.",
+        "repo": "0xroko/obsidian-arena-plugin"
+    },
+    {
+        "id": "datetime-language-changer",
+        "name": "Datetime Language Changer",
+        "author": "Zetab_S",
+        "description": "Customize the language used for datetime formatting by changing moment.js's locale.",
+        "repo": "ZetabS/datetime-language-changer"
+    },
+    {
+        "id": "minio-uploader",
+        "name": "Minio Uploader",
+        "author": "Seebin",
+        "description": "Upload images, videos, audio, PDFs, and other files to Minio OSS.",
+        "repo": "seebin/obsidian-minio-uploader-plugin"
+    },
+    {
+        "id": "better-canvas-lock",
+        "name": "Better Canvas Lock",
+        "author": "Mara-Li",
+        "description": "Enhance the read-only mode in Canvas with fully lock the scroll, zoom, drag-and-drop in read-only!",
+        "repo": "Mara-Li/obsidian-better-canvas-lock"
+    },
+    {
+        "id": "file-indicators",
+        "name": "File indicators",
+        "author": "Jakob",
+        "description": "Add custom indicators to the file explorer.",
+        "repo": "JakobMick/obsidian-file-indicators"
+    },
+    {
+        "id": "sort-frontmatter",
+        "name": "Sort Frontmatter",
+        "author": "Kanzi",
+        "description": "Sort frontmatter recursively.",
+        "repo": "mariomui/obsidian-sort-frontmatter"
+    },
+    {
+        "id": "image-classify-paste",
+        "name": "Image Classify Paste",
+        "author": "tianfx",
+        "description": "Paste your image like Typora, the image link name not ![[Paste xxx]] but ![some name](relative-directory/xxx.png) with a relative directory.",
+        "repo": "ostoe/Ob-ImagePastePlugin"
+    },
+    {
+        "id": "publish-url",
+        "name": "Publish URL",
+        "author": "Hananoshika Yomaru",
+        "description": "Copy Obsidian Publish URL to the clipboard.",
+        "repo": "HananoshikaYomaru/obsidian-publish-url"
+    },
+    {
+        "id": "3d-graph-new",
+        "name": "3D Graph New",
+        "author": "Hananoshika Yomaru (original by Alexander Weichart)",
+        "description": "A 3D Graph view.",
+        "repo": "HananoshikaYomaru/obsidian-3d-graph"
+    },
+    {
+        "id": "omglol-statuslog-publish",
+        "name": "Omg.publish",
+        "author": "May Meow",
+        "description": "Post selected text to OMG.lol statuslog.",
+        "repo": "MayMeow/obsidian-omglol-statuslog"
+    },
+    {
+        "id": "local-graphql",
+        "name": "Local GraphQL",
+        "author": "Hawtian Wang",
+        "description": "Export Obsidian data as a local GraphQL server.",
+        "repo": "TwIStOy/obsidian-local-graphql"
+    },
+    {
+        "id": "feeds",
+        "name": "Feeds",
+        "author": "LukeMT, pashashocky, madx",
+        "description": "Create feeds of topic-specific bullet points.",
+        "repo": "lukemt/obsidian-feeds"
+    },
+    {
+        "id": "spotify-links",
+        "name": "Song Links",
+        "author": "Dillon Cutaiar",
+        "description": "Insert a link to the song currently playing on your Spotify.",
+        "repo": "cutaiar/obsidian-song-links"
+    },
+    {
+        "id": "hunchly",
+        "name": "Hunchly",
+        "author": "sapperlabs",
+        "description": "Import notes and images from Hunchly.",
+        "repo": "shadowoption/Hunchly-obsidian-plugin"
+    },
+    {
+        "id": "tckr",
+        "name": "tckr",
+        "author": "Git-Sum",
+        "description": "Get your TickTicks!",
+        "repo": "Git-Sum/obsidian-tckr"
+    },
+    {
+        "id": "periodic-table",
+        "name": "Periodic Table",
+        "author": "jake-cramer",
+        "description": "View a periodic table of elements in the sidebar.",
+        "repo": "Jake-Cramer/Periodic-Table-Obsidian"
+    },
+    {
+        "id": "helpmate",
+        "name": "HelpMate",
+        "description": "Add a sidebar view to see help sites for the plugins and themes you have installed.",
+        "author": "TfTHacker",
+        "repo": "TfTHacker/obsidian42-HelpMate"
+    },
+    {
+        "id": "paste-link",
+        "name": "Paste Link",
+        "author": "Jose Elias Alvarez",
+        "description": "Intelligently paste Markdown links.",
+        "repo": "jose-elias-alvarez/obsidian-paste-link"
+    },
+    {
+        "id": "incomplete-files",
+        "name": "Incomplete files",
+        "author": "Hananoshika Yomaru",
+        "description": "Rule based keep track of your incomplete files.",
+        "repo": "HananoshikaYomaru/obsidian-incomplete-files"
+    },
+    {
+        "id": "timethings",
+        "name": "Time Things",
+        "author": "Nick Winters",
+        "description": "Show a clock in the corner. Track the total editing time of a note and the last time it was modified.",
+        "repo": "DynamicPlayerSector/timethings"
+    },
+    {
+        "id": "custom-note-width",
+        "name": "Custom Note Width",
+        "author": "0skater0",
+        "description": "Effortlessly change the line width of each note individually. Provides multiple ways to customize the experience, making it both efficient and user-friendly to adjust line widths.",
+        "repo": "0skater0/obsidian-custom-note-width"
+    },
+    {
+        "id": "manictime",
+        "name": "ManicTime",
+        "author": "Finkit d.o.o.",
+        "description": "Send the path of the active file to locally installed ManicTime client.",
+        "repo": "manictime/manictime-obsidian"
+    },
+    {
+        "id": "calc-craft",
+        "name": "CalcCraft",
+        "author": "Claudiu Ivan",
+        "description": "Enable table-based calculations with a spreadsheet-like approach, utilizing references. Highlight the dependencies within tables and identifies circular references with support for array formulas.",
+        "repo": "klaudyu/CalcCraft"
+    },
+    {
+        "id": "tag-buddy",
+        "name": "Tag Buddy",
+        "author": "David Fasullo",
+        "description": "Add, edit, and remove tags in reading mode. Copy, move, or edit tagged blocks in reading and edit mode.",
+        "repo": "moremeyou/Obsidian-Tag-Buddy"
+    },
+    {
+        "id": "adjacency-matrix-exporter",
+        "name": "Adjacency Matrix Exporter",
+        "author": "danielegrazzini",
+        "description": "Create a numerical adjacency matrix of your vault in two ways: Absolute and Normalized.",
+        "repo": "danielegrazzini/adjacency-matrix-exporter"
+    },
+    {
+        "id": "key-value-list",
+        "name": "Key-Value List",
+        "author": "Christian Wannerstedt",
+        "description": "Turn lists into neatly formatted key-value lists.",
+        "repo": "christianwannerstedt/obsidian-key-value-list"
+    },
+    {
+        "id": "disk-usage",
+        "name": "Disk Usage",
+        "author": "Promptier",
+        "description": "Measure disk usage for tracking size of folders and file types.",
+        "repo": "Promptier/disk-usage"
+    },
+    {
+        "id": "attachment-uploader",
+        "name": "Attachment Uploader",
+        "author": "zhuxining",
+        "description": "Upload attachments to PicSee or uPic, with customization for commands and file type.",
+        "repo": "zhuxining/obsidian-attachment-uploader"
+    },
+    {
+        "id": "formatto-format",
+        "name": "Formatto",
+        "author": "Eva",
+        "description": "Simple, fast, and easy-to-use Markdown formatter.",
+        "repo": "evasquare/formatto"
+    },
+    {
+        "id": "chat-cbt",
+        "name": "ChatCBT",
+        "author": "Claire Froelich",
+        "description": "AI-powered journaling assistant for your notes, inspired by cognitive behavioral therapy (CBT).",
+        "repo": "clairefro/obsidian-chat-cbt-plugin"
+    },
+    {
+        "id": "auto-displaystyle-inline-math",
+        "name": "Auto-\\displaystyle Inline Math",
+        "author": "Ryota Ushio",
+        "description": "Automatically make all inline math \\displaystyle.",
+        "repo": "RyotaUshio/obsidian-auto-displaystyle-inline-math"
+    },
+    {
+        "id": "textanalysis",
+        "name": "Text Analysis",
+        "author": "Miha Kralj",
+        "description": "Real-time text analysis on readability, structure, and complexity, incorporating over 30 indicators.",
+        "repo": "mihakralj/obsidian-textanalysis"
+    },
+    {
+        "id": "minitabs",
+        "name": "Minitabs",
+        "author": "ssjy1919",
+        "description": "Customize a set of nested tabs through code blocks.",
+        "repo": "ssjy1919/Obsidian-minitabs"
+    },
+    {
+        "id": "lyrics",
+        "name": "Lyrics",
+        "author": "eatgrass",
+        "description": "Enhance the audio player with interacive lyrics.",
+        "repo": "eatgrass/obsidian-lyrics"
+    },
+    {
+        "id": "show-whitespace-cm6",
+        "name": "Show Whitespace",
+        "author": "Erin Schnabel",
+        "description": "CSS styles and CM6 extensions to highlight whitespace in Source and Live Preview modes.",
+        "repo": "ebullient/obsidian-show-whitespace-cm6"
+    },
+    {
+        "id": "rendered-block-link-suggestions",
+        "name": "Rendered Block Link Suggestions",
+        "author": "Ryota Ushio",
+        "description": "Upgrade Obsidian's built-in link suggestions with block Markdown rendering.",
+        "repo": "RyotaUshio/obsidian-rendered-block-link-suggestions"
+    },
+    {
+        "id": "quick-preview",
+        "name": "Quick Preview",
+        "author": "Ryota Ushio",
+        "description": "Quickly preview a suggestion before selecting it in link suggestions & quick switcher.",
+        "repo": "RyotaUshio/obsidian-quick-preview"
+    },
+    {
+        "id": "desk",
+        "name": "Desk",
+        "author": "David Landry",
+        "description": "A desk to see notes at a glance. Requires Dataview.",
+        "repo": "davidlandry93/obsidian-desk"
+    },
+    {
+        "id": "tldraw",
+        "name": "Tldraw",
+        "author": "Sam Alhaqab",
+        "description": "Use Tldraw to draw and edit content on a virtual whiteboard.",
+        "repo": "holxsam/tldraw-in-obsidian"
+    },
+    {
+        "id": "autocorrect-formatter",
+        "name": "Autocorrect Formatter",
+        "author": "b-yp",
+        "description": "Format Markdown content using Autocorrect.",
+        "repo": "b-yp/obsidian-autocorrect"
+    },
+    {
+        "id": "vim-yank-highlight",
+        "name": "Vim Yank Highlight",
+        "author": "Aleksey Rowan",
+        "description": "Highlight yanked text in Vim mode. Enjoy that subtle animation you've missed so much.",
+        "repo": "aleksey-rowan/obsidian-vim-yank-highlight"
+    },
+    {
+        "id": "tickticksync",
+        "name": "TickTickSync",
+        "author": "thesamim",
+        "description": "Sync TickTick tasks.",
+        "repo": "thesamim/TickTickSync"
+    },
+    {
+        "id": "slash-commander",
+        "name": "Slash Commander",
+        "author": "alephpiece",
+        "description": "Customize the slash command list, assign each command an icon.",
+        "repo": "alephpiece/obsidian-slash-commander"
+    },
+    {
+        "id": "custom-save",
+        "name": "Custom save",
+        "author": "Hananoshika Yomaru",
+        "description": "Add custom save actions.",
+        "repo": "HananoshikaYomaru/obsidian-custom-save"
+    },
+    {
+        "id": "peerdraft",
+        "name": "Peerdraft",
+        "author": "Peerdraft",
+        "description": "Real-time, instant collaboration on documents or folders. Whether for quick note-taking or building a team knowledge base, Peerdaft syncs with your collaborators' vaults and also offers a Web Editor.",
+        "repo": "peerdraft/obsidian-plugin"
+    },
+    {
+        "id": "note-gallery",
+        "name": "Note Gallery",
+        "author": "Pash Shocky",
+        "description": "A masonry gallery that will visualize your notes, similar to Craft note view.",
+        "repo": "pashashocky/obsidian-note-gallery"
+    },
+    {
+        "id": "smart-title",
+        "name": "Smart Title",
+        "author": "magooup",
+        "description": "Automatically extract tags and aliases from the title.",
+        "repo": "magooup/obsidian-plugin-smart-title"
+    },
+    {
+        "id": "gamified-pkm",
+        "name": "Gamificate your PKM",
+        "author": "Andreas Trebing",
+        "description": "Enhance your Personal Knowledge Management with gamification elements. Boost motivation and achieve growth as you engage with your PKM.",
+        "repo": "saertna/obsidian-gamified-pkm"
+    },
+    {
+        "id": "relax",
+        "name": "R.E.L.A.X.",
+        "description": "Multi-regex management for data linking and batch processing across selection, files, and folders.",
+        "author": "Syr",
+        "repo": "Syr0/R.E.L.A.X."
+    },
+    {
+        "id": "coder",
+        "name": "Encoder/Decoder",
+        "description": "Convert text into base64 format.",
+        "author": "Rudi H\u00e4usler",
+        "repo": "rudimuc/obsidian-coder"
+    },
+    {
+        "id": "habit-tracker-21",
+        "name": "Habit Tracker 21",
+        "author": "zoreet",
+        "description": "Your 21-day journey to habit formation simplified.",
+        "repo": "zoreet/habit-tracker"
+    },
+    {
+        "id": "math-in-callout",
+        "name": "Better Math in Callouts & Blockquotes",
+        "author": "Ryota Ushio",
+        "description": "Add better Live Preview support for math rendering inside callouts & blockquotes.",
+        "repo": "RyotaUshio/obsidian-math-in-callout"
+    },
+    {
+        "id": "dynamic-line-height-cjk",
+        "name": "Dynamic Line Height for CJK",
+        "author": "Ryota Ushio",
+        "description": "Dynamically adjust line height for lines & paragraphs containing CJK characters.",
+        "repo": "RyotaUshio/obsidian-dynamic-line-height-cjk"
+    },
+    {
+        "id": "pomodoro-timer",
+        "name": "Pomodoro Timer",
+        "author": "eatgrass",
+        "description": "Manage your daily focus using the Pomodoro Technique.",
+        "repo": "eatgrass/obsidian-pomodoro-timer"
+    },
+    {
+        "id": "vim-im-control",
+        "name": "Vim IM Control",
+        "author": "hideakitai",
+        "description": "Switch input method when `InsertLeave` and `InsertEnter`. Supports macOS, Windows, and Linux.",
+        "repo": "hideakitai/obsidian-vim-im-control"
+    },
+    {
+        "id": "global-proxy",
+        "name": "Global Proxy",
+        "author": "windingblack",
+        "description": "Configure network proxies for users in areas with restricted networks.",
+        "repo": "windingblack/obsidian-global-proxy"
+    },
+    {
+        "id": "subdivider",
+        "name": "Subdivider",
+        "author": "Tricster",
+        "description": "Convert your notes into nested folders, and automatically create separate files for each subheading.",
+        "repo": "MediosZ/obsidian-subdivider"
+    },
+    {
+        "id": "image-helper",
+        "name": "Image Helper",
+        "author": "Chongmyung Park",
+        "description": "Context menu to convert image format in reading view.",
+        "repo": "byfun/obsidian-image-helper"
+    },
+    {
+        "id": "highlight-helper",
+        "name": "Highlight Helper",
+        "author": "Chongmyung Park",
+        "description": "Helper to collect highlights.",
+        "repo": "byfun/obsidian-highlight-helper"
+    },
+    {
+        "id": "syncread",
+        "name": "syncread-assistant",
+        "description": "Sync articles from SyncRead.",
+        "author": "flyer1b",
+        "repo": "flyer1b/LightRead-master"
+    },
+    {
+        "id": "intelligence",
+        "name": "Intelligence",
+        "author": "John Mavrick",
+        "description": "OpenAI GPT Assistants functionality",
+        "repo": "ransurf/obsidian-intelligence"
+    },
+    {
+        "id": "neighbouring-files",
+        "name": "Neighbouring Files",
+        "author": "Fabian Untermoser",
+        "description": "Navigate to the next and previous file in the current directory.",
+        "repo": "FabianUntermoser/obsidian-neighbouring-files-plugin"
+    },
+    {
+        "id": "storyclock",
+        "name": "Storyclock Viewer",
+        "author": "Jonathan Fisher",
+        "description": "Map timing onto a storyclock. Inspired by Plot Devices Storyclock.",
+        "repo": "jonzfisher/obsidian-chronostory"
+    },
+    {
+        "id": "local-gpt",
+        "name": "Local GPT",
+        "author": "Pavel Frankov",
+        "description": "Local Ollama and OpenAI-like GPT's assistance for maximum privacy and offline access.",
+        "repo": "pfrankov/obsidian-local-gpt"
+    },
+    {
+        "id": "tmayoff-meals",
+        "name": "Meal Plan",
+        "author": "Tyler Mayoff",
+        "description": "Meal planning and recipe manager.",
+        "repo": "tmayoff/obsidian-meals"
+    },
+    {
+        "id": "emoji-autocomplete",
+        "name": "Emoji Autocomplete",
+        "author": "KraXen72",
+        "description": "Smart suggestions when typing emoji shortcodes & more! :star:",
+        "repo": "KraXen72/obsidian-emoji-autocomplete"
+    },
+    {
+        "id": "open-as-md",
+        "name": "open-as-md",
+        "author": "kursad-k",
+        "description": "Edit non-md file types as Markdown files.",
+        "repo": "kursad-k/obsidian-openasmd"
+    },
+    {
+        "id": "ribbon-divider",
+        "name": "Ribbon Divider",
+        "author": "Andrew McGivery",
+        "description": "Add dividers to the ribbon to space out your icons.",
+        "repo": "andrewmcgivery/obsidian-ribbon-divider"
+    },
+    {
+        "id": "hill-charts",
+        "name": "Hill Charts",
+        "author": "stufro",
+        "description": "Add hill charts to your notes.",
+        "repo": "stufro/obsidian-hill-charts"
+    },
+    {
+        "id": "ollama-chat",
+        "name": "Ollama Chat",
+        "author": "Brumik",
+        "description": "Chat with your notes using Ollama and LlamaIndex.",
+        "repo": "brumik/obsidian-ollama-chat"
+    },
+    {
+        "id": "canvas-card-bg-remover",
+        "name": "Canvas Card Background Remover",
+        "author": "luxmargos",
+        "description": "Make the background of cards transparent in canvas files.",
+        "repo": "luxmargos/obsidian-canvas-card-bg-remover"
+    },
+    {
+        "id": "latex-ocr",
+        "name": "Latex OCR",
+        "author": "Lucas Van Mol",
+        "description": "Generate LaTeX equations from images in your vault or clipboard.",
+        "repo": "lucasvanmol/obsidian-latex-ocr"
+    },
+    {
+        "id": "object-writer",
+        "name": "Object Writer",
+        "author": "Iago Grah",
+        "description": "Utility for object writing with random words.",
+        "repo": "IagoGrah/obsidian-object-writer"
+    },
+    {
+        "id": "task-status",
+        "name": "Task Status",
+        "author": "Valerie Burzynski",
+        "description": "Quickly change checkbox and task status markers.",
+        "repo": "vburzynski/obsidian-task-status"
+    },
+    {
+        "id": "copy-without-links",
+        "name": "Strip Internal Links",
+        "author": "Adi Ron",
+        "description": "Copy the contents of files or selections within to the clipboard, without internal links.",
+        "repo": "adiron/obsidian-strip-internal-links"
+    },
+    {
+        "id": "git-file-explorer",
+        "name": "Git File Explorer",
+        "author": "Mateus Molina",
+        "description": "Add relevant git information of detected git repositories to the file explorer.",
+        "repo": "MateusMolina/obsidian-git-file-explorer"
+    },
+    {
+        "id": "youtube-template",
+        "name": "YouTube Template",
+        "author": "sundevista",
+        "description": "Fetch YouTube video data into your vault.",
+        "repo": "sundevista/youtube-template"
+    },
+    {
+        "id": "copy-image",
+        "name": "Copy Image",
+        "author": "Felipe D.S. Lima",
+        "description": "Easily copy images to clipboard by right-clicking an image.",
+        "repo": "felipe-ds-lima/obsidian-copy-image-plugin"
+    },
+    {
+        "id": "widgets",
+        "name": "Widgets",
+        "author": "Rafael Veiga",
+        "description": "Add widgets to your notes like clock, countdown, and quotes.",
+        "repo": "rafaelveiga/obsidian-widgets"
+    },
+    {
+        "id": "metadata-hider",
+        "name": "Metadata Hider",
+        "author": "Benature",
+        "description": "Hide specific metadata property or if its value is empty.",
+        "repo": "Benature/obsidian-metadata-hider"
+    },
+    {
+        "id": "latexocr",
+        "name": "LaTeX-OCR",
+        "author": "Jack Barker",
+        "description": "Run LaTeX-OCR if it is installed locally.",
+        "repo": "JackBarker7/obsidian-latexocr"
+    },
+    {
+        "id": "reference-generator",
+        "name": "Reference Generator",
+        "author": "Kadison McLellan",
+        "description": "Turn links into bibliographies in styles like Harvard, MLA, APA, and more.",
+        "repo": "kadisonm/obsidian-reference-generator"
+    },
+    {
+        "id": "additional-icons",
+        "name": "Additional Icons",
+        "author": "Matthew Turk",
+        "description": "Add additional iconsets.",
+        "repo": "matthewturk/obsidian-additional-icons"
+    },
+    {
+        "id": "extended-task-lists",
+        "name": "Extended Task Lists",
+        "author": "joeriddles",
+        "description": "Extended reader view support for task lists, including in-progress and won't do task items.",
+        "repo": "joeriddles/extended-task-lists"
+    },
+    {
+        "id": "ctrl-xa",
+        "name": "Ctrl-XA cycle various items",
+        "author": "nbossard",
+        "description": "Cycle through various items with keyboard shortcuts. Such as days, months, true-false, log level,... anything you need.",
+        "repo": "nbossard/obsidian-CtrlXA"
+    },
+    {
+        "id": "githobs",
+        "name": "GitHobs",
+        "author": "GabAlpha and MarcoG",
+        "description": "Use Obsidian as Github issue editor with logic taken from Git",
+        "repo": "GabAlpha/obsidian-githobs"
+    },
+    {
+        "id": "soundscapes",
+        "name": "Soundscapes",
+        "author": "Andrew McGivery",
+        "description": "Adds a music/ambiance (E.g. lofi, white noise) player to the status bar to help with concentration",
+        "repo": "andrewmcgivery/obsidian-soundscapes"
+    },
+    {
+        "id": "paste-from-history",
+        "name": "Paste From History",
+        "author": "Daniel Karakka",
+        "description": "Paste from the editor's recent clipboard history.",
+        "repo": "Karakaz/obsidian-paste-from-history"
+    },
+    {
+        "id": "instapaper",
+        "name": "Instapaper",
+        "author": "Instapaper",
+        "description": "Instapaper integration.",
+        "repo": "Instapaper/obsidian-instapaper"
+    },
+    {
+        "id": "full-screen-cross-platform",
+        "name": "Full Screen Toggle",
+        "author": "Donkey Pacific",
+        "description": "Toggle fullscreen across all platforms.",
+        "repo": "DonkeyPacific/obsidian-full-screen-cross-platform-plugin"
+    },
+    {
+        "id": "pkvs",
+        "name": "Persistent Key-Value Store",
+        "author": "Ara Adkins",
+        "description": "Provides a persistent key-value store for use in scripts in Obsidian.",
+        "repo": "iamrecursion/obsidian-pkvs"
+    },
+    {
+        "id": "settings-profiles",
+        "name": "Settings profiles",
+        "author": "4Source",
+        "description": "Allows you to create various global settings profiles. You can sync them between different vaults. To keep all your settings in sync, you'll never have to manually adjust them again for every vault you have or create in the future.",
+        "repo": "4Source/settings-profiles-obsidian-plugin"
+    },
+    {
+        "id": "font-size",
+        "name": "Font Size Adjuster",
+        "author": "Ryota Ushio",
+        "description": "Adjust font size via commands.",
+        "repo": "RyotaUshio/obsidian-font-size"
+    },
+    {
+        "id": "create-task",
+        "name": "Create Task",
+        "author": "Simon Knittel",
+        "description": "Create tasks faster from anywhere.",
+        "repo": "simonknittel/obsidian-create-task"
+    },
+    {
+        "id": "timeline-schedule",
+        "name": "Timeline Schedule",
+        "author": "Evan Bonsignori",
+        "description": "Inline timelines generated from human-readable time strings, e.g. 'Walk dog (30min)' in a ```schedule codeblock.",
+        "repo": "Ebonsignori/obsidian-timeline-schedule"
+    },
+    {
+        "id": "cursor-goaway",
+        "name": "cursor-goaway",
+        "author": "Xuer",
+        "description": "Hide the cursor after opening a note",
+        "repo": "liuxingyu521/obsidian-plugin-cursor-goaway"
+    },
+    {
+        "id": "continuous-mode",
+        "name": "Continuous Mode",
+        "author": "Michael Schrauzer",
+        "description": "Displays all open notes in a tab group as a continuous scrollable page (sometimes called Scrivenings mode).",
+        "repo": "gasparschott/obsidian-continuous-mode"
+    },
+    {
+        "id": "multi-state-checkbox-switcher",
+        "name": "Multi State CheckBox Switcher",
+        "author": "KubaMiszcz",
+        "description": "Click to handle multistate checkboxes.",
+        "repo": "KubaMiszcz/MultiStateCheckBoxSwitcher"
+    },
+    {
+        "id": "relay-md",
+        "name": "Relay.md",
+        "description": "Quickly and easily share notes with your team. Uses topics to limit reach so that only team members subscribed to your topics will automatically receive the shared notes straight into their vault!",
+        "author": "xeroc",
+        "repo": "relay-md/relay-md-obsidian-plugin"
+    },
+    {
+        "id": "insighta",
+        "name": "InsightA",
+        "author": "Hongjian Tang",
+        "description": "Extract a set of atomic notes from a long article and create MOC by note title using LLM",
+        "repo": "HongjianTang/obsidian-insighta"
+    },
+    {
+        "id": "single-file-daily-notes",
+        "name": "Single File Daily Notes",
+        "author": "Pranav Mangal",
+        "description": "Create and manage daily notes in a single file.",
+        "repo": "pranavmangal/obsidian-single-file-daily-notes"
+    },
+    {
+        "id": "apple-books-import-highlights",
+        "name": "Apple Books - Import Highlights",
+        "author": "bandantonio",
+        "description": "Import your Apple Books highlights and notes to Obsidian.",
+        "repo": "bandantonio/obsidian-apple-books-highlights-plugin"
+    },
+    {
+        "id": "rss-copyist",
+        "name": "RSS Copyist",
+        "author": "aoout",
+        "description": "Get RSS articles as notes.",
+        "repo": "aoout/obsidian-rss-copyist"
+    },
+    {
+        "id": "orgmode-cm6",
+        "name": "Orgmode (CM6)",
+        "author": "Benoit Bazard",
+        "description": "Edit Orgmode files.",
+        "repo": "bbazard/obsidian-orgmode-cm6"
+    },
+    {
+        "id": "vk-group-notifier",
+        "name": "Vk group notifier",
+        "author": "Filichev.Evgeny",
+        "description": "Track news posts from vk.com groups.",
+        "repo": "filichev-evgeny/obsidianvkupdatenotifier"
+    },
+    {
+        "id": "pinyin_replacer",
+        "name": "Pinyin Replacer",
+        "author": "LarrySAL",
+        "description": "Use the Pinyin tones without having to install extra keyboard layouts.",
+        "repo": "LarrySAL/pinyin-replacer"
+    },
+    {
+        "id": "markline",
+        "name": "Markline",
+        "author": "\u95f2\u8018",
+        "description": "Timeline view from Markdown",
+        "repo": "hotoo/obsidian-markline"
+    },
+    {
+        "id": "youtube-summarizer",
+        "name": "Youtube Summarizer",
+        "author": "ozdemir08",
+        "description": "Summarize Youtube videos using ChatGPT 3.5.",
+        "repo": "ozdemir08/youtube-video-summarizer"
+    },
+    {
+        "id": "semalogic",
+        "name": "UseSemaLogic",
+        "author": "SemaLogic UG",
+        "description": "Real-time use of the SemaLogic formal language",
+        "repo": "MM-GO/UseSemaLogic"
+    },
+    {
+        "id": "nested-daily-todos",
+        "name": "Nested Daily Todos",
+        "author": "Thomas Brezinski",
+        "description": "Carry over incomplete todos from Daily Notes grouped by headers, with support for nesting and flexible todo states.",
+        "repo": "thomasbrezinski/obsidian-nested-daily-todos"
+    },
+    {
+        "id": "root-folder-context-menu",
+        "name": "Root Folder Context Menu",
+        "author": "mnaoumov",
+        "description": "Enables context menu for vault root folder",
+        "repo": "mnaoumov/obsidian-root-folder-context-menu"
+    },
+    {
+        "id": "daily-note-creator",
+        "name": "Daily note creator",
+        "author": "Mario Holubar",
+        "description": "Automatically creates missing daily notes",
+        "repo": "mario-holubar/obsidian-daily-note-creator"
+    },
+    {
+        "id": "fastimer",
+        "name": "Fastimer",
+        "author": "vkostyanetsky",
+        "description": "Intermittent fasting tracker.",
+        "repo": "vkostyanetsky/ObsidianFastimer"
+    },
+    {
+        "id": "beautitab",
+        "name": "Beautitab",
+        "author": "Andrew McGivery",
+        "description": "Creates a customizable new tab view with beautiful backgrounds, quotes, search, and more.",
+        "repo": "andrewmcgivery/obsidian-beautitab"
+    },
+    {
+        "id": "consecutive-lists",
+        "name": "Consecutive Lists",
+        "author": "Josh Tucker",
+        "description": "Create consecutive lists that are displayed separately in reading mode.",
+        "repo": "jtucker2/obsidian-consecutive-lists"
+    },
+    {
+        "id": "alt-click-to-copy",
+        "name": "Alt-Click to Copy",
+        "author": "Veer Sheth",
+        "description": "Alt-click on codeblocks to copy its data to the clipboard",
+        "repo": "veersheth/obsidian-alt-click-to-copy"
+    },
+    {
+        "id": "hatena",
+        "name": "Hatena Blog Publisher",
+        "author": "Takuro Matsukawa",
+        "description": "Post directly to your Hatena Blog.",
+        "repo": "takmatsukawa/obsidian-hatena"
+    },
+    {
+        "id": "reason",
+        "name": "Enzyme",
+        "author": "Joshua Pham",
+        "description": "A REPL to digest your thoughts",
+        "repo": "jshph/obsidian-reason"
+    },
+    {
+        "id": "icloud-contacts",
+        "name": "iCloud Contacts",
+        "author": "Truls Aagaard",
+        "description": "Imports contacts from iCloud and manages a note for each contact.",
+        "repo": "Trulsaa/obsidian-icloud-contacts"
+    },
+    {
+        "id": "dynamic-text-concealer",
+        "name": "Dynamic Text Concealer",
+        "author": "Matt Cole Anderson",
+        "description": "Conceal or replace user-configured text patterns in Live Preview and reading mode.",
+        "repo": "mattcoleanderson/obsidian-dynamic-text-concealer"
+    },
+    {
+        "id": "timelines-revamped",
+        "name": "Timelines (Revamped)",
+        "author": "Sean Lowe",
+        "description": "Generate a chronological timeline in which all 'events' are notes that include a specific tag or set of tags.",
+        "repo": "seanlowe/obsidian-timelines"
+    },
+    {
+        "id": "gemini-assistant",
+        "name": "Gemini Assistant",
+        "author": "eatgrass",
+        "description": "Your Gemini AI assistant",
+        "repo": "eatgrass/obsidian-gemini-assistant"
+    },
+    {
+        "id": "canvas-dailynote",
+        "name": "Canvas Daily Note",
+        "author": "Andrew McGivery",
+        "description": "Add a daily note node to the canvas that will always show today's note.",
+        "repo": "andrewmcgivery/obsidian-canvas-dailynote"
+    },
+    {
+        "id": "contribution-graph",
+        "name": "Contribution Graph",
+        "author": "vran",
+        "description": "Generate an interactive heatmap to visualize and track your productivity.",
+        "repo": "vran-dev/obsidian-contribution-graph"
+    },
+    {
+        "id": "journals",
+        "name": "Journals",
+        "author": "Sergii Kostyrko",
+        "description": "Manage your journals.",
+        "repo": "srg-kostyrko/obsidian-journal"
+    },
+    {
+        "id": "mathematica-plot",
+        "name": "Mathematica Plot",
+        "author": "Marcos Nicolau",
+        "description": "Render graphs using Wolfram Mathematica code.",
+        "repo": "MarcosNicolau/obsidian-mathematica-plot"
+    },
+    {
+        "id": "evernote-decryptor",
+        "name": "Evernote Decryptor",
+        "author": "rcmdnk",
+        "description": "Manage encrypted data imported from Evernote.",
+        "repo": "rcmdnk/obsidian-evernote-decryptor"
+    },
+    {
+        "id": "arrows-in-md",
+        "name": "Arrows",
+        "author": "artisticat",
+        "description": "Draw arrows across different parts of your notes, similar to on paper.",
+        "repo": "artisticat1/arrows"
+    },
+    {
+        "id": "outline-plus",
+        "name": "Outline++",
+        "author": "Ryota Ushio",
+        "description": "Render Markdown inside the outline view.",
+        "repo": "RyotaUshio/obsidian-outline-plus"
+    },
+    {
+        "id": "better-order-list",
+        "name": "Better Order List",
+        "author": "Boninall",
+        "description": "Support new line order list like 1\u3001 or (1)., etc.",
+        "repo": "quorafind/obsidian-better-order-list"
+    },
+    {
+        "id": "templated-daily-notes",
+        "name": "Templated daily notes",
+        "author": "digitorum",
+        "description": "Create daily notes with a specified template according to the described settings.",
+        "repo": "digitorum/obsidian-templayted-daily-notes"
+    },
+    {
+        "id": "aloud-tts",
+        "name": "Aloud",
+        "author": "Adrian Lyjak",
+        "description": "Speak text from your notes. Converts text to speech in real-time using lifelike voices from OpenAI.",
+        "repo": "adrianlyjak/obsidian-aloud-tts"
+    },
+    {
+        "id": "better-export-pdf",
+        "name": "Better Export PDF",
+        "description": "Export your notes to PDF, supports export preview, add bookmarks outline and header/footer.",
+        "author": "l1xnan",
+        "repo": "l1xnan/obsidian-better-export-pdf"
+    },
+    {
+        "id": "days-since",
+        "name": "Days Since",
+        "author": "gndclouds",
+        "description": "Relive and celebrate your life's milestones on a personal, interactive timeline. A nostalgic journey through your history with anniversary reminders and cherished memories.",
+        "repo": "gndclouds/days-since-obsidian"
+    },
+    {
+        "id": "gslogimaker-my-bible",
+        "name": "My Bible",
+        "description": "Your own customizable markdown bible for your personal vault!",
+        "author": "GsLogimaker",
+        "repo": "GsLogiMaker/my-bible-obsidian-plugin"
+    },
+    {
+        "id": "bible-linker-pro",
+        "name": "Bible linker Pro",
+        "author": "Floydv149",
+        "description": "Converts Bible texts to JW Library links",
+        "repo": "Floydv149/bibleLinkerPro"
+    },
+    {
+        "id": "protected-note",
+        "name": "Protected Note",
+        "author": "Mikail Gadzhikhanov",
+        "description": "Set password and encrypt your notes to protect them from other people.",
+        "repo": "mmiksaa/obsidian-protected-note"
+    },
+    {
+        "id": "statusbar-organizer",
+        "name": "Status Bar Organizer",
+        "author": "Kacper Darowski",
+        "description": "Rearrange and hide status bar elements.",
+        "repo": "Opisek/obsidian-statusbar-organizer"
+    },
+    {
+        "id": "image-inline",
+        "name": "Image Inline",
+        "author": "Zackary W",
+        "description": "Paste your image without attachment files",
+        "repo": "ZackaryW/obsidian-image-inline"
+    },
+    {
+        "id": "task-list",
+        "name": "Task list",
+        "author": "Ted Marozzi",
+        "description": "Enable better task management via lists.",
+        "repo": "ted-marozzi/task-list"
+    },
+    {
+        "id": "share-my-plugin-list",
+        "name": "Share my plugin list",
+        "author": "Benature",
+        "description": "Share the enabled plugins in list/table format.",
+        "repo": "Benature/obsidian-share-my-plugin-list"
+    },
+    {
+        "id": "gpg-encrypt",
+        "name": "GPG Encrypt",
+        "author": "Luis Jaramillo",
+        "description": "Encrypt partial text or complete notes using GPG technology, it is compatible with security keys such as YubiKey or traditional GPG encryption methods",
+        "repo": "lajg-dev/obsidian-plugin-gpg-inline-encrypt"
+    },
+    {
+        "id": "smart-second-brain",
+        "name": "Smart Second Brain",
+        "author": "Leo310, nicobrauchtgit",
+        "description": "Interact with your privacy focused assistant by leveraging Ollama or OpenAI and making your second brain even smarter.",
+        "repo": "your-papa/obsidian-Smart2Brain"
+    },
+    {
+        "id": "github-sync",
+        "name": "GitHub Sync",
+        "author": "Kevin Chin",
+        "description": "Sync vault to personal GitHub.",
+        "repo": "kevinmkchin/Obsidian-GitHub-Sync"
+    },
+    {
+        "id": "kindle-html-importer",
+        "name": "Kindle Highlights Importer",
+        "author": "MovingMillennial",
+        "description": "Imports the kindle highlights from the html file (you get from the kindle app) into a note.",
+        "repo": "l2xu/kindle_html_importer"
+    },
+    {
+        "id": "snsvrno-tags",
+        "name": "Tag Formatter",
+        "author": "snsvrno",
+        "description": "Gives more options on how to display tags in preview mode.",
+        "repo": "snsvrno/snsvrno-short-tags"
+    },
+    {
+        "id": "journalyst",
+        "name": "Journalyst",
+        "author": "Justin Arnold",
+        "description": "Journalyst enables easy creation of topic-specific journals. Organize your life into categories like sleep, routines, or work, with daily or recurring entries for effortless tracking and reflection.",
+        "repo": "Justin-Arnold/Journalyst"
+    },
+    {
+        "id": "wypst",
+        "name": "Wypst",
+        "author": "0xpapercut",
+        "description": "Render math blocks with Typst",
+        "repo": "0xpapercut/obsidian-wypst"
+    },
+    {
+        "id": "tv-tracker",
+        "name": "TV tracker",
+        "author": "Shreshth Mehra",
+        "description": "A movie and TV show tracker.",
+        "repo": "Shreshth-mehra/Obsidian-TV-Tracker"
+    },
+    {
+        "id": "autogen",
+        "name": "Autogen",
+        "author": "Aidan Tilgner",
+        "description": "In place autogeneration of content based on prompts within notes",
+        "repo": "AidanTilgner/AutogenObsidianPlugin"
+    },
+    {
+        "id": "broken-links",
+        "name": "Broken Links",
+        "author": "ipshing",
+        "description": "Find broken links in your vault that don't connect to notes.",
+        "repo": "ipshing/obsidian-broken-links"
+    },
+    {
+        "id": "image_collector",
+        "name": "Image Collector",
+        "author": "tdaykin",
+        "description": "Collects all images from current note and saves them to a new folder",
+        "repo": "tdaykin/obsidian_image_collector"
+    },
+    {
+        "id": "frontmatter-viewmode",
+        "name": "Set View Mode per Note",
+        "author": "Alex Davies",
+        "description": "Use YAML frontmatter to specify a view mode per note.",
+        "repo": "AlexDavies8/obsidian-frontmatter-viewmode"
+    },
+    {
+        "id": "wordwise",
+        "name": "WordWise",
+        "author": "ckt1031",
+        "description": "Writing companion for AI content generation.",
+        "repo": "ckt1031/obsidian-wordwise-plugin"
+    },
+    {
+        "id": "git-integration",
+        "name": "Git Integration",
+        "author": "noradroid",
+        "description": "Easily backup vault on a remote repository.",
+        "repo": "noradroid/obsidian-git-integration"
+    },
+    {
+        "id": "github-link",
+        "name": "GitHub Link",
+        "author": "Nathonius",
+        "description": "Enrich your notes with issue and pull request content from GitHub.",
+        "repo": "nathonius/obsidian-github-link"
+    },
+    {
+        "id": "simple-file-push",
+        "name": "Simple File Push",
+        "author": "Kim Hudaya",
+        "description": "Push Markdown file to API endpoint.",
+        "repo": "huedaya/obsidian-simple-file-push"
+    },
+    {
+        "id": "paste-transform",
+        "name": "Paste transform",
+        "author": "Timofey Koolin",
+        "description": "Modify text from the clipboard by regexp rules",
+        "repo": "rekby/obsidian-paste-transform"
+    },
+    {
+        "id": "vn-memory-lane",
+        "name": "MemoryLane",
+        "author": "BangCa",
+        "description": "Relive and celebrate your life's milestones on a personal, interactive timeline. A nostalgic journey through your history with anniversary reminders and cherished memories.",
+        "repo": "bangca85/obsidian-memorylane-plugin"
+    },
+    {
+        "id": "copy-as-source",
+        "name": "Copy as source",
+        "author": "@gapmiss",
+        "description": "Select and copy source HTML in reading view.",
+        "repo": "gapmiss/copy-as-source"
+    },
+    {
+        "id": "alfonso-money-manager",
+        "name": "Alfonso Money Manager",
+        "author": "SmartLifeGPT Innovation",
+        "description": "Alfonso Money Manager data viewer and financial analytics tool",
+        "repo": "smartlife-gpt/alfonso-money-manager-obsidian"
+    },
+    {
+        "id": "pdf-plus",
+        "name": "PDF++",
+        "author": "Ryota Ushio",
+        "description": "The most Obsidian-native PDF annotation tool ever.",
+        "repo": "RyotaUshio/obsidian-pdf-plus"
+    },
+    {
+        "id": "go-up",
+        "name": "Go Up",
+        "author": "JinMu Go",
+        "description": "Quickly navigate to a specified \"parent\" page",
+        "repo": "JinMuGo/obsidian-go-up"
+    },
+    {
+        "id": "format-with-prettier",
+        "name": "Format with Prettier",
+        "author": "Alex Gavrusev",
+        "description": "Format files in your vault using Prettier.",
+        "repo": "alexgavrusev/obsidian-format-with-prettier"
+    },
+    {
+        "id": "image-magician",
+        "name": "Image Magician",
+        "author": "luxmargos",
+        "description": "Supports viewing and exporting various image formats using ImageMagick.",
+        "repo": "luxmargos/obsidian-image-magician-plugin"
+    },
+    {
+        "id": "graphs",
+        "name": "Graphs",
+        "author": "Dylan Hojnoski",
+        "description": "Create interactive graphs by writing YAML",
+        "repo": "DylanHojnoski/obsidian-graphs"
+    },
+    {
+        "id": "card-note",
+        "name": "CardNote",
+        "author": "cycsd",
+        "description": "Quickly extract your thoughts in the Canvas and Excalidraw.",
+        "repo": "cycsd/obsidian-card-note"
+    },
+    {
+        "id": "simple-image-inserter",
+        "name": "Simple Image Inserter",
+        "author": "Joey Holtzman",
+        "description": "Add images from the file system into notes through a built-in file picker.",
+        "repo": "jdholtz/obsidian-image-inserter"
+    },
+    {
+        "id": "graph-link-types",
+        "name": "Graph Link Types",
+        "author": "natefrisch01",
+        "description": "Link types for graph view.",
+        "repo": "natefrisch01/Graph-Link-Types"
+    },
+    {
+        "id": "fix-require-modules",
+        "name": "Fix Require Modules",
+        "author": "mnaoumov",
+        "description": "Fixes require() calls, supporting JavaScript and TypeScript modules, enabling easy invocation, and adding code buttons for enhanced scripting capabilities",
+        "repo": "mnaoumov/obsidian-fix-require-modules"
+    },
+    {
+        "id": "auto-definition-link",
+        "name": "Auto Definition Link",
+        "author": "Nolan Carpenter",
+        "description": "Automatically converts text to definition links within the current folder when you type them.",
+        "repo": "nmcarp99/obsidian-auto-definition-link"
+    },
+    {
+        "id": "chord-sheets",
+        "name": "Chord Sheets",
+        "author": "Marcel Schaeben",
+        "description": "Work with chord sheets (chords over lyrics or inline) in Live Preview and reading mode: Chord diagrams for guitar, ukulele and mandolin, transpose, autoscroll, and more.",
+        "repo": "olvidalo/obsidian-chord-sheets"
+    },
+    {
+        "id": "enhanced-tables",
+        "name": "Enhanced tables",
+        "author": "pistacchio",
+        "description": "Add programmable controls to selected tables.",
+        "repo": "pistacchio/obsidian-enhanced-tables"
+    },
+    {
+        "id": "folders2graph",
+        "name": "Folders to Graph",
+        "author": "Ratibus11",
+        "description": "Display your vault folder structure into your graphs.",
+        "repo": "Ratibus11/folders2graph"
+    },
+    {
+        "id": "lean-syntax-highlight",
+        "name": "Lean Syntax Highlight",
+        "author": "tomaz1502",
+        "description": "Provides live syntax highlight for the Lean programming language",
+        "repo": "tomaz1502/lean-syntax-highlight"
+    },
+    {
+        "id": "ai-tagger",
+        "name": "AI Tagger",
+        "author": "Luca Grippa",
+        "description": "Simplify tagging. Instantly analyze and tag your document with one click for efficient note organization. OpenAI API key required.",
+        "repo": "lucagrippa/obsidian-ai-tagger"
+    },
+    {
+        "id": "quiz-generator",
+        "name": "Quiz Generator",
+        "author": "Edward Cui",
+        "description": "Generate interactive flashcards from your notes using models from OpenAI (ChatGPT), Google (Gemini), Ollama (local LLMs), and more. Or manually create your own to use with the quiz UI.",
+        "repo": "ECuiDev/obsidian-quiz-generator"
+    },
+    {
+        "id": "goban-sgf",
+        "name": "Goban SGF",
+        "author": "Stinson",
+        "description": "Record Go games (SGF format goban).",
+        "repo": "StinsonZhao/obsidian-plugin-goban-sgf"
+    },
+    {
+        "id": "display-relative-path-img",
+        "name": "Display Relative Path Img",
+        "author": "Dyc",
+        "description": "Display the image of the <img> tag",
+        "repo": "dyc2424748461/obsidian-display-relative-path-img"
+    },
+    {
+        "id": "metadata-icon",
+        "name": "Metadata Icon",
+        "author": "Benature",
+        "description": "Set custom icons for your properties.",
+        "repo": "Benature/obsidian-metadata-icon"
+    },
+    {
+        "id": "fileorganizer2000",
+        "name": "AI File Organizer 2000",
+        "author": "Benjamin Ashgan Shafii",
+        "description": "AI assistant to automatically organize, chat, and format your notes. Works with images, PDFs, and your voice",
+        "repo": "different-ai/file-organizer-2000"
+    },
+    {
+        "id": "spotify-api",
+        "name": "Spotify API",
+        "author": "Darren-project",
+        "description": "Exposes Spotify API",
+        "repo": "Darren-project/obsidian-spotify"
+    },
+    {
+        "id": "pf2e-statblocks",
+        "name": "PF2e Statblocks",
+        "author": "Tyler Pixley",
+        "description": "Render Pathfinder 2e statblocks cleanly, using only Markdown-based syntax.",
+        "repo": "pixley/pf2e-statblock-for-obsidian"
+    },
+    {
+        "id": "canvas-link-optimizer",
+        "name": "Canvas Link Optimizer",
+        "author": "khaelar",
+        "description": "Optimize Canvas links by displaying a page thumbnail.",
+        "repo": "khaelar/obsidian-canvas-link-optimizer"
+    },
+    {
+        "id": "inline-admonitions",
+        "name": "Inline Admonitions",
+        "author": "Scott Tomaszewski",
+        "description": "Inline callouts to make text pop.",
+        "repo": "scottTomaszewski/obsidian-inline-admonitions"
+    },
+    {
+        "id": "filtered-opener",
+        "name": "Filtered Opener",
+        "author": "Roman Kubiv",
+        "description": "Open notes and folders, chose from sets defined by filters.",
+        "repo": "Balibaloo/obsidian-picker"
+    },
+    {
+        "id": "todoist-review",
+        "name": "Todoist Review",
+        "author": "Isaac McAuley",
+        "description": "A pane for reviewing overdue tasks from todoist",
+        "repo": "imcauley/todoist-review"
+    },
+    {
+        "id": "image-to-text-ocr",
+        "name": "Image to text OCR",
+        "author": "Dario Baumberger",
+        "description": "Convert a image in your note to text.",
+        "repo": "dario-baumberger/obsidian-image-to-text-ocr"
+    },
+    {
+        "id": "break-page",
+        "name": "PDF break page",
+        "author": "CG",
+        "description": "Add shortkey and command to insert a break page formating for pdf exports.",
+        "repo": "corentin-godefroy/Obsidian-BreakPage"
+    },
+    {
+        "id": "tiff-viewer",
+        "name": "Tiff Viewer",
+        "author": "Jan Ullmann",
+        "description": "View .tif(f) files by generating duplicates in form of .tif(f).png",
+        "repo": "ullmannJan/obsidian-tiff-viewer"
+    },
+    {
+        "id": "seafile",
+        "name": "Seafile",
+        "author": "conql",
+        "description": "Sync notes across devices using Seafile.",
+        "repo": "conql/obsidian-seafile"
+    },
+    {
+        "id": "select-and-complete",
+        "name": "Select & Complete",
+        "description": "Select something and let the AI complete it for you.",
+        "author": "Mario De Luca",
+        "repo": "macro21KGB/select-and-complete"
+    },
+    {
+        "id": "plugin-reloader",
+        "name": "Plugin Reloader",
+        "author": "Benature",
+        "description": "Manually reload plugins.",
+        "repo": "Benature/obsidian-plugin-reloader"
+    },
+    {
+        "id": "track-a-lot",
+        "name": "Track-a-Lot",
+        "author": "Iulian Onofrei",
+        "description": "Scrapes different webpages, builds lists with the items as Markdown tables, and allows you to track their status.",
+        "repo": "revolter/obsidian-track-a-lot-plugin"
+    },
+    {
+        "id": "ego-rock",
+        "name": "Ego Rock",
+        "author": "Ashton Eby",
+        "description": "A basic taskwarrior UI for listing and modifying tasks.",
+        "repo": "echo-bravo-yahoo/ego-rock"
+    },
+    {
+        "id": "augmented-canvas",
+        "name": "Augmented Canvas",
+        "author": "L\u00e9opold Szabatura",
+        "description": "Augment Canvas with AI features.",
+        "repo": "MetaCorp/obsidian-augmented-canvas"
+    },
+    {
+        "id": "chatgpt-prompt",
+        "name": "Prompt ChatGPT",
+        "author": "Coduhuey",
+        "description": "Send templated prompts to ChatGPT when you open a file.",
+        "repo": "Coduhuey/ChatGPT-Prompt-Plugin-For-Obsidian"
+    },
+    {
+        "id": "canvas-mindmap-helper",
+        "name": "Canvas Mindmap Helper",
+        "author": "Tim Smart",
+        "description": "Make the Canvas work like a mindmap.",
+        "repo": "tim-smart/obsidian-canvas-mindmap"
+    },
+    {
+        "id": "advanced-canvas",
+        "name": "Advanced Canvas",
+        "author": "Developer-Mike",
+        "description": "Supercharge your canvas experience. Create presentations, flowcharts and more.",
+        "repo": "Developer-Mike/obsidian-advanced-canvas"
+    },
+    {
+        "id": "quadro",
+        "name": "Quadro",
+        "description": "Qualitative Data Analysis (QDA) for Social Scientists. An open alternative to MAXQDA and atlas.ti, using Markdown to store data and research codes.",
+        "author": "Chris Grieser (aka pseudometa)",
+        "repo": "chrisgrieser/obsidian-quadro"
+    },
+    {
+        "id": "enhanced-annotations",
+        "name": "Enhanced Annotations",
+        "author": "ycnmhd",
+        "description": "Add a sidebar view for comments and highlights.",
+        "repo": "ycnmhd/obsidian-enhanced-annotations"
+    },
+    {
+        "id": "pomodoro-widget",
+        "name": "Pomodoro Widget",
+        "author": "bitegw",
+        "description": "Provides a widget based on a pomodoro kitchen timer. It's designed to be haptic, and has a constant ticking sound, and an alarm sound that can be toggled.",
+        "repo": "bitegw/obsidian-pomodoro-widget"
+    },
+    {
+        "id": "yesterday",
+        "name": "Yesterday",
+        "author": "Dominik Mayer",
+        "description": "Transform your notes into a visually stunning diary, integrating dialogs, chat logs, and media content blocks for a seamless journaling experience.",
+        "repo": "dominikmayer/obsidian-yesterday"
+    },
+    {
+        "id": "gitlab-wiki-export",
+        "name": "Gitlab Wiki Exporter",
+        "author": "Josef Rabmer",
+        "description": "Makes your entire vault Gitlab Wiki compatible and exports it to a specified location.",
+        "repo": "jrabmer/obsidian-to-gitlab-wiki"
+    },
+    {
+        "id": "mblog-publish",
+        "name": "MBlog Publish",
+        "author": "Jerry",
+        "description": "\u901a\u8fc7Obsidian\u53d1\u5e03\u6587\u7ae0\u5230MBlog\u5e73\u53f0",
+        "repo": "kingwrcy/obsidian-mblog"
+    },
+    {
+        "id": "text-focus",
+        "name": "Text Focus",
+        "author": "usysrc",
+        "description": "Focus the text area when creating new notes",
+        "repo": "usysrc/obsidian-text-focus-plugin"
+    },
+    {
+        "id": "tab-shifter",
+        "name": "Tab Shifter",
+        "author": "Joshua Rozner",
+        "description": "Enables shifting tabs between different tab splits",
+        "repo": "jsrozner/obsidian-tab-shifter"
+    },
+    {
+        "id": "alias-management",
+        "name": "Alias Management",
+        "author": "WithMarcel",
+        "description": "Identify duplicate notes based on similar aliases and filenames.",
+        "repo": "WithMarcel/alias-management"
+    },
+    {
+        "id": "historica",
+        "name": "historica",
+        "author": "Nhan Nguyen",
+        "description": "Intelligently generates timeline from your content",
+        "repo": "nhannht/obsidian-historica"
+    },
+    {
+        "id": "date-inserter",
+        "name": "Date Inserter",
+        "author": "namikaze-40p",
+        "description": "Insert a date at the cursor position using a calendar.",
+        "repo": "namikaze-40p/obsidian-date-inserter"
+    },
+    {
+        "id": "tekken-notation",
+        "name": "Tekken Notation",
+        "author": "OpTi9",
+        "description": "Renders Tekken Notation.",
+        "repo": "OpTi9/obsidian-tekken-notation"
+    },
+    {
+        "id": "mantou-ai",
+        "name": "MantouAI",
+        "author": "Morino Pan",
+        "description": "Work as a personal assistant for translation, writing polish, general Q&A, summarizing, using the power of large language models.",
+        "repo": "ravenSanstete/Obsidian-MantouAI"
+    },
+    {
+        "id": "pomodoro-planner",
+        "name": "Pomodoro Planner",
+        "author": "Onur Nesvat",
+        "description": "Generates a pomodoro schedule plan.",
+        "repo": "onesvat/obsidian-pomodoro-planner"
+    },
+    {
+        "id": "bookfusion",
+        "name": "BookFusion",
+        "author": "BookFusion",
+        "description": "Import your BookFusion highlights & annotations into your vault.",
+        "repo": "BookFusion/obsidian-plugin"
+    },
+    {
+        "id": "mxmind",
+        "name": "Mxmind Mindmap",
+        "author": "mxmind",
+        "description": "Convert Markdown files to a mind map,mind map editor.",
+        "repo": "webceoboy/mxmind-obsidian"
+    },
+    {
+        "id": "contextual-sidecar",
+        "name": "Contextual Sidecar",
+        "author": "Matthew Turk",
+        "description": "Add a context-dependent sidecar panel.",
+        "repo": "matthewturk/obsidian-sidecar-panel"
+    },
+    {
+        "id": "diffzip",
+        "name": "Differential ZIP Backup",
+        "author": "vorotamoroz",
+        "description": "Back our vault up with lesser storage.",
+        "repo": "vrtmrz/diffzip"
+    },
+    {
+        "id": "media-notes",
+        "name": "Media Notes",
+        "author": "jemstelos",
+        "description": "Take notes on YouTube videos and podcasts with media controls and timestamps.",
+        "repo": "jemstelos/obsidian-media-notes"
+    },
+    {
+        "id": "cooklang-viewer-and-editor",
+        "name": "Cooklang",
+        "author": "Roger Veciana i Rovira",
+        "description": "Display and edit recipes written in the Cooklang format.",
+        "repo": "rveciana/obsidian-cooklang"
+    },
+    {
+        "id": "contextual-note-templating",
+        "name": "Contextual note templating",
+        "author": "Roman Kubiv",
+        "description": "Prompts for values and templates to create notes.",
+        "repo": "Balibaloo/obsidian-local-template-configuration"
+    },
+    {
+        "id": "vault-transfer",
+        "name": "Vault Transfer",
+        "author": "ImaginaryProgramming",
+        "description": "Transfers a note from one vault to another.",
+        "repo": "ImaginaryProgramming/obsidian-vault-transfer"
+    },
+    {
+        "id": "movie-search",
+        "name": "Movie Search",
+        "author": "Gubchik123",
+        "description": "Helps you find movies and create notes.",
+        "repo": "Gubchik123/obsidian-movie-search-plugin"
+    },
+    {
+        "id": "view-count",
+        "name": "View Count",
+        "author": "DecafDev",
+        "description": "Tracks view count for each vault file.",
+        "repo": "decaf-dev/obsidian-view-count"
+    },
+    {
+        "id": "notice-controller",
+        "name": "Notification Controller",
+        "author": "juan-miii",
+        "description": "Manages notifications at startup.",
+        "repo": "juan-miii/obsidian-notice-plugin"
+    },
+    {
+        "id": "calendarium",
+        "name": "Calendarium",
+        "author": "Jeremy Valentine",
+        "description": "Craft mind-bending fantasy and sci-fi calendars.",
+        "repo": "javalent/calendarium"
+    },
+    {
+        "id": "confluence-sync",
+        "name": "Confluence Sync",
+        "author": "Prateek Grover",
+        "description": "Sync notes with Confluence",
+        "repo": "kerry/obsidian-confluence-sync"
+    },
+    {
+        "id": "persian-calendar",
+        "name": "Persian Calendar",
+        "author": "Hossein Maleknejad",
+        "description": "Persian Calendar for managing periodic notes based on persian solar (shamsi) calendar.",
+        "repo": "maleknejad/obsidian-persian-calendar"
+    },
+    {
+        "id": "daily-note-navbar",
+        "name": "Daily Note Navbar",
+        "author": "Karsten Finderup Pedersen",
+        "description": "Navigate between sequential daily notes with ease.",
+        "repo": "karstenpedersen/obsidian-daily-note-navbar"
+    },
+    {
+        "id": "orion-publish",
+        "name": "Orion Publish",
+        "author": "Sean Collings",
+        "description": "Quickly and easily publish your notes to the web with Orion Publish.",
+        "repo": "seanrcollings/orion-publish-plugin"
+    },
+    {
+        "id": "gistr",
+        "name": "Gistr",
+        "author": "Aetherinox",
+        "description": "Use your notes to embed, create, and update gists for Github and Opengist.",
+        "repo": "Aetherinox/obsidian-gistr"
+    },
+    {
+        "id": "things3-today",
+        "name": "Things3 Today",
+        "author": "wudanyang6",
+        "description": "Manage today's tasks with Things3.",
+        "repo": "wudanyang6/obsidian-things3-today"
+    },
+    {
+        "id": "command-block-list",
+        "name": "Command Block List",
+        "author": "Ryota Ushio",
+        "description": "Hide unwanted commands from the command palette.",
+        "repo": "RyotaUshio/obsidian-command-block-list"
+    },
+    {
+        "id": "crafty",
+        "name": "Crafty",
+        "author": "liolle",
+        "description": "Add tooltip to any canvas node and quickly navigate between canvas nodes.",
+        "repo": "liolle/Crafty"
+    },
+    {
+        "id": "color-cycler",
+        "name": "Color cycler",
+        "author": "Taylor Brennan",
+        "description": "Dynamically change the accent color of the theme.",
+        "repo": "tjbrennan/obsidian-color-cycler"
+    },
+    {
+        "id": "markmap-to-csv",
+        "name": "Markmap to CSV",
+        "description": "Converts Markmap data to CSV format.",
+        "author": "maxlee",
+        "repo": "pj4316/markmap-to-csv-obsidian"
+    },
+    {
+        "id": "ear-training",
+        "name": "Ear Training",
+        "author": "Poe Zoel",
+        "description": "Get ear training exercises inside your vault.",
+        "repo": "shiwer/ear-training-obsidian-plugin"
+    },
+    {
+        "id": "hugo-codeblock-highlight",
+        "name": "Hugo codeblock highlight",
+        "author": "aarol",
+        "description": "Highlights lines in code blocks using Hugo's hl_lines syntax.",
+        "repo": "aarol/obsidian-hugo-codeblock-highlight"
+    },
+    {
+        "id": "canvas-node-screenshot",
+        "name": "Node Screenshot",
+        "author": "istfredy",
+        "description": "Capture node effortlessly with precision screenshot.",
+        "repo": "istfredy/obsidian-canvas-node-screenshot"
+    },
+    {
+        "id": "line-commands",
+        "name": "Line Commands",
+        "author": "charliecm",
+        "description": "Adds commands to quickly select, copy, cut, and paste lines under the selection or cursor.",
+        "repo": "charliecm/obsidian-line-commands"
+    },
+    {
+        "id": "title-renamer",
+        "name": "Title renamer",
+        "author": "Peter Str\u00f8iman",
+        "description": "Keep top heading in note synced with file name.",
+        "repo": "stroiman/obsidian-title-sync"
+    },
+    {
+        "id": "markdown-media-card",
+        "name": "Markdown Media Card",
+        "author": "Zhou Hua",
+        "description": "Insert media information cards in Markdown, such as books, music, movies, etc.",
+        "repo": "zhouhua/obsidian-markdown-media-card"
+    },
+    {
+        "id": "canvas-minimap",
+        "name": "Canvas minimap",
+        "author": "ifree",
+        "description": "Obsidian Canvas minimap support.",
+        "repo": "ifree/Obsidian-canvas-minimap"
+    },
+    {
+        "id": "fit",
+        "name": "Fit",
+        "author": "joshuakto",
+        "description": "Minimalist File gIT (FIT) to sync your files across mobile and desktop devices using GitHub.",
+        "repo": "joshuakto/fit"
+    },
+    {
+        "id": "vlc-bridge",
+        "name": "VLC Bridge",
+        "author": "zuluwi",
+        "description": "Take video/movie notes with timestamp links and snapshots from VLC Player.",
+        "repo": "zuluwi/obsidian-vlc-bridge"
+    },
+    {
+        "id": "progress-clocks",
+        "name": "Progress Clocks",
+        "author": "Nathan Clark",
+        "description": "Progress clocks and other useful widgets for real-time status tracking.",
+        "repo": "tokenshift/obsidian-progress-clocks"
+    },
+    {
+        "id": "note-companion-folder",
+        "name": "Note Companion Folder",
+        "description": "Manage a separate folder of attachments for each note.",
+        "author": "Chris Verbree",
+        "repo": "vkodocha/NoteCompanionFolder"
+    },
+    {
+        "id": "tab-selector",
+        "name": "Tab Selector",
+        "author": "namikaze-40p",
+        "description": "Quickly switch tabs in various ways.",
+        "repo": "namikaze-40p/obsidian-tab-selector"
+    },
+    {
+        "id": "default-query-in-backlink",
+        "name": "Default query in backlinks",
+        "author": "Benature",
+        "description": "Automatically input default query in search input of backlinks in document.",
+        "repo": "Benature/obsidian-default-query-in-backlink"
+    },
+    {
+        "id": "metafolders",
+        "name": "Metafolders",
+        "author": "Makary Sharoyan",
+        "description": "Multidimensional note navigation.",
+        "repo": "makary-s/obsidian-metafolders"
+    },
+    {
+        "id": "spellcheck-toggler",
+        "name": "Spellcheck Toggler",
+        "description": "Toggle spellchecking for types of text blocks in the editing view.",
+        "author": "Julian Szachowicz",
+        "repo": "julzerinos/spellcheck-toggler-obsidian-plugin"
+    },
+    {
+        "id": "simsapa",
+        "name": "Simsapa",
+        "author": "gambhiro",
+        "description": "P\u0101li dictionary and sutta search using Simsapa Dhamma Reader. Open a sidebar or double-click to lookup P\u0101li words in the dictionary, or search in the suttas.",
+        "repo": "simsapa/simsapa-obsidian"
+    },
+    {
+        "id": "project-browser",
+        "name": "Project Browser",
+        "author": "Dale de Silva",
+        "description": "Replaces your new tab window with a browseable list of the files and folders in your vault.",
+        "repo": "daledesilva/obsidian_project-browser"
+    },
+    {
+        "id": "cicada-sync",
+        "name": "Cicada Synchronizer",
+        "author": "Adapole, Adapole, Mahyar Mirrashed",
+        "description": "uses Git to synchronize vaults for team collaboration.",
+        "repo": "adapole/cicada-sync"
+    },
+    {
+        "id": "verse-of-the-day",
+        "name": "Verse of the Day",
+        "author": "Janis Ringli",
+        "description": "Lets you add the verse of the day from YouVersion to your notes",
+        "repo": "janisringli/verse-of-the-day-for-obsidian"
+    },
+    {
+        "id": "etymology-lookup",
+        "name": "Etymology Lookup",
+        "author": "Claire Froelich",
+        "description": "Get the etymology of words in your notes, from Online Etymology Dictionary",
+        "repo": "clairefro/obsidian-plugin-etymology-lookup"
+    },
+    {
+        "id": "fight-note",
+        "name": "Fight Note",
+        "author": "Dmitry Loac",
+        "description": "Render Tekken notation into an easy-to-read format (partially useful for other fighting games: Guilty Gear, Street Fighter and etc).",
+        "repo": "Loac/obsidian-fight-note"
+    },
+    {
+        "id": "cards-view",
+        "name": "Cards View",
+        "author": "Maud Royer",
+        "description": "Displays a card view of your notes.",
+        "repo": "jillro/obsidian-cards-view-plugin"
+    },
+    {
+        "id": "swiftlatex-render",
+        "name": "SwiftLaTeX Render",
+        "author": "gboyd068",
+        "description": "Render LaTeX in codeblocks into a PDF, without needing to install LaTeX separately.",
+        "repo": "gboyd068/obsidian-swiftlatex-render"
+    },
+    {
+        "id": "password-protect",
+        "name": "Password Protect",
+        "author": "Aspharmyx",
+        "description": "Password protect your notes.",
+        "repo": "Aspharmyx/obsidian-password-protect"
+    },
+    {
+        "id": "moulinette",
+        "name": "Moulinette Search for TTRPG",
+        "author": "Moulinette",
+        "description": "Search, browse and download TTRPG (tabletop role-playing game) content from Moulinette Cloud.",
+        "repo": "SvenWerlen/moulinette-obsidian-plugin"
+    },
+    {
+        "id": "semantic-canvas",
+        "name": "Semantic Canvas",
+        "author": "Aaron Gillespie",
+        "description": "Create semantic knowledge graphs using Canvases to modify note properties graphically.",
+        "repo": "aarongilly/obsidian-semantic-canvas-plugin"
+    },
+    {
+        "id": "crypt-it",
+        "name": "Crypt It",
+        "author": "fyears",
+        "description": "Generate encrypted version of file(s) using rclone encryption format.",
+        "repo": "remotely-save/crypt-it"
+    },
+    {
+        "id": "para-workflower",
+        "name": "PARA Workflower",
+        "author": "KevTheDevX",
+        "description": "Helpful commands for starting and working in your vault with the PARA method.",
+        "repo": "trucke/para-workflower"
+    },
+    {
+        "id": "lavadocs",
+        "name": "Lavadocs",
+        "author": "Saalik Lokhandwala",
+        "description": "Public docs, from the fires of your vault.",
+        "repo": "saaliklok/lavadocs-obsidian"
+    },
+    {
+        "id": "unofficial-kinopoisk",
+        "name": "Kinopoisk search",
+        "author": "Alintor",
+        "description": "Helps you find movies and tv shows via Kinopoisk and create notes.",
+        "repo": "Alintor/obsidian-kinopoisk-plugin"
+    },
+    {
+        "id": "multilingual",
+        "name": "Multilingual",
+        "author": "leolazou",
+        "description": "Simplify linking notes across multiple languages by automatically adding translations of note names into aliases. Designed for multilingual users.",
+        "repo": "leolazou/obsidian-multilingual"
+    },
+    {
+        "id": "quick-file-name",
+        "name": "Quick File Name",
+        "author": "Wapply",
+        "description": "Generates a note with a random string as its name.",
+        "repo": "Wapply/obsidian-quick-file-name"
+    },
+    {
+        "id": "sticky-heading",
+        "name": "Sticky Headings",
+        "author": "Shen Shen",
+        "description": "Sticky headings and shows the heading level",
+        "repo": "imshenshen/obsidian-sticky-heading"
+    },
+    {
+        "id": "ai-zhipu",
+        "name": "AI Zhipu",
+        "author": "Tarslab",
+        "description": "Generate text using the ZhipuAI API.",
+        "repo": "TarsLab/obsidian-ai-zhipu"
+    },
+    {
+        "id": "new-tab-plus",
+        "name": "New Tab +",
+        "author": "Rapha\u00ebl Le Carval",
+        "description": "Allow to open markdown files, graph and canvas in new tab as the default behavior.",
+        "repo": "Raphlette/obsidian-new-tab-plus"
+    },
+    {
+        "id": "back-it-up",
+        "name": "BackItUp",
+        "author": "Hammad Javed",
+        "description": "Quickly make a copy or snapshot of a note.",
+        "repo": "hammadxp/back-it-up"
+    },
+    {
+        "id": "callout-suggestions",
+        "name": "Callout Suggestions",
+        "author": "Casey Fryer",
+        "description": "Adds a fuzzy searched suggestion modal for callouts.",
+        "repo": "cwfryer/obsidian-callout-suggestions"
+    },
+    {
+        "id": "ai_llm",
+        "name": "AI LLM",
+        "author": "Sparky4567",
+        "description": "Integrate local machine learning (OLLAMA) functionality into your notes, enhancing their capabilities.",
+        "repo": "Sparky4567/obsidian_ai_plugin"
+    },
+    {
+        "id": "tag-links",
+        "name": "Tag Links",
+        "author": "Zacchary Dempsey-Plante",
+        "description": "Open tags as links using a hotkey.",
+        "repo": "zedseven/obsidian-tag-links"
+    },
+    {
+        "id": "notice-logger",
+        "name": "Notice logger",
+        "author": "@gapmiss",
+        "description": "Logs all notices to the developer console, with optional prefix.",
+        "repo": "gapmiss/notice-logger"
+    },
+    {
+        "id": "buckwalter-transliteration",
+        "name": "Buckwalter Transliteration",
+        "author": "Amr Ojjeh",
+        "description": "Renders Arabic using Buckwalter's encoding scheme.",
+        "repo": "amrojjeh/obsidian-buckwalter"
+    },
+    {
+        "id": "hemingway-mode",
+        "name": "Hemingway Mode",
+        "author": "Joaqu\u00edn Bernal",
+        "description": "Prevents any editing, only letting you write ahead.",
+        "repo": "jobedom/obsidian-hemingway-mode"
+    },
+    {
+        "id": "univer",
+        "name": "Univer",
+        "author": "DreamNum",
+        "description": "Create, edit, and view spreadsheets and documents in various formats like Excel and Word directly within your knowledge base.",
+        "repo": "dream-num/obsidian-univer"
+    },
+    {
+        "id": "telegram-inbox",
+        "name": "Telegram Inbox",
+        "author": "icealtria",
+        "description": "Receive messages from Telegram bot and add them to daily note.",
+        "repo": "icealtria/obsidian-telegram-inbox"
+    },
+    {
+        "id": "misskey-connector",
+        "name": "Misskey Connector",
+        "author": "minimarimo3",
+        "description": "Enables posting and embedding Misskey notes.",
+        "repo": "minimarimo3/Obsidian-plugin-for-Misskey"
+    },
+    {
+        "id": "shiki-highlighter",
+        "name": "Shiki Highlighter",
+        "author": "Moritz Jung",
+        "description": "Highlight code blocks with Shiki.",
+        "repo": "mProjectsCode/obsidian-shiki-plugin"
+    },
+    {
+        "id": "foodiary",
+        "name": "Foodiary",
+        "author": "vkostyanetsky",
+        "description": "Food tracker, macronutrient and calorie calculator.",
+        "repo": "vkostyanetsky/ObsidianFoodiary"
+    },
+    {
+        "id": "noteson-publish",
+        "name": "NotesOn Publish",
+        "author": "Andrey Shapkin",
+        "description": "Make single notes instantly available on the web.",
+        "repo": "shapkinaa/noteson-obsidian-plugin"
+    },
+    {
+        "id": "ai-summarize",
+        "name": "AI Summarize",
+        "author": "Alp Sariyer",
+        "description": "Summarize your notes using AI",
+        "repo": "RavenWits/obsidian-ai-summarize"
+    },
+    {
+        "id": "livecodes-playground",
+        "name": "Livecodes Playground",
+        "description": "Client-side code editor playground - Powered by LiveCodes",
+        "author": "@gapmiss",
+        "repo": "gapmiss/livecodes-playground"
+    },
+    {
+        "id": "auto-embed",
+        "name": "Auto Embed",
+        "author": "GnoxNahte",
+        "description": "Helps to embed links using markdown instead of iframe.",
+        "repo": "GnoxNahte/obsidian-auto-embed"
+    },
+    {
+        "id": "vare",
+        "name": "VARE",
+        "author": "4Source",
+        "description": "Now you can easily manage your plugins and themes. Simply select the version you want or install unlisted versions from GitHub. You can also install beta version and switch back if necessary.",
+        "repo": "4Source/vare-obsidian-plugin"
+    },
+    {
+        "id": "hugo-publish",
+        "name": "Hugo Publish",
+        "author": "kirito",
+        "description": "Publish your blog to hugo site.",
+        "repo": "kirito41dd/obsidian-hugo-publish"
+    },
+    {
+        "id": "autoplay-and-loop",
+        "name": "Autoplay & Loop",
+        "author": "Zerkshop & Wapply",
+        "description": "AutoPlay videos inside and outside notes.",
+        "repo": "Wapply/obsidian-autoplay-and-loop"
+    },
+    {
+        "id": "mehrmaid",
+        "name": "Mehrmaid",
+        "author": "huterguier",
+        "description": "Enables you to put Markdown inside of Mermaid diagrams.",
+        "repo": "huterguier/obsidian-mehrmaid"
+    },
+    {
+        "id": "note-toolbar",
+        "name": "Note Toolbar",
+        "author": "Chris Gurney",
+        "description": "Add customizable toolbars to your notes.",
+        "repo": "chrisgurney/obsidian-note-toolbar"
+    },
+    {
+        "id": "supernote",
+        "name": "Unofficial Supernote by Ratta Integration",
+        "author": "philips",
+        "description": "View Supernote notes, generate markdown from note and capture screen mirror.",
+        "repo": "philips/supernote-obsidian-plugin"
+    },
+    {
+        "id": "cloud-atlas",
+        "name": "Cloud Atlas",
+        "author": "Cloud Atlas",
+        "description": "The most effective way to use LLMs in your vault: Add your current note, reference backlinks/forward links, and a Canvas mode to assemble a prompt with all the context you.",
+        "repo": "cloud-atlas-ai/obsidian-client"
+    },
+    {
+        "id": "slurp",
+        "name": "Slurp",
+        "author": "inhumantsar",
+        "description": "Slurps webpages and saves them as clean, uncluttered Markdown.",
+        "repo": "inhumantsar/slurp"
+    },
+    {
+        "id": "current-folder-notes-pamphlet",
+        "name": "Current Folder Notes",
+        "author": "Pamela Wang",
+        "description": "Shows a list of notes in the current folder, and allows you to filter the titles to include or exclude notes.",
+        "repo": "Caffa/Obsidian-Current-Folder-Note-Display-Plugin"
+    },
+    {
+        "id": "reverse-prompter",
+        "name": "Reverse Prompter",
+        "author": "Ryan Halliday",
+        "description": "Generate prompts to keep you writing with AI.",
+        "repo": "ryanhalliday/obsidian-reverse-prompter"
+    },
+    {
+        "id": "automation",
+        "name": "Automation",
+        "author": "Benature",
+        "description": "Execute commands on specific events.",
+        "repo": "Benature/obsidian-automation"
+    },
+    {
+        "id": "click-clack",
+        "name": "Click Clack",
+        "author": "Acylation",
+        "description": "Simulates typewriter / mechanical keyboard sounds.",
+        "repo": "Acylation/obsidian-click-clack"
+    },
+    {
+        "id": "grind-manager",
+        "name": "Gamified Tasks",
+        "author": "dromse",
+        "description": "Gamify your task management with rewards system, craft your tasks by tags.",
+        "repo": "dromse/obsidian-gamified-tasks"
+    },
+    {
+        "id": "dictionary-translator",
+        "name": "Dictionary translator",
+        "author": "Grover",
+        "description": "Helps you to quickly underline word translations and insert word cards in your notes.",
+        "repo": "grover572/obsidian-Dictionary-translator"
+    },
+    {
+        "id": "vconsole",
+        "name": "vConsole",
+        "author": "Zhou Hua",
+        "description": "Integrate vConsole for developers to facilitate the debugging of mobile plugins.",
+        "repo": "zhouhua/obsidian-vconsole"
+    },
+    {
+        "id": "external-links",
+        "name": "External Links",
+        "author": "Juan Vimberg",
+        "description": "List external links on the right side panel.",
+        "repo": "jivimberg/external-links"
+    },
+    {
+        "id": "target-word-count",
+        "name": "Target Word Count",
+        "author": "TwoFive Labs",
+        "description": "Disable editing until you've added a target number of words.",
+        "repo": "twofive-labs/target-word-count"
+    },
+    {
+        "id": "cloudatlas-o-am",
+        "name": "Amazing Marvin Integration",
+        "author": "Cloud Atlas",
+        "description": "Integration with Amazing Marvin (unofficial). Supports exporting AM tasks/projects, creating new tasks and completing tasks.",
+        "repo": "cloud-atlas-ai/obsidian-am"
+    },
+    {
+        "id": "cluster",
+        "name": "Cluster",
+        "author": "Lorens Osman",
+        "description": "Make the notes clustering simpler on mobile devices and work well on PCs ether, Notes Clustering is the process of creating hierarchical notes structures.",
+        "repo": "lorens-osman-dev/cluster"
+    },
+    {
+        "id": "imdb-sync",
+        "name": "IMDb",
+        "author": "Andrew Chen",
+        "description": "Sync your IMDb list.",
+        "repo": "aaachen/IMDb-Obsidian"
+    },
+    {
+        "id": "daily-prompt",
+        "name": "Daily Prompt",
+        "author": "Erl-koenig",
+        "description": "Set up custom prompts and automatically fill them into your daily notes.",
+        "repo": "Erl-koenig/obsidian-dailyPrompt"
+    },
+    {
+        "id": "custom-sidebar-icons",
+        "name": "Custom Icons",
+        "author": "RavenHogWarts",
+        "description": "Enhance your workspace with customizable icons for documents and folders.",
+        "repo": "RavenHogWarts/obsidian-custom-icons"
+    },
+    {
+        "id": "update-time-updater",
+        "name": "Update Time Updater",
+        "author": "MURATAGAWA Kei",
+        "description": "Manually update the modified date field in frontmatter.",
+        "repo": "muratagawa/update-time-updater"
+    },
+    {
+        "id": "markpilot",
+        "name": "Markpilot",
+        "author": "Taichi Maeda",
+        "description": "Inline completions and chat view powered by OpenAI.",
+        "repo": "taichimaeda/markpilot"
+    },
+    {
+        "id": "hierarchical-outgoing-links",
+        "name": "Hierarchical Outgoing Links",
+        "author": "Jason Motylinski",
+        "description": "Displays outgoing links in a tree structure.",
+        "repo": "jasonmotylinski/hierarchical-outgoing-links"
+    },
+    {
+        "id": "create-note-list",
+        "name": "Create List of Notes",
+        "author": "Andrew Heekin",
+        "description": "Creates a bulleted list of notes contained within the parent folder and prepends to current note content after YAML frontmatter.",
+        "repo": "andrewheekin/obsidian-create-note-list"
+    },
+    {
+        "id": "alias-picker",
+        "name": "Alias Picker",
+        "description": "Pick aliases or blocks of links.",
+        "author": "rostunic",
+        "repo": "rostunic/obsidian-alias-picker"
+    },
+    {
+        "id": "fontsource",
+        "name": "Fontsource",
+        "author": "Ayuhito",
+        "description": "Load custom fonts from Fontsource into your notes.",
+        "repo": "fontsource/obsidian-fontsource"
+    },
+    {
+        "id": "ob2static-site",
+        "name": "Static Site MD Exporter",
+        "author": "Yunfi",
+        "description": "Export specific notes to general Markdown files for static page generator like Hugo, Hexo, Astro and more.",
+        "repo": "yy4382/obsidian-static-site-export"
+    },
+    {
+        "id": "enhanced-copy",
+        "name": "Enhanced Copy",
+        "author": "Mara-Li",
+        "description": "Copy your selection and add it some edit to paste in other markdown software. Allows to keep markdown in reading view, removing wikilinks in editing, copy from locked canvas, and more!",
+        "repo": "Mara-Li/obsidian-enhanced-copy"
+    },
+    {
+        "id": "ink",
+        "name": "Ink",
+        "author": "Dale de Silva",
+        "description": "Hand write or draw directly between paragraphs using a digital pen, stylus, or Apple pencil. Useful for handwriting, sketches, scribbles, or even math equations and scientific notation. Runs on the tldraw framework and drawing provides an infinite canvas.",
+        "repo": "daledesilva/obsidian_ink"
+    },
+    {
+        "id": "sync-config-folder-to-common-folder",
+        "name": "Sync config folder to common folder",
+        "author": "codeonquer",
+        "description": "Sync contents from config folder to common folder for backup or other purposes.",
+        "repo": "codeonquer/obsidian-sync-config-folder-to-common-folder"
+    },
+    {
+        "id": "ai-templater",
+        "name": "AI for Templater",
+        "author": "TfTHacker",
+        "description": "AI Extension for the Templater plugin with the OpenAI Client Library.",
+        "repo": "TfTHacker/obsidian-ai-templater"
+    },
+    {
+        "id": "dust-calendar",
+        "name": "Dust Calendar",
+        "author": "\u7eb3\u7c73\u7ea7\u5c18\u57c3",
+        "description": "\u66f4\u7b26\u5408\u4e2d\u56fd\u4e60\u60ef\u7684\u65e5\u5386\uff0c\u53ef\u4ee5\u663e\u793a\u519c\u5386\u3001\u8282\u6c14\u3001\u8282\u5047\u65e5\u3001\u8c03\u4f11\u4fe1\u606f\uff0c\u652f\u6301\u6708\u89c6\u56fe\u548c\u5e74\u89c6\u56fe\u5207\u6362\uff0c\u652f\u6301\u5173\u8054\u521b\u5efa\u5468\u671f\u6027\u7b14\u8bb0\u3002",
+        "repo": "a-nano-dust/dust-obsidian-calendar"
+    },
+    {
+        "id": "google-blogger",
+        "name": "Google Blogger",
+        "author": "Hugo Sansaqua",
+        "description": "Publish notes to Google Blogger.",
+        "repo": "privet-kitty/obsidian-blogger"
+    },
+    {
+        "id": "notes-to-strapi-export-article-ai",
+        "name": "Strapi Exporter AI",
+        "author": "Cinquin Andy",
+        "description": "Effortlessly export your notes to Strapi CMS with AI-powered handling and SEO optimization.",
+        "repo": "CinquinAndy/notes-to-strapi-export-article-ai"
+    },
+    {
+        "id": "mindmap",
+        "name": "Mindmap",
+        "author": "YunXiaoYi",
+        "description": "Create notes with Mindmaps.",
+        "repo": "OneCalmCloud/obsidian-mindmap"
+    },
+    {
+        "id": "outline-converter",
+        "name": "Outline Converter",
+        "author": "masaki39",
+        "description": "Convert outline to continuous text.",
+        "repo": "masaki39/outline-converter"
+    },
+    {
+        "id": "universal-renderer",
+        "name": "Universal renderer",
+        "author": "Kloud",
+        "description": "Render various diagrams using system native packages",
+        "repo": "dgudim/obsidian-universal-renderer"
+    },
+    {
+        "id": "canvas2document",
+        "name": "Canvas2Document",
+        "description": "Convert a complete Canvas to a long form document, integrating all cards, notes, images and other media content into a single markdown file.",
+        "author": "slnsys",
+        "repo": "slnsys/obsidian-canvas2document"
+    },
+    {
+        "id": "letterboxd-rss-sync",
+        "name": "Letterboxd Diary RSS Sync",
+        "author": "Nick Felker",
+        "description": "Syncs your public Letterboxd diary.",
+        "repo": "fleker/letterboxd-for-obsidian"
+    },
+    {
+        "id": "bitcoin-block-stamp",
+        "name": "Bitcoin Block Stamp",
+        "author": "sefiro",
+        "description": "Stamp your notes with the current Bitcoin block.",
+        "repo": "sfr0xyz/obsidian-bitcoin-block-stamp"
+    },
+    {
+        "id": "slides-extended",
+        "name": "Slides Extended",
+        "author": "Erin Schnabel (original: MSzturc)",
+        "description": "Create markdown-based reveal.js presentations. Fork of Advanced Slides.",
+        "repo": "ebullient/obsidian-slides-extended"
+    },
+    {
+        "id": "my_anime_list_text_exporter",
+        "name": "my anime list text exporter",
+        "author": "XmoncocoX",
+        "description": "add anime data for your notes.",
+        "repo": "Xmoncoco/my_anime_list_text_exporter"
+    },
+    {
+        "id": "coco-askai",
+        "name": "CoCo AskAI",
+        "author": "Yukee",
+        "description": "Let your questions flow swiftly with CoCo AskAI. (Closed source)",
+        "repo": "yamfeel/coco-askai"
+    },
+    {
+        "id": "kv-store",
+        "name": "KV Store",
+        "author": "Darren-project",
+        "description": "Adds a key-value store. Use it to store and retrieve key-value pairs in your vault.",
+        "repo": "Darren-project/obsidian-kv"
+    },
+    {
+        "id": "personal-os",
+        "name": "Personal OS",
+        "author": "A.Buot",
+        "description": "Streamlining task management and productivity with a touch of gamification.",
+        "repo": "GengAd/obsidian-personal-os"
+    },
+    {
+        "id": "time-saver",
+        "name": "TimeSaver",
+        "description": "Save your time. 1. Quickly insert todo directive. 2. Quickly count the time spent on tasks in the current note and the total time spent.",
+        "author": "tommy.li",
+        "repo": "odayou/obsidian-task-processing-extension"
+    },
+    {
+        "id": "calendar-event-sync",
+        "name": "Calendar Event Sync",
+        "author": "Stephen Dolan",
+        "description": "Sync your current note with a relevant calendar event.",
+        "repo": "stephendolan/obsidian-calendar-event-sync"
+    },
+    {
+        "id": "painter",
+        "name": "Painter",
+        "author": "KraXen72 and Chetachi Ezikeuzor",
+        "description": "Paint text different colors.",
+        "repo": "KraXen72/obsidian-painter"
+    },
+    {
+        "id": "random-names",
+        "name": "Random names",
+        "author": "Tom Parker-Shemilt",
+        "description": "Generates random names.",
+        "repo": "palfrey/obsidian-random-names"
+    },
+    {
+        "id": "note-splitter",
+        "name": "Note Splitter",
+        "author": "DecafDev",
+        "description": "Split a note into individual notes based on a delimiter.",
+        "repo": "decaf-dev/obsidian-note-splitter"
+    },
+    {
+        "id": "bearings",
+        "name": "Bearings",
+        "author": "Jeet Sukumaran",
+        "description": "Flow through dynamically-scoped collapsible tree views of your vault's semantic and logical architectures.",
+        "repo": "jeetsukumaran/obsidian-bearings"
+    },
+    {
+        "id": "image-search",
+        "name": "Image Search",
+        "author": "Mohammad Razeghi",
+        "description": "Search and insert images using Google API",
+        "repo": "razeghi71/obsidian-image-search"
+    },
+    {
+        "id": "lava-vtt-uploader",
+        "name": "Lava VTT Uploader",
+        "author": "Lavaforge",
+        "description": "Display images from your vault in Lava VTT.",
+        "repo": "lavaforge/obsidian-lava-vtt-uploader"
+    },
+    {
+        "id": "outline-task-list",
+        "name": "Outline to task list",
+        "author": "alexandrerbb",
+        "description": "Convert a note's outline to a task list.",
+        "repo": "alexandrerbb/obsidian-outline-tasklist-plugin"
+    },
+    {
+        "id": "systemsculpt-ai",
+        "name": "SystemSculpt AI",
+        "author": "SystemSculpt.com",
+        "description": "Enhance your data flow with AI-powered tools for note-taking, task management, templates, and so much more.",
+        "repo": "systemsculpt/obsidian-systemsculpt-ai"
+    },
+    {
+        "id": "generate-hash",
+        "name": "Generate Hash",
+        "author": "zigahertz",
+        "description": "Generates a cryptographically strong pseudorandom hash.",
+        "repo": "zigahertz/obsidian-hash"
+    },
+    {
+        "id": "simple-citations",
+        "name": "Simple Citations",
+        "author": "masaki39",
+        "description": "Add & update simple literature notes from Zotero.",
+        "repo": "masaki39/simple-citations"
+    },
+    {
+        "id": "custom-new-file-name",
+        "name": "Custom new file name",
+        "author": "homu-konamilk",
+        "description": "Enables the creation of new notes with custom formatted names, including dynamic datetime stamps.",
+        "repo": "homu-konamilk/obsidian-custom-new-file-name"
+    },
+    {
+        "id": "bookmarks-caller",
+        "name": "Bookmarks Caller",
+        "author": "namikaze-40p",
+        "description": "Easily open bookmarks.",
+        "repo": "namikaze-40p/obsidian-bookmarks-caller"
+    },
+    {
+        "id": "ai-writer",
+        "name": "ai-writer",
+        "author": "Donovan Ye",
+        "description": "Use AI to generate high-quality articles with knowledge fragments.",
+        "repo": "Donovan-Ye/obsidian-ai-writer-plugin"
+    },
+    {
+        "id": "link-magic",
+        "name": "LinkMagic",
+        "author": "AndyReifman",
+        "description": "Automatically adds links to defined regex.",
+        "repo": "AndyReifman/LinkMagic"
+    },
+    {
+        "id": "mapbox-location",
+        "name": "Mapbox Location Image",
+        "author": "Aaron Czichon",
+        "description": "Renders an mapbox location image based on given coordinates.",
+        "repo": "aaronczichon/obsidian-location-plugin"
+    },
+    {
+        "id": "tab-navigator",
+        "name": "Tab Navigator",
+        "author": "o02c",
+        "description": "Simple Tab Switcher, search open tabs.",
+        "repo": "o02c/obsidian-tab-navigator"
+    },
+    {
+        "id": "day-one-importer",
+        "name": "Day One Importer",
+        "author": "Marc Donald",
+        "description": "Import Day One journals.",
+        "repo": "marcdonald/obsidian-day-one-importer"
+    },
+    {
+        "id": "draft-indicator",
+        "name": "Draft Indicator",
+        "author": "Brian Boucheron",
+        "description": "Show draft status in the file explorer.",
+        "repo": "beardicus/obsidian-draft-indicator-plugin"
+    },
+    {
+        "id": "azure-linker",
+        "name": "Azure DevOps Linker",
+        "author": "Steven Zilberberg",
+        "description": "Quickly format an Azure DevOps issue tag as a link to you Azure DevOps instance.",
+        "repo": "srz2/obsidian-azure-devops-linker"
+    },
+    {
+        "id": "arenasys-ai-chat",
+        "name": "AI Chat",
+        "author": "arenasys",
+        "description": "Chat with AI about your notes.",
+        "repo": "arenasys/obsidian-ai-chat"
+    },
+    {
+        "id": "local-llm-helper",
+        "name": "Local LLM Helper",
+        "author": "Mani Mohan",
+        "description": "Use a local LLM server to augment your notes",
+        "repo": "manimohans/obsidian-local-llm-helper"
+    },
+    {
+        "id": "text2audio",
+        "name": "Text2Audio",
+        "author": "Haifeng Lu",
+        "description": "Convert text to speech.",
+        "repo": "luhaifeng666/obsidian-text2audio"
+    },
+    {
+        "id": "ruby-wasm",
+        "name": "ruby.wasm",
+        "author": "geeknees",
+        "description": "Run ruby code in your notes using WebAssembly.",
+        "repo": "geeknees/obsidian-ruby-wasm-plugin"
+    },
+    {
+        "id": "tinychart",
+        "name": "TinyChart",
+        "author": "Alin Coop",
+        "description": "Generate simple ASCII charts.",
+        "repo": "alincoop/obsidian-tinychart"
+    },
+    {
+        "id": "checkbox-sounds",
+        "name": "Checkbox Sounds",
+        "author": "yasd251",
+        "description": "Adds a nice completion sound to checkboxes when ticked off",
+        "repo": "yasd251/checkbox-sounds-plugin"
+    },
+    {
+        "id": "zettelkasten-navigation",
+        "name": "zettelkasten navigation",
+        "author": "terrychenzw",
+        "description": "Visualize a Luhmann-style zettelkasten.",
+        "repo": "terrychenzw/obsidian-zettelkasten-navigation"
+    },
+    {
+        "id": "canvasblocks",
+        "name": "Canvas Blocks",
+        "author": "Kay606",
+        "description": "Execute python scripts from canvas",
+        "repo": "Kay607/obsidian-canvasblocks"
+    },
+    {
+        "id": "timekeep",
+        "name": "Timekeep",
+        "author": "Jacobtread",
+        "description": "Time tracking.",
+        "repo": "jacobtread/obsidian-timekeep"
+    },
+    {
+        "id": "select-word",
+        "name": "Select word",
+        "author": "Connor Espino",
+        "description": "Selects the word that is closest to the caret.",
+        "repo": "ConnorEspino/ObsidianSelectWord"
+    },
+    {
+        "id": "note-chain",
+        "name": "Note Chain",
+        "author": "ZigHolding",
+        "description": "Thoughts as river, notes as chain. Add prev and next notes to a notes, and order files by the chain in File Explorer.",
+        "repo": "zigholding/obsidian-notechain-plugin"
+    },
+    {
+        "id": "folder-periodic-notes",
+        "name": "Folder Periodic Notes",
+        "author": "Andrew Heekin",
+        "description": "Periodic notes in a year, month, and day folder hierarchy.",
+        "repo": "andrewheekin/obsidian-folder-periodic-notes"
+    },
+    {
+        "id": "s3agle",
+        "name": "S3agle",
+        "author": "Turner Monroe (turnercore)",
+        "description": "Use S3 providers and/or Eagle to manage vault attachments locally and remotely.",
+        "repo": "turnercore/s3agle"
+    },
+    {
+        "id": "markwhen",
+        "name": "Markwhen",
+        "author": "Markwhen",
+        "description": "Create timelines, gantt charts, calendars, and more using markwhen.",
+        "repo": "mark-when/obsidian-plugin"
+    },
+    {
+        "id": "canvas-keyboard-pan",
+        "name": "Canvas Keyboard Pan",
+        "author": "Nathonius",
+        "description": "Pan around your canvas using the keyboard",
+        "repo": "nathonius/obsidian-canvas-pan"
+    },
+    {
+        "id": "weekly-review-linker",
+        "name": "Weekly Review notes linker",
+        "description": "This links all of the files you have created in the last week into a Weekly Review note.",
+        "author": "Aditya Khowal and Brandon Boswell",
+        "repo": "AdityaKhowalGithub/weekly-review-notes-linker"
+    },
+    {
+        "id": "advanced-canvas-filter",
+        "name": "Advanced \u0421anvas Filter",
+        "author": "CHex0K",
+        "description": "Filter Canvas to show only items with specified tags.",
+        "repo": "CHex0K/advanced-canvas-filter"
+    },
+    {
+        "id": "future-dates",
+        "name": "Future Dates",
+        "author": "Dmitry Manannikov",
+        "description": "Show list of future dates in vault",
+        "repo": "slonoed/obsidian-future-dates"
+    },
+    {
+        "id": "gdscript-syntax-highlighting",
+        "name": "GDScript Syntax Highlighting",
+        "author": "RobTheFiveNine",
+        "description": "Add live GDScript syntax highlighting to code block.",
+        "repo": "RobTheFiveNine/obsidian-gdscript"
+    },
+    {
+        "id": "fuzzy-note-creator",
+        "name": "Fuzzy Note Creator",
+        "author": "HaloGamer33",
+        "description": "Create notes in folders with the help of a fuzzy finder.",
+        "repo": "HaloGamer33/Obsidian-Fuzzy-Note-Creator"
+    },
+    {
+        "id": "bibtex-manager",
+        "name": "BibTeX Manager",
+        "author": "Akop Kesheshyan",
+        "description": "Create a literature notes from a BibTeX entries.",
+        "repo": "akopdev/obsidian-bibtex-manager"
+    },
+    {
+        "id": "most-used",
+        "name": "MostUsed",
+        "author": "Levi Kingma",
+        "description": "Creates a list from your 100 most commonly used words",
+        "repo": "levi-ivel/MostUsed"
+    },
+    {
+        "id": "vault-explorer",
+        "name": "Vault Explorer",
+        "author": "DecafDev",
+        "description": "Explore your vault in visual format",
+        "repo": "decaf-dev/obsidian-vault-explorer"
+    },
+    {
+        "id": "cursor-jump",
+        "name": "Cursor Jump",
+        "author": "Sangwon Jung",
+        "description": "Quickly jump between list items and headings throughout same or upper/lower level.",
+        "repo": "LifeFi/obsidian-jump"
+    },
+    {
+        "id": "timesheet",
+        "name": "Timesheet",
+        "author": "vkostyanetsky",
+        "description": "Timesheet generator for tasks in daily notes.",
+        "repo": "vkostyanetsky/ObsidianTimesheet"
+    },
+    {
+        "id": "list-outline-helper",
+        "name": "List Outline Helper",
+        "author": "triangular-sneaky",
+        "description": "Utilities to work with list outlines. Currently supports selecting the outline (current line and children)",
+        "repo": "triangular-sneaky/obsidian-list-outline-helper"
+    },
+    {
+        "id": "query-json",
+        "name": "Query JSON",
+        "author": "rooyca",
+        "description": "Read, query and work with JSON.",
+        "repo": "rooyca/query-json"
+    },
+    {
+        "id": "voicenotes-sync",
+        "name": "Voicenotes Sync",
+        "author": "Andrew Lombardi",
+        "description": "A plugin for syncing Voicenotes.com data into notes",
+        "repo": "mysticcoders/voicenotes-sync"
+    },
+    {
+        "id": "legifrance-integration",
+        "name": "L\u00e9gifrance Int\u00e9gration",
+        "author": "hurj",
+        "description": "Int\u00e9gration de l'API L\u00e9gifrance.",
+        "repo": "carnetdethese/obsidian-legifrance-integration"
+    },
+    {
+        "id": "github-copilot",
+        "name": "Github Copilot",
+        "author": "Vasseur Pierre-Adrien",
+        "description": "Implement suggestions from Github Copilot directly in your editor.",
+        "repo": "Pierrad/obsidian-github-copilot"
+    },
+    {
+        "id": "toggle-rtl-mode",
+        "name": "Toggle RTL mode",
+        "author": "Yoni Asulin",
+        "description": "Toggle RTL mode using command or ribbon action",
+        "repo": "YoniA/toggle-rtl-obsidian-plugin"
+    },
+    {
+        "id": "update-time",
+        "name": "Update Time",
+        "author": "S\u00e9bastien Dubois",
+        "description": "Update front matter to include creation and last update times",
+        "repo": "dsebastien/obsidian-update-time"
+    },
+    {
+        "id": "solo-rpg-toolkit",
+        "name": "Solo RPG Toolkit",
+        "author": "Alex Kurowski",
+        "description": "Helpful tools for playing TTRPG games, geared towards solo play with a GM emulator.",
+        "repo": "alexkurowski/solo-toolkit"
+    },
+    {
+        "id": "interactivity",
+        "name": "Interactivity: Calculations and Scripts",
+        "author": "ichichikin",
+        "description": "Interactivity lets you run local shell commands and scripts directly within your notes, providing the output alongside your written content. Use your favorite tools like Python, Node.js, Java, Perl, PHP, bash, or any other REPLs while taking notes.",
+        "repo": "ichichikin/obsidian-plugin-interactivity"
+    },
+    {
+        "id": "heti",
+        "name": "heti",
+        "author": "Moeyua",
+        "description": "\u4e13\u4e3a\u4e2d\u6587\u5185\u5bb9\u5c55\u793a\u8bbe\u8ba1\u7684\u6392\u7248\u6837\u5f0f\u589e\u5f3a\u3002\u5b83\u57fa\u4e8e\u901a\u884c\u7684\u4e2d\u6587\u6392\u7248\u89c4\u8303\u800c\u6765\uff0c\u53ef\u4ee5\u5e26\u6765\u66f4\u597d\u7684\u9605\u8bfb\u4f53\u9a8c\u3002",
+        "repo": "moeyua/obsidian-heti"
+    },
+    {
+        "id": "stashpad-docs",
+        "name": "Stashpad Docs",
+        "author": "Stashpad",
+        "description": "Create a Stashpad Doc from your notes.",
+        "repo": "stashpad/obsidian-to-stashpad"
+    },
+    {
+        "id": "smart-gantt",
+        "name": "Smart Gantt",
+        "author": "Nhan Nguyen",
+        "description": "Intelligently generate Gantt chart from your tasks",
+        "repo": "nhannht/obsidian-smart-gantt"
+    },
+    {
+        "id": "tw-task-wiki",
+        "name": "TaskWarrior Task Wiki",
+        "author": "SntTGR",
+        "description": "Wrapper and integration around TaskWarrior. Allows you to view and edit tasks in your TaskWarrior database as tables.",
+        "repo": "SntTGR/obsidian-tw-task-wiki"
+    },
+    {
+        "id": "notes2tweets",
+        "name": "Notes 2 Tweets",
+        "author": "Tejas Sharma",
+        "description": "Generate tweets automatically from all the notes you took",
+        "repo": "Tej-Sharma/notes2tweets-obsidian"
+    },
+    {
+        "id": "note-definitions",
+        "name": "Note Definitions",
+        "author": "Dominic Let",
+        "description": "Personal dictionary for your notes",
+        "repo": "dominiclet/obsidian-note-definitions"
+    },
+    {
+        "id": "mathlive-in-editor-mode",
+        "name": "MathLive in Editor Mode",
+        "author": "MizarZh",
+        "description": "MathLive input in editor mode",
+        "repo": "MizarZh/obsidian-mathlive-codemirror"
+    },
+    {
+        "id": "lineage",
+        "name": "Lineage",
+        "author": "ycnmhd",
+        "description": "A writing interface that combines structure and content. Inspired by Gingko Writer.",
+        "repo": "ycnmhd/obsidian-lineage"
+    },
+    {
+        "id": "settings-management",
+        "name": "Settings Management",
+        "author": "Huajin",
+        "description": "Manage settings options, including show enabled/disabled plugins and css, grid layout, save current plugins/css enable config for quick enable/disable, etc.",
+        "repo": "xhuajin/obsidian-settings-options-management"
+    },
+    {
+        "id": "laser-beam",
+        "name": "Laser beam",
+        "author": "Bernardo Pires",
+        "description": "Improve your reading experience with customizable laser lines.",
+        "repo": "drbap/laser-beam-for-obsidian"
+    },
+    {
+        "id": "freeform",
+        "name": "Freeform",
+        "author": "tmcw",
+        "description": "Create visualizations, run custom JS, and mix live programs with your notes",
+        "repo": "tmcw/obsidian-freeform"
+    },
+    {
+        "id": "smart-html-select",
+        "name": "Smart HTML Select",
+        "author": "Isaia Riva",
+        "description": "Create select that change the markdown on change adding an action button to the ribbon (left sidebar)",
+        "repo": "IsaiaScope/smart-html-select-plugin"
+    },
+    {
+        "id": "file-preview",
+        "name": "File Preview",
+        "author": "Huajin",
+        "description": "Add file preview contents under file in file explorer.",
+        "repo": "xhuajin/obsidian-file-preview"
+    },
+    {
+        "id": "regex-mark",
+        "name": "Regex Mark",
+        "author": "Mara-Li",
+        "description": "Add custom CSS classes to text based on regular expressions.",
+        "repo": "Mara-Li/obsidian-regex-mark"
+    },
+    {
+        "id": "focus-tracker",
+        "name": "Focus Tracker",
+        "author": "Jeet Sukumaran",
+        "description": "Track and align your focus.",
+        "repo": "jeetsukumaran/obsidian-focus-tracker"
+    },
+    {
+        "id": "header-counter",
+        "name": "Header Counter",
+        "author": "Nancy Lee",
+        "description": "Count the number of headers in the current note.",
+        "repo": "nancyel/header-counter"
+    },
+    {
+        "id": "ii-quicker",
+        "name": "ii",
+        "author": "Wilson",
+        "description": "Quickly insert common Markdown code and HTML code, and customize your own insertion commands.",
+        "repo": "wish5115/obsidian-ii-quicker"
+    },
+    {
+        "id": "statblock-sidekick",
+        "name": "Statblock Sidekick",
+        "author": "n21rl",
+        "description": "Create and expand D&D 5e statblocks.",
+        "repo": "n21rl/stablock-sidekick"
+    },
+    {
+        "id": "checkbox-time-tracker",
+        "name": "Checkbox Time Tracker",
+        "author": "UD",
+        "description": "Insert timestamp when you check off the checkbox",
+        "repo": "udus122/checkbox-time-tracker"
+    },
+    {
+        "id": "noor",
+        "name": "Noor",
+        "author": "MKSherbini",
+        "description": "Aims to help Muslims stay enlightened with Islam, Quran, Hadith, and Sunnah",
+        "repo": "MKSherbini/obsidian-noor"
+    },
+    {
+        "id": "graph-banner",
+        "name": "Graph Banner",
+        "author": "ras0q",
+        "description": "Display a local graph view to the note header",
+        "repo": "ras0q/obsidian-graph-banner"
+    },
+    {
+        "id": "memos-sync",
+        "name": "Memos Sync",
+        "author": "RyoJerryYu",
+        "description": "Syncing memos from a Memos server to your daily note. Fully compatible with official Daily Notes plugin, Calendar plugin and Periodic Notes plugin.",
+        "repo": "RyoJerryYu/obsidian-memos-sync"
+    },
+    {
+        "id": "pin-enhancer",
+        "name": "Pin Enhancer",
+        "author": "Sheeplet1",
+        "description": "Prevents closure of pinned tabs",
+        "repo": "Sheeplet1/obsidian-pin-enhancer"
+    },
+    {
+        "id": "link-to-verse",
+        "name": "Link to Verse",
+        "author": "Alberto Sesiliano (aygjiay)",
+        "description": "From a bible reference selected creates a markdown link to a configured bible site.",
+        "repo": "aygjiay/obsidian-link-to-verse"
+    },
+    {
+        "id": "templify",
+        "name": "Templify",
+        "description": "Enables flexible conversion of note views into various layout (Closed source).",
+        "author": "Boninall",
+        "repo": "quorafind/obsidian-templify"
+    },
+    {
+        "id": "ayanite",
+        "name": "Ayanite",
+        "author": "jemstelos",
+        "description": "An integrated thinking environment - advanced AI chat and knowledge copilot (Closed source).",
+        "repo": "jemstelos/obsidian-ayanite"
+    },
+    {
+        "id": "docxer",
+        "name": "Docxer",
+        "author": "Developer-Mike",
+        "description": "Import Word files easily. Adds a preview mode for .docx files and the ability to convert them to markdown (.md) files.",
+        "repo": "Developer-Mike/obsidian-docxer"
+    },
+    {
+        "id": "the-queue",
+        "name": "The Queue",
+        "author": "Kolja Sam Pluemer",
+        "description": "Randomly exposes you to notes from your vault. Supports habits, to-dos, spaced repetition flashcards, iterative reading and more.",
+        "repo": "koljapluemer/obsidian-the-queue"
+    },
+    {
+        "id": "folder-by-tags-distributor",
+        "name": "Folder by tags distributor",
+        "author": "RevoTale",
+        "description": "Automatically move notes into existing folders by tags specified in note.",
+        "repo": "RevoTale/obsidian-folder-by-tags-distributor"
+    },
+    {
+        "id": "power-mode",
+        "name": "POWER MODE",
+        "author": "Zhou Hua",
+        "description": "Active POWER MODE!!!!",
+        "repo": "zhouhua/obsidian-power-mode"
+    },
+    {
+        "id": "rapid-ai",
+        "name": "Rapid AI",
+        "author": "Rapid AI",
+        "description": "An AI assistant for selected text, along with generating content with Markdown. Shortcuts and quick action buttons provide instant AI assistance.",
+        "repo": "ahmed3developer/rapid-ai"
+    },
+    {
+        "id": "click-up-sync",
+        "name": "ClickUp sync",
+        "author": "Khokim Mamarasulov",
+        "description": "Manage ClickUp space from notes.",
+        "repo": "hokim-m/click-up-x-obsidian"
+    },
+    {
+        "id": "tabs",
+        "name": "Tabs",
+        "author": "Huajin",
+        "description": "Create tabs in your notes.",
+        "repo": "xhuajin/obsidian-tabs"
+    },
+    {
+        "id": "vault-name",
+        "name": "Vault Name",
+        "author": "@gapmiss",
+        "description": "Display and customize the vault name (title) in the side navigation file explorer.",
+        "repo": "gapmiss/obsidian-vault-name"
+    },
+    {
+        "id": "substitutions",
+        "name": "Substitutions",
+        "description": "Automatically replace text fragments with symbols or different text",
+        "author": "BambusControl",
+        "repo": "BambusControl/obsidian-substitutions"
+    },
+    {
+        "id": "infostacker",
+        "name": "Infostacker Note Publish",
+        "author": "Taskscape LTD, Patryk Nowak, Kacper Pabianiak",
+        "description": "Share your notes with attachments easy!",
+        "repo": "taskscape/InfostackerPlugin"
+    },
+    {
+        "id": "audiopen-sync",
+        "name": "AudioPen Sync",
+        "author": "Jonas Haefele",
+        "description": "Sync notes from AudioPen.",
+        "repo": "jonashaefele/audiopen-obsidian"
+    },
+    {
+        "id": "pt-url-helper",
+        "name": "Pivotal Tracker URL Helper",
+        "author": "kndshein",
+        "description": "Automatically creates a Markdown link for Pivotal Tracker stories.",
+        "repo": "kndshein/obsidian-pt-url-helper"
+    },
+    {
+        "id": "relative-timestamps",
+        "name": "Relative Timestamps",
+        "author": "Charles Young",
+        "description": "Track the time between log entries.",
+        "repo": "agctute/relative-timestamps"
+    },
+    {
+        "id": "simple-prompt",
+        "name": "Simple Prompt",
+        "author": "David Zachariae",
+        "description": "Simple interface to generate or rewrite content using LLMs based on user input.",
+        "repo": "arumie/obsidian-simple-prompt-plugin"
+    },
+    {
+        "id": "explorer-hider",
+        "name": "Explorer Hider",
+        "author": "Mara-Li",
+        "description": "Hide a file or a folder from the explorer (and bookmarks) using a little bit of auto-managed CSS.",
+        "repo": "mara-li/obsidian-explorer-hider"
+    },
+    {
+        "id": "headings-in-explorer",
+        "name": "Headings in Explorer",
+        "author": "Patrick Chiang",
+        "description": "Show headings in the file explorer.",
+        "repo": "patrickchiang/obsidian-headings-in-explorer"
+    },
+    {
+        "id": "medium-importer",
+        "name": "Medium Importer",
+        "author": "David Zachariae",
+        "description": "Import Medium posts into your vault.",
+        "repo": "arumie/obsidian-medium-importer-plugin"
+    },
+    {
+        "id": "smart-connections-visualizer",
+        "name": "Smart Connections Visualizer",
+        "author": "Evan Moscoso",
+        "description": "View your Smart Connections in a visualized format.",
+        "repo": "mossy1022/smart-connections-graph-view"
+    },
+    {
+        "id": "prettier",
+        "name": "Prettier",
+        "author": "GoodbyeNJN",
+        "description": "Format your notes with Prettier and custom formatting options.",
+        "repo": "GoodbyeNJN/obsidian-plugin-prettier"
+    },
+    {
+        "id": "pinned-notes",
+        "name": "Pinned Notes",
+        "author": "vasilcoin002",
+        "description": "Pin frequently-used notes on Ribbon actions (left sidebar)",
+        "repo": "vasilcoin002/pinned-notes-plugin-obsidian"
+    },
+    {
+        "id": "svelte-syntax-highlighter",
+        "name": "Svelte Syntax Highlighter",
+        "author": "Typhoon-Kim",
+        "description": "Syntax highlighting for Svelte code blocks.",
+        "repo": "typhoon-kim/obsidian-svelte-syntax-highlighter"
+    },
+    {
+        "id": "midi-logger",
+        "name": "MIDI Logger",
+        "author": "@maybehelloworld",
+        "description": "Insert parsed musical notes from MIDI input devices.",
+        "repo": "maybe-hello-world/midi-logger"
+    },
+    {
+        "id": "checklist-progress",
+        "name": "Checklist Progress",
+        "author": "acidghost",
+        "description": "Automatically fill progress (as fraction or percentage) of check-lists.",
+        "repo": "acidghost/obsidian-checklist-progress"
+    },
+    {
+        "id": "explain-selection-with-ai",
+        "name": "Explain Selection With AI",
+        "author": "Ben Wurster",
+        "description": "Use an OpenAI Chat Completion API-compatible LLM endpoint to expand on selected text in the context of your notes.",
+        "repo": "BWurster/obsidian-ai-expander"
+    },
+    {
+        "id": "toggle-dark-mode",
+        "name": "Toggle Dark Mode",
+        "author": "Julia van der Kris",
+        "description": "Adds a command to toggle dark mode on and off",
+        "repo": "juliavdkris/obsidian-toggle-dark-mode"
+    },
+    {
+        "id": "plugins-annotations",
+        "name": "Plugins Annotations",
+        "author": "Andrea Alberti",
+        "description": "Allows adding personal comments to each installed plugin.",
+        "repo": "alberti42/obsidian-plugins-annotations"
+    },
+    {
+        "id": "close-window-when-empty",
+        "name": "Close Window When Empty",
+        "author": "Taylor Jadin",
+        "description": "Close the window when the last note is closed, kind of how browsers work.",
+        "repo": "TaylorJadin/close-window-when-empty"
+    },
+    {
+        "id": "tars",
+        "name": "Tars",
+        "author": "Tarslab",
+        "description": "Text generation based on tag suggestions, using Claude, OpenAI, Ollama, Kimi, Doubao, Qwen, Zhipu, DeepSeek, QianFan & more.",
+        "repo": "TarsLab/obsidian-tars"
+    },
+    {
+        "id": "toggle-readable-line-length",
+        "name": "Toggle Readable line length",
+        "author": "Doug Richardson",
+        "description": "Add command to toggle Readable line length editor setting.",
+        "repo": "drichardson/obsidian-toggle-readable-line-length"
+    },
+    {
+        "id": "definition-list",
+        "name": "Definition List",
+        "author": "shammond42",
+        "description": "Adds HTML definition list support.",
+        "repo": "shammond42/definition-list"
+    },
+    {
+        "id": "line-arrange",
+        "name": "Line Arrange",
+        "author": "Chitwan Singh",
+        "description": "Shuffle, reverse, or sort lines, using either visual width or lexical order.",
+        "repo": "chitwan27/lineArrange"
+    },
+    {
+        "id": "search-in-canvas",
+        "name": "Search In Canvas",
+        "author": "Boninall",
+        "description": "Search text in canvas.",
+        "repo": "quorafind/obsidian-search-in-canvas"
+    },
+    {
+        "id": "sheet-plus",
+        "name": "Sheet Plus",
+        "author": "ljcoder",
+        "description": "Create Excel-like spreadsheets and easily embed them in Markdown.",
+        "repo": "ljcoder2015/obsidian-sheet-plus"
+    },
+    {
+        "id": "watched-metadata",
+        "name": "Watched-Metadata",
+        "author": "Nail Ahmed",
+        "description": "Watches for changes in metadata and performs user-specified actions based on these changes.",
+        "repo": "NailAhmed/Watched-Metadata"
+    },
+    {
+        "id": "task-list-kanban",
+        "name": "Task List Kanban",
+        "author": "Chris Kerr",
+        "description": "Organizes all of the tasks within your files into a kanban view.",
+        "repo": "chrskerr/task-list-kanban"
+    },
+    {
+        "id": "interactive-code-blocks",
+        "name": "Interactive Code Blocks",
+        "author": "Student Assistenten Team Deeltaken",
+        "description": "Preview interactive code blocks!",
+        "repo": "Windesheim-HBO-ICT/Obsidian-Interactive-Code-Block-Plugin"
+    },
+    {
+        "id": "you-and-your-research",
+        "name": "You and Your Research",
+        "author": "Neo Zhang",
+        "description": "Research with the help of A.I.",
+        "repo": "neozhang/you-and-your-research"
+    },
+    {
+        "id": "dialogue-mode",
+        "name": "Dialogue Mode",
+        "author": "Patrick Chiang",
+        "description": "Dialogue mode for editing speech in writing.",
+        "repo": "patrickchiang/obsidian-dialogue-mode"
+    },
+    {
+        "id": "smart-text-mover",
+        "name": "Smart Text Mover",
+        "author": "Ankush-Chander",
+        "description": "Intelligent way to arrange text/links in file.",
+        "repo": "Ankush-Chander/obsidian-smart-move-text"
+    },
+    {
+        "id": "note-promixity",
+        "name": "Lookalike",
+        "author": "jlweston",
+        "description": "Find similar notes based on the frequency of terms within the vault.",
+        "repo": "jlweston/obsidian-note-proximity-plugin"
+    },
+    {
+        "id": "header-adjuster",
+        "name": "Header Adjuster",
+        "author": "Valentin Pelletier",
+        "description": "Easily adjust header levels in Markdown documents by increasing or decreasing their levels. Supports full document adjustments or specified line ranges, with default settings and commands for convenience.",
+        "repo": "Netajam/header-adjuster"
+    },
+    {
+        "id": "gemini-generator",
+        "name": "Gemini Generator",
+        "author": "Bjarne Rentz",
+        "description": "Let Google Gemini generator your notes!",
+        "repo": "BjarneRentz/obsidian-gemini-generator"
+    },
+    {
+        "id": "node-auto-resize",
+        "name": "Node Auto Resize",
+        "author": "Boninall",
+        "description": "Automatically resize the node when the content changes.",
+        "repo": "quorafind/obsidian-node-auto-resize"
+    },
+    {
+        "id": "sqlseal",
+        "name": "SQLSeal",
+        "author": "hypersphere",
+        "description": "Use SQL in your notes to query your vault files and CSV content",
+        "repo": "h-sphere/sql-seal"
+    },
+    {
+        "id": "spoilers",
+        "name": "Spoilers",
+        "author": "Jacobtread",
+        "description": "Hide and reveal blocks of information",
+        "repo": "jacobtread/obsidian-spoilers"
+    },
+    {
+        "id": "asciidoc-reader",
+        "name": "Asciidoc Reader",
+        "author": "voidgrown",
+        "description": "Enables the rendering of AsciiDoc.",
+        "repo": "Voidgrown/obsidian-asciidoc"
+    },
+    {
+        "id": "another-sticky-headings",
+        "name": "Another Sticky Headings",
+        "author": "Zhou Hua",
+        "description": "Display headings tree during editing and preview to indicate the current position.",
+        "repo": "zhouhua/obsidian-sticky-headings"
+    },
+    {
+        "id": "doing",
+        "name": "doing",
+        "author": "rooyca",
+        "description": "It helps you remember what you were doing.",
+        "repo": "rooyca/doing"
+    },
+    {
+        "id": "daily-note-structure",
+        "name": "Daily Note Structure",
+        "author": "db-developer",
+        "description": "One-Click create a structure for and including your daily notes.",
+        "repo": "db-developer/daily-note-structure"
+    },
+    {
+        "id": "rpg-stat-tracker",
+        "name": "RPG Stat Tracker",
+        "author": "Cunjur",
+        "description": "RPG-like stat tracker.",
+        "repo": "name/obsidian-rpg"
+    },
+    {
+        "id": "smart-memos",
+        "name": "Smart Memos",
+        "author": "Evan Moscoso",
+        "description": "Create personalized and intelligent analysis, brainstorms, summaries, transcriptions, and more for audio recordings that can be imported or spoken directly into a note",
+        "repo": "Mossy1022/smart-transcriptions"
+    },
+    {
+        "id": "syrinscape-player-control",
+        "name": "Syrinscape Online Player",
+        "author": "Stephen Cooper",
+        "description": "Control Syrinscape Online Player from inside of notes.",
+        "repo": "scooper4711/obsidian-syrinscape"
+    },
+    {
+        "id": "quran-helper",
+        "name": "Quran Helper",
+        "author": "Ammar Alakkad",
+        "description": "Find and insert any Quran Ayah (verse) in your notes.",
+        "repo": "AmmarCodes/obsidian-quran-plugin"
+    },
+    {
+        "id": "page-scroll",
+        "name": "Page Scroll",
+        "author": "triski",
+        "description": "Page Up|Down|Top|Bottom",
+        "repo": "chenshutian9610/obsidian-pagescroll-plugin"
+    },
+    {
+        "id": "wechat-public-platform",
+        "name": "Wechat Public Platform",
+        "description": "Release the article from your vault to WeChat, Baidu Baijiahao, or another article release platform.",
+        "author": "Blake Chan",
+        "repo": "ai-chen2050/obsidian-wechat-public-platform"
+    },
+    {
+        "id": "note-to-mp",
+        "name": "NoteToMP",
+        "author": "Sun Booshi",
+        "description": "Send notes to WeChat MP drafts, or copy notes to WeChat MP editor, perfect preservation of note styles, support code highlighting, line numbers in code, and support local image uploads.",
+        "repo": "sunbooshi/note-to-mp"
+    },
+    {
+        "id": "xournalpp",
+        "name": "Xournal++",
+        "author": "Jon Jampen",
+        "description": "Integration with Xournal++ for handwritten notes and annotations.",
+        "repo": "jonjampen/obsidian-xournalpp"
+    },
+    {
+        "id": "dataview-serializer",
+        "name": "Dataview Serializer",
+        "author": "S\u00e9bastien Dubois",
+        "description": "Serialize Dataview queries to Markdown, and keep the Markdown representation up to date",
+        "repo": "dsebastien/obsidian-dataview-serializer"
+    },
+    {
+        "id": "fast-text-color",
+        "name": "Fast Text Color",
+        "author": "Leon Holtmeier",
+        "description": "Quickly apply fully integrated text coloring and formatting with a custom syntax and a keyboard-centric interface.",
+        "repo": "Superschnizel/obisdian-fast-text-color"
+    },
+    {
+        "id": "guid-renamer",
+        "name": "Guid Renamer",
+        "author": "Taskscape LTD, Kacper Pabianiak",
+        "description": "Rename selected file with a random GUID",
+        "repo": "taskscape/ObsidianUniqueFileName"
+    },
+    {
+        "id": "multiplatform-highlights-import",
+        "name": "Multiplatform Highlights Importer",
+        "author": "wwwkieran",
+        "description": "Import and consolidate highlights from different reading sources. Supports reconciling books across reading sources.",
+        "repo": "wwwkieran/obsidian-multiplatform-highlights-import"
+    },
+    {
+        "id": "front-matter-timestamps",
+        "name": "Front Matter Timestamps",
+        "author": "LighthouseDino",
+        "description": "Automatically manages and updates 'created' and 'modified' timestamps in the frontmatter of your notes.",
+        "repo": "lighthousedino/obsidian-front-matter-timestamps"
+    },
+    {
+        "id": "publish-to-dev",
+        "name": "Publish to DEV",
+        "author": "Peter Str\u00f8iman",
+        "description": "Publish and update notes as articles on DEV (https://dev.to)",
+        "repo": "stroiman/obsidian-dev-publish"
+    },
+    {
+        "id": "e-daiary",
+        "name": "e-Daiary",
+        "author": "Thomas Campanholi",
+        "description": "Creates directories and notes based on the day of the year.",
+        "repo": "wholetomy/obsidian-e-daiary"
+    },
+    {
+        "id": "dataview-publisher",
+        "name": "Dataview Publisher",
+        "author": "UD",
+        "description": "Output markdown from your Dataview queries and keep them up to date. You can also publish them.",
+        "repo": "udus122/dataview-publisher"
+    },
+    {
+        "id": "nsfw-filter",
+        "name": "NSFW filter",
+        "author": "catvatar",
+        "description": "Adds customizable and easly togglable NSFW filter",
+        "repo": "catvatar/Obsidian-NSFW-Plugin"
+    },
+    {
+        "id": "edit-in-neovim",
+        "name": "Edit in Neovim",
+        "author": "Theseus",
+        "description": "Open a Neovim buffer for the currently open file",
+        "repo": "TheseusGrey/edit-in-neovim"
+    },
+    {
+        "id": "todoist-indicator",
+        "name": "Todoist Indicator",
+        "author": "kapej42",
+        "description": "Adds a badge to \"project\" files to indicate a missing link to a Todoist project.",
+        "repo": "kapej42/obsidian-todoist-indicator"
+    },
+    {
+        "id": "vimium",
+        "name": "Vimium",
+        "author": "Karsten Finderup Pedersen",
+        "description": "Interact with elements using keyboard shortcuts in the spirit of Vim.",
+        "repo": "karstenpedersen/obsidian-vimium"
+    },
+    {
+        "id": "checkbox-styling-helper",
+        "name": "Checkbox styling helper",
+        "author": "JaewonE",
+        "description": "Helps you styling checkboxes in preview mode.",
+        "repo": "jaewonE/checkbox-styling-helper"
+    },
+    {
+        "id": "import-attachments-plus",
+        "name": "Import Attachments+",
+        "author": "Andrea Alberti",
+        "description": "Import and manage attachments by enabling moving and linking",
+        "repo": "alberti42/obsidian-import-attachments-plus"
+    },
+    {
+        "id": "virtual-linker",
+        "name": "Virtual Linker / Glossary",
+        "description": "Automatically creates virtual links for text within your notes that match the titles or aliases of other notes in your vault. Create a glossary-like functionality, show unlinked mentions and transform them to real links.",
+        "author": "Valentin Schr\u00f6ter",
+        "repo": "vschroeter/obsidian-virtual-linker"
+    },
+    {
+        "id": "arena-manager",
+        "name": "Are.na Manager",
+        "author": "Javier Arce",
+        "description": "Publish content from your vault to Arena and the other way around.",
+        "repo": "javierarce/arena-manager"
+    },
+    {
+        "id": "shrink-pinned-tabs",
+        "name": "Shrink pinned tabs",
+        "author": "Nicolas L\u0153uillet",
+        "description": "Shrinks pinned tabs to save screen space.",
+        "repo": "nicosomb/obsidian-shrink-pinned-tabs"
+    },
+    {
+        "id": "remove-newlines",
+        "name": "Remove Newlines",
+        "author": "Elias Jaffe",
+        "description": "Remove newlines from text selections and also paste content from the clipboard without newlines.",
+        "repo": "HandcartCactus/obsidian-remove-newlines"
+    },
+    {
+        "id": "entity-linker",
+        "name": "Entity Linker",
+        "author": "Ankush-Chander",
+        "description": "Link research terms to standard entities",
+        "repo": "Ankush-Chander/obsidian-entity-linker"
+    },
+    {
+        "id": "datepicker",
+        "name": "Datepicker",
+        "author": "Mostafa Mohamed",
+        "description": "Use a date picker to modify and insert date/time anywhere in your markdown notes.",
+        "repo": "joycode-hub/datepicker-plugin"
+    },
+    {
+        "id": "ai-chat-as-md",
+        "name": "AI Chat as Markdown",
+        "author": "Charl P. Botha",
+        "description": "Multiple branching AI conversations as Markdown hierarchy",
+        "repo": "cpbotha/obsidian-ai-chat-as-md"
+    },
+    {
+        "id": "sidebar-resizer",
+        "name": "Sidebar Resizer",
+        "author": "Jeet Sukumaran",
+        "description": "Adjust the sidebar sizes easily.",
+        "repo": "jeetsukumaran/obsidian-sidebar-resizer"
+    },
+    {
+        "id": "refresh-preview",
+        "name": "Refresh Preview",
+        "author": "mnaoumov",
+        "description": "Allows to refresh preview mode without reopening the note",
+        "repo": "mnaoumov/obsidian-refresh-preview"
+    },
+    {
+        "id": "hash-pasted-image",
+        "name": "Hash Pasted Image",
+        "author": "Minh V\u01b0\u01a1ng",
+        "description": "Auto rename pasted images added to the vault via hash algorithm SHA-512",
+        "repo": "hardingadonis/hash-pasted-image"
+    },
+    {
+        "id": "yanki",
+        "name": "Yanki",
+        "author": "Eric Mika",
+        "description": "Sync flashcards from a folder in your vault to Anki. Pure Markdown syntax. No fuss.",
+        "repo": "kitschpatrol/yanki-obsidian"
+    },
+    {
+        "id": "iconic",
+        "name": "Iconic",
+        "author": "Holo",
+        "description": "Customize your icons and their colors directly from the UI, including tabs, files, bookmarks, properties, and ribbon commands.",
+        "repo": "gfxholo/iconic"
+    },
+    {
+        "id": "notes-refresher",
+        "name": "Notes Refresher",
+        "author": "Connor Park",
+        "description": "Provides AI-generated refresher summaries of notes from your Vault using GPT-4.",
+        "repo": "connorpark24/refresher-plugin"
+    },
+    {
+        "id": "docbase-unofficial",
+        "name": "DocBase (Unofficial)",
+        "author": "yurikuvanov",
+        "description": "Pull and push notes to DocBase",
+        "repo": "kuvanov-2/obsidian-docbase"
+    },
+    {
+        "id": "latex-render",
+        "name": "Latex Render",
+        "author": "jvsteiner",
+        "description": "Render small latex snippets in your notes as SVG and PNG files.",
+        "repo": "jvsteiner/obsidian-latex-render"
+    },
+    {
+        "id": "code-link",
+        "name": "Code Link",
+        "author": "observerw",
+        "description": "Link to code files in your notes",
+        "repo": "observerw/obsidian-code-link"
+    },
+    {
+        "id": "index-notes",
+        "name": "Index Notes",
+        "author": "Alejandro Daniel Noel",
+        "description": "Keep your notes indexed based on their (hierarchical) tags",
+        "repo": "adanielnoel/obsidian-index-notes"
+    },
+    {
+        "id": "plot-vectors-graphs",
+        "name": "Plot Vectors and Graphs",
+        "author": "Nicole Tan YiTong",
+        "description": "Generates graphs and vectors.",
+        "repo": "nicoletanyt/obsidian-plugin-graphs"
+    },
+    {
+        "id": "nyanbar",
+        "name": "NyanBar",
+        "author": "xhyabunny",
+        "description": "Nyan Cat Progress Bar generator!",
+        "repo": "xhyabunny/nyanbar"
+    },
+    {
+        "id": "mpv-links",
+        "name": "mpv links",
+        "author": "patsh90",
+        "description": "Add mpv links with timestamps",
+        "repo": "patsh90/mpv-obsidian-plugin"
+    },
+    {
+        "id": "iron-vault",
+        "name": "Iron Vault",
+        "author": "Iron Vault Dev Team",
+        "description": "Gameplay plugin/VTT for the Ironsworn/Starforged family of tabletop RPGs.",
+        "repo": "iron-vault-plugin/iron-vault"
+    },
+    {
+        "id": "popkit",
+        "name": "PopKit",
+        "author": "Zhou Hua",
+        "description": "Select text to instantly access quick tools",
+        "repo": "zhouhua/obsidian-popkit"
+    },
+    {
+        "id": "account-viewer",
+        "name": "Account Viewer",
+        "author": "Muaz Yediy\u00fczk\u0131rkiki",
+        "description": "Automatically generate accounting tables from Markdown code blocks tagged with accounting.",
+        "repo": "muaz742/obsidian-accointing-viewer"
+    },
+    {
+        "id": "better-markdown-links",
+        "name": "Better Markdown Links",
+        "author": "mnaoumov",
+        "description": "Adds support for angle bracket links and manages relative links properly",
+        "repo": "mnaoumov/obsidian-better-markdown-links"
+    },
+    {
+        "id": "languagetool",
+        "name": "LanguageTool",
+        "author": "Lars Wrenger, Clemens Ertle",
+        "description": "Inofficial integration of the LanguageTool spell and grammar checker.",
+        "repo": "wrenger/obsidian-languagetool"
+    },
+    {
+        "id": "browser-interface",
+        "name": "Browser Interface",
+        "author": "Jason Lieb",
+        "description": "Allows you to interact with the browser.",
+        "repo": "jason-lieb/obsidian-browser-interface-plugin"
+    },
+    {
+        "id": "nextcloud-link-fixer",
+        "name": "Nextcloud Link Fixer",
+        "author": "KaelLarkin",
+        "description": "Nextcloud breaks Wiki-links. This fixes them.",
+        "repo": "KFreon/nextcloud-link-fixer"
+    },
+    {
+        "id": "everyday-classical-music",
+        "name": "Everyday Classical Music",
+        "author": "the flying markhor",
+        "description": "Display a different piece of classical music each day with a YouTube link in your daily note.",
+        "repo": "Eloliuyx/everyday-classical-music-plugin"
+    },
+    {
+        "id": "vikunja-sync",
+        "name": "Vikunja Sync",
+        "author": "Peter Heiss",
+        "description": "Synchronizes tasks to Vikunja.",
+        "repo": "Heiss/obsidian-vikunja-plugin"
+    },
+    {
+        "id": "chinese-calendar",
+        "name": "Chinese Calendar",
+        "author": "DevilRoshan",
+        "description": "\u7b26\u5408\u4e2d\u56fd\u4e60\u60ef\u7684\u65e5\u5386\uff0c\u53ef\u4ee5\u663e\u793a\u519c\u5386\u3001\u8282\u65e5\u3001\u8c03\u4f11\u3001\u8282\u6c14\u7b49\u4fe1\u606f\uff0c\u652f\u6301\u6708\u89c6\u56fe\u548c\u5e74\u89c6\u56fe\u5207\u6362\uff0c\u652f\u6301\u70b9\u51fb\u65e5\u671f\u521b\u5efa\u7b14\u8bb0\uff0c\u652f\u6301\u4f7f\u7528QuickAdd\u63d2\u4ef6\u521b\u5efa\u7b14\u8bb0\u3002",
+        "repo": "DevilRoshan/obsidian-lunar-calendar"
+    },
+    {
+        "id": "unofficial-fabric-integration",
+        "name": "Unofficial Fabric Integration",
+        "author": "Chasebank87",
+        "description": "Integrates Fabric into your vault",
+        "repo": "chasebank87/unofficial-fabric-plugin"
+    },
+    {
+        "id": "caret",
+        "name": "Caret",
+        "author": "Jake Colling",
+        "description": "An AI workbench. Canvas, Chat and more LLM powered features.",
+        "repo": "jcollingj/caret"
+    },
+    {
+        "id": "messager",
+        "name": "Messager",
+        "author": "Rainyluo",
+        "description": "Save messages into vault which sending through WeChat/HTTP API/Email",
+        "repo": "xiaotianhu/obsidian-messager"
+    },
+    {
+        "id": "giphy",
+        "name": "Giphy",
+        "author": "LuCrypto",
+        "description": "Search and insert gifs in a note.",
+        "repo": "LuCrypto/giphy-plugin"
+    },
+    {
+        "id": "image-metadata",
+        "name": "Image Metadata",
+        "author": "alexeiskachykhin",
+        "description": "Annotate photos with Exif and other metadata right from the image viewer screen.",
+        "repo": "alexeiskachykhin/obsidian-image-metadata-plugin"
+    },
+    {
+        "id": "journal-folder",
+        "name": "Journal Folder",
+        "author": "Charl Fourie",
+        "description": "Utilities for folder-based journaling.",
+        "repo": "chfourie/obsidian-journal-folder"
+    },
+    {
+        "id": "litegallery",
+        "name": "Lite Gallery",
+        "author": "Jordan Poles",
+        "description": "Easily create carousel galleries to better organize/view images in your notes.",
+        "repo": "jpoles1/obsidian-litegal"
+    },
+    {
+        "id": "pia-viewer",
+        "name": "Pia viewer",
+        "author": "dldisud",
+        "description": "Make it look mobile on pc",
+        "repo": "dldisud/obsidian-pia-viewer"
+    },
+    {
+        "id": "ca-sync",
+        "name": "Cognitive Architect Sync",
+        "author": "Bram Havers",
+        "description": "Synchronise Cognitive Architect (aka IBM IT Architect Assistant) architectures.",
+        "repo": "bhavers/obsidian-ca"
+    },
+    {
+        "id": "ai-image-analyzer",
+        "name": "AI image analyzer",
+        "author": "Swaggeroo",
+        "description": "Analyze images with AI to get keywords of the image.",
+        "repo": "Swaggeroo/obsidian-ai-image-analyzer"
+    },
+    {
+        "id": "virt-folder",
+        "name": "VirtFolder",
+        "author": "mr.grogrig",
+        "description": "Creating a hierarchical structure like Luhmann's Zettelkasten",
+        "repo": "gr0grig/obsidian-virt-folder"
+    },
+    {
+        "id": "magic-move",
+        "name": "Magic Move",
+        "author": "imfenghuang",
+        "description": "Animating code blocks with markdown and code syntax highlighting with beautiful themes.",
+        "repo": "imfenghuang/obsidian-magic-move"
+    },
+    {
+        "id": "math-indicator-changer",
+        "name": "Math Indicator Changer",
+        "author": "Ori Replication",
+        "description": "Change the math indecator from parentheses & brackets to $, make the math formula generated by GPT & Other AI display correctly.",
+        "repo": "Ori-Replication/obsidian-math-indicator-changer"
+    },
+    {
+        "id": "pdf-annotator",
+        "name": "Pdf Annotator",
+        "author": "Boninall",
+        "description": "Simple but powerful pdf annotator.",
+        "repo": "quorafind/obsidian-pdf-annotator"
+    },
+    {
+        "id": "openapi-renderer",
+        "name": "OpenAPI Renderer",
+        "author": "Sentiago",
+        "description": "Integrate OpenAPI specification management with features for version control, visualization, editing, and easy navigation of API specs.",
+        "repo": "Ssentiago/obsidian-openapi-renderer"
+    },
+    {
+        "id": "tags-routes",
+        "name": "Tags Routes",
+        "author": "Ken",
+        "description": "A powerful tool for visualizing 3D graphs and managing orphan files, offering a dynamic and colorful 3D graph view for enhanced user experience.",
+        "repo": "kctekn/obsidian-TagsRoutes"
+    },
+    {
+        "id": "note-linker-with-previewer",
+        "name": "Note Linker with Previewer",
+        "author": "Nick Allison",
+        "description": "Link your notes together.",
+        "repo": "nickrallison/obsidian-note-linker-with-previewer"
+    },
+    {
+        "id": "paste-as-embed",
+        "name": "Paste as Embed",
+        "author": "Matt Laporte",
+        "description": "Redirect pasted text into a separate note, and embed it.",
+        "repo": "mlprt/obsidian-paste-as-embed"
+    },
+    {
+        "id": "better-recall",
+        "name": "Better Recall",
+        "author": "FlorianWoelki",
+        "description": "Add anki-like spaced repetition and recall to your vault.",
+        "repo": "FlorianWoelki/obsidian-better-recall"
+    },
+    {
+        "id": "images-to-gist",
+        "name": "Images to Gist",
+        "author": "Inder Singh",
+        "description": "Upload images to your GitHub secret Gists. Also, resize uploaded images on the fly.",
+        "repo": "singh-inder/obsidian-images-to-gist"
+    },
+    {
+        "id": "heading-toggler",
+        "name": "Heading Toggler",
+        "author": "Lord Turmoil",
+        "description": "Easily toggle heading levels in Markdown documents with shortcuts.",
+        "repo": "Lord-Turmoil/heading-toggler-obsidian"
+    },
+    {
+        "id": "rollover-weekly-todo",
+        "name": "Rollover Weekly Todo",
+        "description": "Rollover unchecked todo items from the previous weekly note",
+        "author": "Shubham Sethi",
+        "repo": "shsethi/obsidian-rollover-weekly-todos"
+    },
+    {
+        "id": "youtube-downloader",
+        "name": "YouTube downloader",
+        "author": "Blake Chan",
+        "description": "Download videos from YouTube",
+        "repo": "ai-chen2050/obsidian-youtube-downloader"
+    },
+    {
+        "id": "image-notes-photes-io",
+        "name": "Image to notes by Photes.IO",
+        "author": "Kanaries Data Inc.",
+        "description": "Turn your images into text notes with AI.",
+        "repo": "Kanaries/photes-io-obsidian-plugin"
+    },
+    {
+        "id": "note-2-tag-generator",
+        "name": "Note 2 Tag Generator",
+        "author": "Augustin",
+        "description": "Generate tags from notes without openai key in multiple languages",
+        "repo": "augustin7698/note-2-tag-generator"
+    },
+    {
+        "id": "post-medium-draft",
+        "name": "Post Medium Draft",
+        "author": "Everett Bolton",
+        "description": "Post the current note to your Medium account as a draft.",
+        "repo": "eebmagic/post-medium-draft"
+    },
+    {
+        "id": "fast-image-upload",
+        "name": "Fast Image Auto Uploader",
+        "author": "Longtao Wu",
+        "description": "Fast upload images from your clipboard by gopic",
+        "repo": "eust-w/obsidian-image-auto-upload"
+    },
+    {
+        "id": "auto-folder-collapse",
+        "name": "Auto Folder Collapse",
+        "author": "Dario Casciato",
+        "description": "Automatically collapses subfolders when a parent folder is collapsed",
+        "repo": "DarioCasciato/obsidian-auto-folder-collapse"
+    },
+    {
+        "id": "dashboard-navigator",
+        "name": "Dashboard navigator",
+        "author": "Bernardo Pires",
+        "description": "Vault dashboard and navigator. Show recent files by type, files per day, week, month, search files by name, date, tags and more.",
+        "repo": "drbap/dashboard-navigator-for-obsidian"
+    },
+    {
+        "id": "quick-open",
+        "name": "Quick Select",
+        "author": "James Alexandre",
+        "description": "Quickly select items in any modal using keyboard shortcuts. Supercharge your workflow with fast, efficient item selection in Obsidian modals.",
+        "repo": "itsonlyjames/obsidian-quick-select"
+    },
+    {
+        "id": "rich-text-editor-shortcuts",
+        "name": "Rich Text Editor Shortcuts",
+        "author": "Joshua Wootonn",
+        "description": "Create and toggle checkboxes, paste links wrapping your current selection, and toggle underline without leaving the keyboard.",
+        "repo": "joshuawootonn/obsidian-rich-text-editor-shortcuts"
+    },
+    {
+        "id": "share-via-notepad-tab",
+        "name": "Share via Notepad Tab",
+        "author": "Iulian Onofrei",
+        "description": "Share notes via Notepad Tab (https://notepadtab.com).",
+        "repo": "revolter/obsidian-share-via-notepad-tab-plugin"
+    },
+    {
+        "id": "recent-tab-switcher",
+        "name": "Recent Tab Switcher",
+        "description": "Switch to the most recently used tab.",
+        "author": "Samuel Ang",
+        "repo": "samuelrawrs/recent-tab-switcher"
+    },
+    {
+        "id": "marker-api",
+        "name": "Marker PDF to MD",
+        "author": "L3N0X",
+        "description": "Convert PDFs to rich Markdown, including images and ocr using the marker api",
+        "repo": "l3-n0x/obsidian-marker"
+    },
+    {
+        "id": "hexo-publisher",
+        "name": "Hexo Publisher",
+        "author": "zhenlohuang",
+        "description": "Publish your notes to Hexo.",
+        "repo": "zhenlohuang/obsidian-hexo-publisher"
+    },
+    {
+        "id": "inline-spoilers",
+        "name": "Inline spoilers",
+        "author": "logonoff",
+        "description": "Adds Discord-like syntax for inline spoilers in reader mode.",
+        "repo": "logonoff/obsidian-inline-spoilers"
+    },
+    {
+        "id": "enhanced-symbols-prettifier",
+        "name": "Enhanced Symbols Prettifier",
+        "author": "Noam Schmitt",
+        "description": "Replace/substitute the symbols with actual symbols you commonly type. It also works for emojis shortcuts, abbreviations, greek letters, math symbols or other snippets/aliases you define",
+        "repo": "noam-sc/obsidian-enhanced-symbols-prettifier"
+    },
+    {
+        "id": "smart-templates",
+        "name": "Smart Templates",
+        "description": "AI powered templates for generating structured content. Works with Local Models, Anthropic Claude, Gemini, OpenAI & more.",
+        "author": "\ud83c\udf34 Brian Petro",
+        "repo": "brianpetro/obsidian-smart-templates"
+    },
+    {
+        "id": "canvas-picture-in-picture",
+        "name": "Canvas Picture in Picture",
+        "author": "hypersphere",
+        "description": "Enables ability to pin Canvas nodes and float them above the board (Picture-in-Picture mode)",
+        "repo": "h-sphere/obsidian-canvas-picture-in-picture"
+    },
+    {
+        "id": "super-duper-audio-recorder",
+        "name": "Super Duper Audio Recorder",
+        "author": "Thiago MadPin",
+        "description": "Records audio directly, with input device and folder configuration, similar to the core one, but better",
+        "repo": "madpin/super-duper-audio-recorder"
+    },
+    {
+        "id": "vertical-tabs",
+        "name": "Vertical Tabs",
+        "author": "oxdc",
+        "description": "Offer an alternative view that displays open tabs vertically, allowing users to group and organize tabs for a better navigation experience.",
+        "repo": "oxdc/obsidian-vertical-tabs"
+    },
+    {
+        "id": "truth-table-gen",
+        "name": "Truth Table+",
+        "description": "Generate truth tables quickly in your .md files",
+        "author": "Maximilian Schulten",
+        "repo": "Max-Schulten/truth-table-plus"
+    },
+    {
+        "id": "learnie",
+        "name": "Learnie",
+        "description": "Enhance your learning with active recall and spaced repetition. Track changes, create review questions, and streamline your study process for more effective, long-lasting learning.",
+        "author": "tankh99",
+        "repo": "tankh99/learnie-plugin"
+    },
+    {
+        "id": "confluence-link",
+        "name": "Confluence Link",
+        "author": "Razvan Bunga",
+        "description": "Upload files to Confluence pages",
+        "repo": "BungaRazvan/confluence-link"
+    },
+    {
+        "id": "system3-relay",
+        "name": "Relay",
+        "author": "System 3",
+        "description": "Collaborate in real time with live cursors. Share folders. Manage access to updates.",
+        "repo": "no-instructions/relay"
+    },
+    {
+        "id": "vault-size-history",
+        "name": "Vault Size History",
+        "author": "Technerium",
+        "description": "Graph of the Number of Files in the Vault.",
+        "repo": "technerium/obsidian-vault-size-history"
+    },
+    {
+        "id": "harper",
+        "name": "Harper",
+        "author": "Elijah Potter",
+        "description": "The grammar checker for everyone.",
+        "repo": "elijah-potter/harper-obsidian-plugin"
+    },
+    {
+        "id": "geulo-youtube-liked-video",
+        "name": "Geulo",
+        "author": "Junyoung Bang",
+        "description": "Fetch all the YouTube videos you have liked, search and sort them with multiple sort options, and add them to your daily note.",
+        "repo": "zzunebye/obsidian-google-liked-video"
+    },
+    {
+        "id": "sync-db-os",
+        "name": "sync-db-os",
+        "author": "ketd",
+        "description": "For synchronization between multiple platforms",
+        "repo": "ketd/obsidian-sync-DB-OS"
+    },
+    {
+        "id": "auto-correct-capitals",
+        "name": "Auto Correct Capitals Misspellings",
+        "author": "Ummel",
+        "description": "Correct words with the first two letters in uppercase.",
+        "repo": "Ummler/obsidian-auto-correct-capitals"
+    },
+    {
+        "id": "daily-statistics",
+        "name": "Daily Statistics",
+        "author": "yefengr",
+        "description": "Count the number of words written each day and display it on a calendar.",
+        "repo": "yefengr/obsidian-daily-statistics"
+    },
+    {
+        "id": "block-link-plus",
+        "name": "Block Link Plus",
+        "author": "Jasper",
+        "description": "Simplifies the creation of multi-line blockquotes, with customizable block IDs.",
+        "repo": "Jasper-1024/block-link-plus"
+    },
+    {
+        "id": "lds-library-reference",
+        "name": "LDS Library Reference",
+        "author": "Paco Kwon, Stein Ingebretsen",
+        "description": "Easily insert references to scriptures and conference talks from the Church of Jesus Christ of Latterday Saints.",
+        "repo": "ingiestein/obsidian-lds-scriptures-plugin"
+    },
+    {
+        "id": "css-inlay-colors",
+        "name": "CSS Inlay Colors",
+        "author": "Benji Grant",
+        "description": "Show inline color hints for CSS colors",
+        "repo": "GRA0007/obsidian-css-inlay-colors"
+    },
+    {
+        "id": "gtp-preview",
+        "name": "GTP Preview",
+        "author": "Barba828",
+        "description": "Supports rendering of GuitarPro files such as `gtp/gp/gp5/gpx`.",
+        "repo": "Barba828/obsidian-plugin-gtp-preview"
+    },
+    {
+        "id": "structured-tree",
+        "name": "Structured Tree",
+        "author": "Marius Svarverud",
+        "description": "A file explorer for navigating hierarchical notes separated by '.'",
+        "repo": "Rudtrack/structured-tree"
+    },
+    {
+        "id": "current-file",
+        "name": "Current File",
+        "author": "Mark Fowler",
+        "description": "Allows external applications to know what file the desktop app is currently viewing.",
+        "repo": "2shortplanks/current-file"
+    },
+    {
+        "id": "arcane-obfuscate",
+        "name": "Arcane Obfuscate",
+        "author": "Shusako",
+        "description": "Obfuscate text with an arcane runic effect.",
+        "repo": "Shusako/arcane-obfuscate"
+    },
+    {
+        "id": "todoistprojectsync",
+        "name": "Todoist Project sync",
+        "author": "Jonas Dam",
+        "description": "Synchronizes projects from Todoist, creating a note for each.",
+        "repo": "stuporfly/ObsidianTodoistProjects"
+    },
+    {
+        "id": "recursive-copy",
+        "name": "Recursive Copy",
+        "author": "datawitch",
+        "description": "Recursively copies all Markdown files in a folder, concatenates them, and copies them into the clipboard.",
+        "repo": "StructByLightning/obsidian-recursive-copy"
+    },
+    {
+        "id": "blockreffer",
+        "name": "Blockreffer",
+        "author": "tyler.earth",
+        "description": "Search and embed blocks with ^block-references.",
+        "repo": "tyler-dot-earth/obsidian-blockreffer"
+    },
+    {
+        "id": "emera",
+        "name": "Emera",
+        "author": "OlegWock",
+        "description": "Enables you to use custom React components and inline JavaScript, kinda like MDX.",
+        "repo": "OlegWock/obsidian-emera"
+    },
+    {
+        "id": "ai-latex-generator",
+        "name": "AI LaTeX Generator",
+        "description": "Convert natural language to LaTeX equations using a local LLM.",
+        "author": "Aayush Shah",
+        "repo": "aaaaayushh/ai-latex-generator"
+    },
+    {
+        "id": "listen-up",
+        "name": "Listen Up!",
+        "author": "Tejas H",
+        "description": "Covert text to natural voice audio, locally - Listen Up!",
+        "repo": "tejas-hosamani/obsidian-plugin-text-to-speech"
+    },
+    {
+        "id": "serendipity",
+        "name": "Serendipity",
+        "author": "Gaurav Ramesh",
+        "description": "Forces serendipitous discoveries by displaying random notes from your vault each time you open the app",
+        "repo": "ggauravr/obsidian-serendipity-plugin"
+    },
+    {
+        "id": "note-reviewer",
+        "name": "Note Reviewer",
+        "author": "Travis Linkey",
+        "description": "Plugin to filter and review notes",
+        "repo": "TravisLinkey/note-reviewer"
+    },
+    {
+        "id": "abbreviations-mark",
+        "name": "Abbreviations and Acronyms",
+        "description": "Implements automatic marking of abbreviations and acronyms (terminology).",
+        "author": "dragonish",
+        "repo": "dragonish/obsidian-abbreviations"
+    },
+    {
+        "id": "mahjong-renderer",
+        "name": "Mahjong Renderer",
+        "author": "hypersphere",
+        "description": "Render mahjong tiles (riichi mahjong) using MPSZ notation",
+        "repo": "h-sphere/obsidian-mahjong-renderer"
+    },
+    {
+        "id": "external-file-card",
+        "name": "External File Card",
+        "author": "James-Yu",
+        "description": "Display file cards for external files.",
+        "repo": "James-Yu/external-file-card"
+    },
+    {
+        "id": "vitepress-publisher",
+        "name": "Vitepress Publisher",
+        "author": "mistj",
+        "description": "Conveniently preview and publish Markdown files using vitepress.",
+        "repo": "tyrad/obsidian-vitepress"
+    },
+    {
+        "id": "keepsidian",
+        "name": "KeepSidian",
+        "author": "lc0rp",
+        "description": "Commands to import Google Keep notes.",
+        "repo": "lc0rp/KeepSidian"
+    },
+    {
+        "id": "suggest-notes",
+        "name": "Suggest Notes",
+        "author": "Doggy-Footprint",
+        "description": "Suggest notes as selected by user.",
+        "repo": "Doggy-Footprint/Obsidian-keyword-suggest"
+    },
+    {
+        "id": "file-share",
+        "name": "File Share",
+        "author": "muckmuck",
+        "description": "Enables end-to-end encrypted file sharing directly between vaults through a socket server.",
+        "repo": "muckmuck96/obsidian-file-share"
+    },
+    {
+        "id": "canvas-explorer",
+        "name": "Canvas Explorer",
+        "author": "Henri Jamet",
+        "description": "Explore your vault by iteratively adding or ignoring linked notes, ultimately generating a customizable canvas that visually represents the preserved notes and their connections.",
+        "repo": "hjamet/Canvas-Explorer"
+    },
+    {
+        "id": "lazy-plugins",
+        "name": "Lazy Plugin Loader",
+        "author": "Alan Grainger",
+        "description": "Load plugins with a delay on startup, so that you can get your app startup down into the sub-second loading time.",
+        "repo": "alangrainger/obsidian-lazy-plugins"
+    },
+    {
+        "id": "battery-indicator",
+        "name": "Battery Indicator",
+        "author": "Kacper Darowski",
+        "description": "Displays current battery level in the status bar.",
+        "repo": "Opisek/obsidian-battery-indicator"
+    },
+    {
+        "id": "virustotal-enrich",
+        "name": "Virus Total Enrichment",
+        "author": "ytisf",
+        "description": "Enrich your notes with information from VirusTotal.",
+        "repo": "ytisf/virustotal-enrich"
+    },
+    {
+        "id": "snippets-manager",
+        "name": "Snippets Manager",
+        "author": "Venkatraman Dhamodaran",
+        "description": "Snippets manager with full mobile support. You can manage code snippets, infos like passport number, email signature or anything.",
+        "repo": "ramandv/obsidian-snippets-manager"
+    },
+    {
+        "id": "css-inserter",
+        "name": "CSS Inserter",
+        "author": "Erika Gozar",
+        "description": "Inserts user-defined CSS snippets into the selected text.",
+        "repo": "Erallie/css-inserter"
+    },
+    {
+        "id": "anysocket-sync",
+        "name": "AnySocket Sync",
+        "author": "Andrei Vaduva",
+        "description": "Self-Hosted synchronization for you Vault using AnySocket",
+        "repo": "lynxaegon/obsidian-anysocket-sync"
+    },
+    {
+        "id": "live-variables",
+        "name": "Live Variables",
+        "author": "Hamza Ben Yazid",
+        "description": "Define variables in your note's properties and reuse them throughout your content.",
+        "repo": "HamzaBenyazid/obsidian-live-variables"
+    },
+    {
+        "id": "imgbb-uploader",
+        "name": "ImgBB Uploader",
+        "author": "Jordan Handy",
+        "description": "Upload images from your clipboard to ImgBB.",
+        "repo": "jordanhandy/obsidian-imgbb-uploader"
+    },
+    {
+        "id": "import-github-readme",
+        "name": "Import GitHub Readme",
+        "author": "Chasebank87",
+        "description": "Allows you to import a GitHub README file into your vault.",
+        "repo": "chasebank87/import-github-readme"
+    },
+    {
+        "id": "backtick-text-selector",
+        "name": "Backtick text selector",
+        "author": "Ram Rachum",
+        "description": "Easily select text in backticks.",
+        "repo": "cool-RR/backtick-text-selector"
+    },
+    {
+        "id": "daily-note-collector",
+        "name": "Daily Note Collector",
+        "author": "Adar Butel",
+        "description": "Adds links to new notes to your daily note.",
+        "repo": "LA/obsidian-daily-note-collector"
+    },
+    {
+        "id": "quick-cards",
+        "name": "Quick Cards",
+        "author": "Camus Qiu",
+        "description": "Cardify your files.",
+        "repo": "abcamus/obsidian-quick-card"
+    },
+    {
+        "id": "vault-to-blog",
+        "name": "Vault to blog",
+        "author": "barkstone2",
+        "description": "Publish the vault to a GitHub Pages blog.",
+        "repo": "barkstone2/vault-to-blog"
+    },
+    {
+        "id": "tailwind-snippet",
+        "name": "Tailwind Snippet",
+        "author": "Nicholas Wilcox",
+        "description": "Use TailwindCSS utility classes in your markup.",
+        "repo": "nicholas-wilcox/tailwind-snippet-obsidian-plugin"
+    },
+    {
+        "id": "simple-sketch",
+        "name": "simple-sketch",
+        "author": "Yoh",
+        "description": "Create minimalist sketches in a dedicated view, draw with a pencil, generate shapes, add text, save it to the vault or download it as an image.",
+        "repo": "Yohh/obsidian-simple-sketch"
+    },
+    {
+        "id": "pug-templates",
+        "name": "Pug Templates",
+        "author": "Nicholas Wilcox",
+        "description": "Use the Pug templating engine in your vault.",
+        "repo": "nicholas-wilcox/pug-templates-obsidian-plugin"
+    },
+    {
+        "id": "draw-steel-elements",
+        "name": "Draw Steel Elements",
+        "author": "Scott Tomaszewski (Xentis)",
+        "description": "Components to support the Draw Steel TTRPG by MCDM.",
+        "repo": "SteelCompendium/draw-steel-elements"
+    },
+    {
+        "id": "highlight-active-folder-section",
+        "name": "Highlight active folder section",
+        "author": "Lukas Collier",
+        "description": "Highlight the active folder section and the title in the file explorer.",
+        "repo": "justanotherjurastudent/highlight-active-folder-section"
+    },
+    {
+        "id": "canvas-task-importer",
+        "name": "Canvas LMS Task Importer",
+        "author": "jordaeday",
+        "description": "Import assignments from Canvas LMS.",
+        "repo": "jordaeday/canvas-task-importer"
+    },
+    {
+        "id": "tokenz",
+        "name": "Tokenz",
+        "author": "Ferenc Moricz",
+        "description": "Insert any type of short codes into your document. You can add smileys (:), ;), ...) or emojis (:smile:, :wink:, ...). More code maps will be added later. Even you, as a user can create your own.",
+        "repo": "ferenk/obsidian-tokenz"
+    },
+    {
+        "id": "diarian",
+        "name": "Diarian",
+        "author": "Erika Gozar",
+        "description": "All-in-one journaling toolkit.",
+        "repo": "Erallie/diarian"
+    },
+    {
+        "id": "nexus-ai-chat-importer",
+        "name": "Nexus AI Chat Importer",
+        "author": "Superkikim",
+        "description": "Import conversations from ChatGPT export files.",
+        "repo": "superkikim/nexus-ai-chat-importer"
+    },
+    {
+        "id": "auto-periodic-notes",
+        "name": "Auto Periodic Notes",
+        "author": "Jamie Hurst",
+        "description": "Creates new periodic notes automatically in the background and allows these to be pinned in your open tabs, requires the Periodic Notes plugin.",
+        "repo": "jamiefdhurst/obsidian-auto-periodic-notes"
+    },
+    {
+        "id": "mesh-ai",
+        "name": "Mesh AI",
+        "author": "Chasebank87",
+        "description": "Enables you to store AI prompts as patterns and run them seemlessly with most providers.",
+        "repo": "chasebank87/mesh-ai"
+    },
+    {
+        "id": "onto-tracker",
+        "name": "Onto Tracker",
+        "author": "Jacob Hart",
+        "description": "Manage projects according to an ontology.",
+        "repo": "jdchart/onto-tracker"
+    },
+    {
+        "id": "journaling",
+        "name": "Journaling",
+        "author": "Ordeeper",
+        "description": "View daily notes in a journal-like format, similar to Logseq. It enhances note organization and facilitates better reflection by consolidating daily notes into a continuous journaling view.",
+        "repo": "Ordeeper/obsidian-journaling-plugin"
+    },
+    {
+        "id": "shortcut-edit-mode",
+        "name": "Edit mode switch",
+        "author": "Mara-Li",
+        "description": "Add a button in the file header, in edit mode, to switch between source and live-preview.",
+        "repo": "Mara-Li/obsidian-edit-shortcut"
+    },
+    {
+        "id": "print",
+        "name": "Print",
+        "author": "Marijn Bent",
+        "description": "Print notes and documents directly from your workspace.",
+        "repo": "marijnbent/obsidian-print"
+    },
+    {
+        "id": "morgen-tasks",
+        "name": "Morgen Tasks",
+        "author": "Morgen AG",
+        "description": "Plan, time block, and track tasks from your vault in any calendar using Morgen.",
+        "repo": "morgen-so/morgen-obsidian"
+    },
+    {
+        "id": "immich",
+        "name": "Immich",
+        "author": "Talal Abou Haiba",
+        "description": "Link your Immich images within your vault.",
+        "repo": "Talal-A/obsidian-immich"
+    },
+    {
+        "id": "verovio-music-renderer",
+        "name": "Verovio Music Renderer",
+        "author": "Kornelius Paede",
+        "description": "Verovio Music Renderer displays musical notation from various formats (MEI, MusicXML, abc) and plays it back.",
+        "repo": "kpaede/Verovio-Music-Renderer"
+    },
+    {
+        "id": "card-navigator",
+        "name": "Card Navigator",
+        "author": "wakeyi",
+        "description": "Navigate your notes visually with card-based interface",
+        "repo": "wakeyi-git/obsidian-card-navigator-plugin"
+    },
+    {
+        "id": "callout-menu",
+        "name": "Callout menu",
+        "author": "Anareaty",
+        "description": "Adds some extra options to callouts context menu and allows you to add your own custom callouts.",
+        "repo": "anareaty/callout-menu"
+    },
+    {
+        "id": "enhanced-image",
+        "name": "Enhanced Image",
+        "author": "situ2001",
+        "description": "Enhance the experience of image seamlessly. For example, operations for image in context menu, command palette.",
+        "repo": "situ2001/obsidian-enhanced-image"
+    },
+    {
+        "id": "poker-range",
+        "name": "Poker Range",
+        "author": "marplek",
+        "description": "Create a poker range grid",
+        "repo": "marplek/obsidian-poker-range"
+    },
+    {
+        "id": "spaced-everything",
+        "name": "Spaced everything",
+        "author": "Zach Mueller",
+        "description": "Apply spaced repetition algorithms to everything in your vault.",
+        "repo": "zachmueller/spaced-everything"
+    },
+    {
+        "id": "epiphany",
+        "name": "Epiphany",
+        "author": "Epiphany",
+        "description": "Synchronize voice notes from the Epiphany app directly into your vault",
+        "repo": "Epiphany-Notes/epiphany-obsidian-plugin"
+    },
+    {
+        "id": "pexels-banner",
+        "name": "Pixel Banner",
+        "author": "Justin Parker",
+        "description": "Apply an image from various sources as a banner to your notes.",
+        "repo": "jparkerweb/pixel-banner"
+    },
+    {
+        "id": "rich-foot",
+        "name": "Rich Foot",
+        "author": "Justin Parker",
+        "description": "Adds backlink tags and created/modified dates to the footer of your notes.",
+        "repo": "jparkerweb/rich-foot"
+    },
+    {
+        "id": "pintora",
+        "name": "Pintora",
+        "author": "Amias Lee",
+        "description": "Generates diagrams using Pintora.",
+        "repo": "amiaslee/obsidian-pintora"
+    },
+    {
+        "id": "alignment-tracker",
+        "name": "Alignment Tracker",
+        "author": "LittleOwl",
+        "description": "Track character alignment using a 3x3 grid.",
+        "repo": "FioPio/ObsidianAlignmentTracker"
+    },
+    {
+        "id": "auto-pause",
+        "name": "AutoPause",
+        "author": "Chris Kephart",
+        "description": "Allows one audio track to be played at a time, pausing or stopping any others.",
+        "repo": "ckep1/obsidian-AutoPause"
+    },
+    {
+        "id": "code-language-completer",
+        "name": "Code Language Completer",
+        "author": "Stanley Wang",
+        "description": "Autosuggests and completes codeblock language options based on history.",
+        "repo": "Stanley-Wang910/obsidian-code-language-completer"
+    },
+    {
+        "id": "guitar-chord",
+        "name": "Guitar Chord",
+        "author": "Barba828",
+        "description": "Quickly enter and display guitar chords, with optional chords based on music theory. No need to write in code blocks, they can be inserted and edited directly in the document.",
+        "repo": "Barba828/obsidian-plugin-chord"
+    },
+    {
+        "id": "symlink-creator",
+        "name": "Symlink Creator",
+        "author": "Tobias Heidler",
+        "description": "Create symlinks to files and folders inside and outside of your vault.",
+        "repo": "pteridin/obsidian_symlink_plugin"
+    },
+    {
+        "id": "remove-unused-block-ids",
+        "name": "Remove Unused Block IDs",
+        "author": "Daniel Geneta",
+        "description": "Remove unused block ids in your vault.",
+        "repo": "isdmg/obsidian-remove-unused-block-ids"
+    },
+    {
+        "id": "collapse-linked-mentions",
+        "name": "Collapse Linked Mentions",
+        "author": "Nathan K.",
+        "description": "Automatically collapse embedded backlink mentions",
+        "repo": "n810K/obsidian-collapse-linked-mentions"
+    },
+    {
+        "id": "remove-html-tag",
+        "name": "Remove HTML Tag",
+        "author": "ChenPengyuan",
+        "description": "Remove HTML tags from Markdown files",
+        "repo": "gitcpy/obsidian-remove-html-tag"
+    },
+    {
+        "id": "diagram-zoom-drag",
+        "name": "Diagram Zoom Drag",
+        "author": "ChenPengyuan",
+        "description": "Add zoom and drag functionality to diagrams from Mermaid, Plantuml, Graphviz, Gravizo and so on",
+        "repo": "gitcpy/diagram-zoom-drag"        
+    },
+	{
+        "id": "figma-embed",
+        "name": "Figma Embed",
+        "author": "Kyle Kochanek",
+        "description": "Embed Figma files as inline previews.",
+        "repo": "kocheck/obsidian-figma-viewer"
+    },
+    {
+        "id": "xmind-viewer",
+        "name": "XMind Viewer",
+        "author": "Sentiago",
+        "description": "Integrate viewing of your XMind files",
+        "repo": "Ssentiago/obsidian-xmind-viewer"
+    },
+    {
+        "id": "auto-strikethrough-task",
+        "name": "Auto Strikethrough Tasks",
+        "author": "Nomekuma",
+        "description": "Automatically adds strikethrough to completed tasks.",
+        "repo": "Nomekuma/auto-strikethrough-task-obsidian-pluggin"
+    },
+    {
+        "id": "colorizelt",
+        "name": "Colorizelt",
+        "author": "Artsem Holub (WiNE-iNEFF)",
+        "description": "Easy color and clear selected text",
+        "repo": "WiNE-iNEFF/colorizelt"
+    },
+    {
+        "id": "magic-mic",
+        "name": "Magic Mic",
+        "author": "Drew McDonald",
+        "description": "Record, transcribe, and summarize audio directly into your vault with custom assistants.",
+        "repo": "drewmcdonald/obsidian-magic-mic"
+    },
+    {
+        "id": "editing-mode-hotkey",
+        "name": "Editing Mode Hotkey",
+        "author": "Signynt",
+        "description": "Adds a command and hotkey to toggle the default editing mode (between Live Preview and Source)",
+        "repo": "Signynt/obsidian-editing-mode-hotkey"
+    },
+    {
+        "id": "hierarchy",
+        "name": "Hierarchy",
+        "author": "Kodai Nakamura",
+        "description": "Visualize the hierarchy of your link.",
+        "repo": "kdnk/obsidian-hierarchy"
+    },
+     {
+        "id": "minimize-on-close",
+        "name": "Minimize on Close",
+        "author": "Andrea Alberti",
+        "description": "Minimizes the app window to an icon after closing the last open pane",
+        "repo": "alberti42/obsidian-minimize-on-close" 
+     },
+    {
+        "id": "custom-node-size",
+        "name": "Custom Node Size",
+        "author": "jackvonhouse",
+        "description": "Customize nodes size for improved graph understanding.",
+        "repo": "jackvonhouse/custom-node-size"
+  },
+  {
+      "id": "mermaid-popup",
+      "name": "Diagram Popup",
+      "author": "ChenPengyuan",
+      "description": "Show diagrams, from Mermaid, PlantUML, Graphviz and so on, in a draggable and zoomable popup",
+      "repo": "gitcpy/obsidian-diagram-popup"
+  },
+  {
+    "id": "newledge",
+    "name": "新枝Newledge",
+    "author": "新枝Newledge",
+    "description": "Import Newledge data.",
+    "repo": "DepartingAgain/obsidian-newledge"
+  },
+  {
+        "id": "immersive-translate",
+        "name": "Immersive Translate",
+        "author": "imfenghuang",
+        "description": "A free-to-use translatation service for foreign language markdown file.",
+        "repo": "imfenghuang/obsidian-immersive-translate"
+  },
+  {
+	"id": "scripture-indexer",
+	"name": "Scripture Indexer",
+	"author": "jdrbrn",
+	"description": "Indexes references to scriptures in notes.",
+	"repo": "jdrbrn/obsidian-scripture-indexer"
+  },
+  {
+        "id": "open-sidebar-on-hover",
+        "name": "Open Sidebar on Hover",
+        "author": "AnAngryRaven",
+        "description": "Enables the ability to open the sidebar by hovering over it.",
+        "repo": "AnAngryRaven/obsidian-open-sidebar-on-hover"
+  },
+  {
+    "id": "onlyworlds-builder",
+    "name": "OnlyWorlds Builder",
+    "author": "Titus",
+    "description": "World building toolset with OnlyWorlds integration.",
+    "repo": "OnlyWorlds/obsidian-plugin"
+    },
+    {
+        "id": "command-tracker",
+        "name": "Command Tracker",
+        "author": "namikaze-40p",
+        "description": "Track the number of times the command is used.",
+        "repo": "namikaze-40p/obsidian-command-tracker"
+    },
+    {
+        "id": "llm-summary",
+        "name": "LLM Summary",
+        "author": "QSun",
+        "description": "Quick note taking with the help of LLMs. LLMs help you to summarize / organize PDFs or existing notes.",
+        "repo": "larksq/obsidian-llm-summary"
+    },
+    {
+        "id": "bookxnote-sync",
+        "name": "BookXNote Sync",
+        "author": "CodeListening",
+        "description": "同步bookxnote中的读书笔记",
+        "repo": "CodeListening/obsidian-bookxnote"
+    },
+    {
+        "id": "find-orphaned-images",
+        "name": "Find Orphaned Images",
+        "author": "Josmar Cristello",
+        "description": "Finds images in the vault that are not linked to any notes. Either lists, or deletes them.",
+        "repo": "josmarcristello/Obsidian-Find-Orphaned-Images"
+    },
+    {
+        "id": "link-navigation",
+        "name": "Link Navigation",
+        "author": "xRyul",
+        "description": "Navigate between incoming links (inlinks), outgoing links (outlinks) N levels deep. Links from Canvas are also supported.",
+        "repo": "xRyul/link-navigation"
+    },
+    {
+        "id": "modal-opener",
+        "name": "Modal Opener",
+        "author": "Muuxi",
+        "description": "Open files and links in modal windows, or create and edit compatible files in modal windows.",
+        "repo": "likemuuxi/obsidian-modal-opener"
+    },
+    {
+        "id": "mouse-navigation",
+        "name": "Mouse Navigation",
+        "author": "HoBeomJeon",
+        "description": "Enables smooth navigation using mouse gestures for scrolling and switching pages.",
+        "repo": "hobeom/obsidian-mouse-navigation"
+    },
+	{
+  		"id": "ffmpeg-converter",
+		"name": "Ffmpeg Converter",
+		"author": "MrAnyx",
+		"description": "Convert most used file formats into another format to optimize your vault space.",
+		"repo": "MrAnyx/obsidian-ffmpeg-converter"
+    },
+    {
+        "id": "crackboard",
+        "name": "Crackboard",
+        "author": "Franklin",
+        "description": "tpot leaderboard productivity tracker",
+        "repo": "bruce-pain/crackboard-obsidian"
+	},
+    {
+        "id": "quick-notes",
+        "name": "Quick Notes",
+        "author": "Sean McOwen",
+        "description": "Speeds up some note taking abilities and allows for creating notes/links in the background",
+        "repo": "SeanMcOwen/Quick-Note-Obsidian-Plugin"
+    },
+  {
+    "id": "typefully",
+    "name": "Typefully",
+    "author": "Sébastien Dubois",
+    "description": "Typefully integration. Publish social media posts with ease",
+    "repo": "dsebastien/obsidian-typefully"
+    },
+    {
+        "id": "infranodus-graph-view",
+        "name": "InfraNodus AI Graph View",
+        "author": "Nodus Labs",
+        "description": "Interactive 3D graph view: text analysis, topic modeling, gap detection, and AI.",
+        "repo": "noduslabs/infranodus-obsidian-plugin"
+    },
+    {
+        "id": "open-interpreter",
+        "name": "Open Interpreter",
+        "author": "Mike Bird",
+        "description": "An AI assistant that you can control with natural language. The power of Open Interpreter in your vault",
+        "repo": "MikeBirdTech/obsidian-open-interpreter"
+  },
+	{
+		"id": "scrambling-title-animations",
+		"name": "Scrambling Title Animations",
+		"author": "HistidineDwarf",
+		"description": "Animates the title of any note you open by scrambling and revealing it in several visually appealing ways.",
+		"repo": "DvorakDwarf/scrambling-title-animations"
+    },
+    {
+        "id": "lemons-search",
+        "name": "Lemons Search",
+        "author": "Moritz Jung",
+        "description": "A blazingly fast fuzzy finder with file preview.",
+        "repo": "mProjectsCode/obsidian-lemons-search-plugin"
+    },
+    {
+        "id": "flow",
+        "name": "Flow",
+        "author": "Ben Phillips",
+        "description": "Implements key processes in David Allen's Getting Things Done (GTD) methodology",
+        "repo": "tavva/flow-release"
+    },
+    {
+        "id": "quarto-exporter",
+        "name": "Quarto Exporter",
+        "author": "Andreas Varotsis",
+        "description": "Export notes to Quarto-compatible QMD files.",
+        "repo": "AndreasThinks/obsidian-to-quarto-exporter"
+    },
+    {
+        "id": "copy-section",
+        "name": "Copy Section",
+        "author": "skztr",
+        "description": "Adds a Copy button to the top of Headed sections.",
+        "repo": "skztr/obsidian-plugin-section-copy"
+    },
+   {
+        "id": "cloud-storage",
+        "name": "Cloud Storage",
+        "author": "Jiajun Ma",
+        "description": "Allows users to upload local files to the cloud, reducing the burden on local vaults and enabling seamless synchronization across multiple devices.",
+        "repo": "yingjialong/obsidian-CloudStorage"
+	},
+  { 
+        "id": "local-media-embedder",
+        "name": "Local Media Embedder",
+        "author": "seyf1elislam", 
+        "description": "Embed videos and images and audios from your local device in your notes.", 
+        "repo": "seyf1elislam/obsidian-LocalMediaEmbedder-plugin" 
+    },
+  {
+      "id": "tab-panels",
+      "name": "Tab Panels",
+      "author": "GnoxNahte",
+      "description": "Create tab panels to organize content into sections",
+      "repo": "GnoxNahte/obsidian-tab-panels"
+  },
+  {
+      "id": "jura-links",
+      "name": "Jura Links",
+      "author": "Lukas Collier & Emi Le",
+      "description": "Verlinke deine notierten Gesetzesnormen, Aktenzeichen und Zeitschriften-Fundstellen mit Gesetzesanbietern.",
+      "repo": "justanotherjurastudent/Jura-Links"
+  },
+  {
+      "id": "advanced-copy",
+      "name": "Advanced Copy",
+      "author": "leschuster",
+      "description": "Copy Markdown and transform it according to your needs.",
+      "repo": "leschuster/obsidian-advanced-copy"
+  },
+    {
+        "id": "nav-link-header",
+        "name": "Nav Link Header",
+        "author": "ahts4962",
+        "description": "Display navigation links at the top of the notes.",
+        "repo": "ahts4962/nav-link-header"
+    },
+  {
+      "id": "japanese-novel-ruby",
+      "name": "Japanese Novel Ruby",
+      "author": "quels <@k-quels>",
+      "description": "Treat ruby(Furigana) ​​marks commonly used in Japanese novels",
+      "repo": "k-quels/japanese-novel-ruby"
+  },
+  {
+    "id": "asciidoctor-editor",
+    "name": "Asciidoctor editor",
+    "author": "dzruyk",
+    "description" : "View and modify asciidoc pages",
+    "repo": "dzruyk/obsidian-asciidoc"
+  },
+  {
+      "id": "replace-all",
+      "name": "Replace All",
+      "author": "Patrick Chiang",
+      "description": "Adds replace all functionality into search.",
+      "repo": "patrickchiang/obsidian-replace-all"
+  },
+  {
+	"id": "metadata-auto-classifier",
+	"name": "Metadata Auto Classifier",
+	"author": "Beomsu Koh",
+	"description": "Automatically classifies and applies metadata to your notes.",
+    "repo": "GoBeromsu/Metadata-Auto-Classifier"
+  },
+    {
+        "id": "strava-sync",
+        "name": "Strava Sync",
+        "author": "Howard Wilson",
+        "description": "Sync activities from Strava.",
+        "repo": "watsonbox/obsidian-strava-sync"
+    },
+    {
+        "id": "another-simple-todoist-sync",
+        "name": "Another Simple Todoist Sync",
+        "author": "eudennis",
+        "description": "Simple plugin to sync with Todoist. Fork from Ultimate Todoist Sync plugin.",
+        "repo": "eudennis/ultimate-todoist-sync-for-obsidian-experiment"
+
+    },
+  {
+    "id": "translate-inline",
+    "name": "Translate Inline",
+    "author": "Lucas Langholf",
+    "description": "Translations at your fingertips. Inline Translations for your Notes.",
+    "repo": "kon-foo/Obsidian-Translate-Inline"
+  },
+  {
+    "id": "youtube-iframe-timestamps",
+    "name": "Youtube Iframe Timestamps",
+    "description": "Allows you to embed YouTube videos with timestamps directly in your notes, enabling seamless referencing and note-taking without needing to open a separate browser window.",
+    "author": "Nils Leo",
+    "repo": "NilsLeo/obsidian-youtube-iframe-timestamps"
+  },
+  {
+    "id": "random-retrieval",
+    "name": "random-retrieval",
+    "author": "Rachninomav",
+    "description": "Random Note Retrieval based on LLM.",
+    "repo": "JeanJean-rxl/random-retrieval-plugin"
+  },
+  {
+	"id": "occura-word-highlighter",
+	"name": "Occura",
+	"author": "Alexey Sedoykin",
+	"description": "Find and highlight all occurrences of selected text in notes, similar to Notepad++ or IDEs.",
+	"repo": "Krusty84/obsidian-occura-plugin"
+    },
+  {
+    "id": "callout-toggles",
+    "name": "Callout Toggles",
+    "author": "Aly Thobani",
+    "description": "Quickly add, change, or remove callouts in your notes.",
+    "repo": "alythobani/obsidian-callout-toggles"
+  },
+  {
+    "id": "separate-explorer-views",
+    "name": "Separate Explorer Views",
+    "description": "Adds ribbon icons to toggle between file explorer, search, and bookmarks views",
+    "author": "eriolloan",
+    "repo": "eriolloan/obsidian-separate-explorer-views"
+  }
+]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL
Link to my plugin: https://github.com/eriolloan/obsidian-separate-explorer-views

## Release Checklist
- [x] I have tested the plugin on
  - [ ] Windows
  - [ ] macOS
  - [x] Linux
  - [ ] Android _(if applicable)_
  - [ ] iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.