### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14003,9 +14003,9 @@
 "id": "automatic-renumbering",
 "name": "Automatic Renumbering",
 "author": "Omri Levi",
-"description": "Updates numbered lists automatically to keep them in sequential order. Features live updates, smart pasting, and manual control options.",
+"description": "Automatically renumber numbered lists as you edit them.",
 "repo": "OmriLeviGit/Automatic-Renumbering-Obsidian"
-  },
+},
 {
     "id": "three-noun-prompts",
     "name": "Three Noun Prompts",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14001,7 +14001,7 @@
 },
 {
 "id": "automatic-renumbering",
-"name": "Automatic Renumbering",
+"name": "Automatic List Renumbering",
 "author": "Omri Levi",
 "description": "Automatically renumber numbered lists as you edit them.",
 "repo": "OmriLeviGit/Automatic-Renumbering-Obsidian"


### PR DESCRIPTION
# Title and description update
**My plugin is already on the community plugin.**
I could not find a way to update the description or the title. If this is not how, I would love to know how to do so. Thank you.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:
https://github.com/OmriLeviGit/Automatic-Renumbering-Obsidian
## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
