### PR TITLE
Update Luminex theme to support both dark and light modes

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2179,6 +2179,6 @@
     "author": "abhimangs",
     "repo": "abhimangs/Obsidian-Luminex",
     "screenshot": "Assets/Obsidian-Cover.png",
-    "modes": ["dark"]
+    "modes": ["dark", "light"]
   }
 ]


### PR DESCRIPTION
Hello **Obsidian team**,

I am submitting this pull request to update the theme metadata for my theme, Luminex. Previously, Luminex supported only dark mode, but I have recently added light mode support as well. This change is reflected in the modes property of the theme metadata, which has been updated from **["dark"]** to **["dark", "light"]**.

**Summary of Changes:**
Theme Modes: Added support for light mode alongside the existing dark mode.
GitHub Repository: All necessary updates, including light mode styles, are already published in my GitHub repository ([abhimangs/Obsidian-Luminex](https://github.com/abhimangs/Obsidian-Luminex)).
This update allows users to switch between dark and light modes depending on their preference. The theme should now provide a seamless experience across both modes, enhancing usability in different lighting environments.

Thank you for considering this update! Please let me know if there’s any additional information I can provide.

Best regards,
Abhiman G S
GitHub: @abhimangs
Email: theabhimangs@gmail.com