### PR TITLE
Add plugin: Better File Explorer

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14067,7 +14067,7 @@
   "id": "better-file-explorer",
   "name": "Better File Explorer",
   "author": "Jim",
-  "description": "Show quick add buttons when hovering over folders",
+  "description": "Show quick add buttons when hovering over folders.",
   "repo": "jkj-jim/better-file-explorer"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14062,6 +14062,13 @@
     "author": "Omri Levi",
     "description": "Updates numbered lists automatically to keep them in sequential order. Features live updates, smart pasting, and manual control options.",
     "repo": "OmriLeviGit/Automatic-Renumbering-Obsidian"
+  },
+  {
+  "id": "better-file-explorer",
+  "name": "Better File Explorer",
+  "author": "Jim",
+  "description": "Show quick add buttons when hovering over folders",
+  "repo": "jkj-jim/better-file-explorer"
   }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:https://github.com/jkj-jim/better-file-explorer

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
      
