### PR TITLE
Add plugin: Link Preview

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14208,5 +14208,12 @@
     "author": "dangehub",
     "description": "Blur anything you want to keep your privacy.",
     "repo": "dangehub/obsidian-blur-mode"
-  }
+  },
+  {
+    "id": "link-preview",
+    "name": "Link Preview",
+    "author": "Felipe Tappata",
+    "description": "Show a preview of external links on hover",
+    "repo": "felipetappata/obsidian-link-preview"
+}
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:  [https://github.com/felipetappata/obsidian-link-preview](https://github.com/felipetappata/obsidian-link-preview)

## Release Checklist
- [x] I have tested the plugin on
  - [x] Windows
  - [x] macOS
  - [x] Linux
  - [x] Android _(if applicable)_
  - [x] iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.

