### PR TITLE
Add plugin: Cypher

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13999,6 +13999,13 @@
     "author": "Omri Levi",
     "description": "Updates numbered lists automatically to keep them in sequential order. Features live updates, smart pasting, and manual control options.",
     "repo": "OmriLeviGit/Automatic-Renumbering-Obsidian"
+  },
+{
+    "id": "cypher",
+    "name": "Cypher",
+    "author": "Atharva Wankhede",
+    "description": "Hides text in a simple diagrammatic cypher to make reading unrecognizable for viewers.",
+    "repo": "aths7/cypher"
   }
 ]
 


### PR DESCRIPTION
### Title:
Add Cypher Plugin - Icon-Based Text Transformation for Obsidian

### Description:
This pull request adds the **Cypher Text Plugin** to the Obsidian community plugins repository. The plugin allows users to toggle between normal text and icon-based cyphered text, providing a fun way to obscure or visually enhance their notes.

**Repo URL**: [Cypher Text Plugin Repository](https://github.com/aths7/cypher)

**Link to Plugin**: [Obsidian Plugin Directory](https://github.com/aths7/cypher)

---

### Release Checklist:
- **Platform Testing**:
  - [x] Windows
  - [x] macOS
  - [x] Linux
  - [ ] Android (if applicable)
  - [ ] iOS (if applicable)
  
- **GitHub Release Contents**:
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` (optional)

- **Versioning and IDs**:
  - [x] GitHub release name matches the exact version number specified in `manifest.json` (no `v` prefix).
  - [x] The `id` in `manifest.json` matches the `id` in the `community-plugins.json` file.

- **README**:
  - [x] `README.md` describes the plugin's purpose and provides clear usage instructions.

- **Developer Policies**:
  - [x] I have read the developer policies at [Obsidian Developer Policies](https://docs.obsidian.md/Developer+policies) and confirmed that my plugin adheres to these guidelines.

- **Guidelines and Common Pitfalls**:
  - [x] I have reviewed the [Plugin Guidelines and Tips](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines) and performed a self-review to avoid common pitfalls.

- **Licensing**:
  - [x] I have added a license in the LICENSE file.
  - [x] The project respects and is compatible with the original license of any code from other plugins used, and proper attribution is provided in `README.md` if applicable.