### PR TITLE
Add FastForwardLink plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13882,4 +13882,3 @@
       "repo": "IdanLib/ObsidianFastForwardLinkPlugin"
     },
 ]
-

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13859,6 +13859,13 @@
       "author": "Fabrice Hong",
       "description": "Create reusable, modular prompts.",
       "repo": "fabricehong/obsidian-prompt-crafter-plugin"
+    },
+    {
+    "id": "fast-forward-link",
+    "name": "FastForwardLink",
+    "author": "Idan Liberman",
+    "description": "Fast-forward multiple links to a single target note. Create custom link shorthands (like `ps` > `photoshop`) to create synonyms, streamline navigation, and keep your vault organized.",
+    "repo": "IdanLib/ObsidianFastForwardLinkPlugin"
     }
 ]
 


### PR DESCRIPTION
Add FastForwardLink, a plugin that lets you use multiple links to a single target note.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [ ]  macOS
  - [X]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
