### PR TITLE
Add plugin: Post Webhook

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14272,4 +14272,11 @@
     "description": "Quickly remove all completed todos from your notes or selected text.",
     "repo": "gutentag2012/obsidian-plugin-clear-todos"
   }
+  {
+    "id": "obsidian-post-webhook",
+    "name": "Post Webhook",
+    "author": "MasterB1234",
+    "description": "Send notes to webhook endpoints, for seamless integration with i.a. n8n, Make.com, and Zapier.",
+    "repo": "Masterb1234/obsidian-post-webhook"
+  }	
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14273,7 +14273,7 @@
     "repo": "gutentag2012/obsidian-plugin-clear-todos"
   },
   {
-    "id": "obsidian-post-webhook",
+    "id": "post-webhook",
     "name": "Post Webhook",
     "author": "MasterB1234",
     "description": "Send notes to webhook endpoints, for seamless integration with i.a. n8n, Make.com, and Zapier.",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14271,7 +14271,7 @@
     "author": "Joshua Gawenda",
     "description": "Quickly remove all completed todos from your notes or selected text.",
     "repo": "gutentag2012/obsidian-plugin-clear-todos"
-  }
+  },
   {
     "id": "obsidian-post-webhook",
     "name": "Post Webhook",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Masterb1234/obsidian-post-webhook/ 

## Release Checklist
- [ v] I have tested the plugin on
  - [ v]  Windows
  - [ v]  macOS
  - [ v]  Linux
  - [ v]  Android _(if applicable)_
  - [ v]  iOS _(if applicable)_
- [ v] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [v ] `main.js`
  - [v] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ v] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [v ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [v ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ v] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [v ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [v ] I have added a license in the LICENSE file.
- [ v] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
