### PR TITLE
Update cover image location in theme metadata

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2178,7 +2178,7 @@
     "name": "Luminex",
     "author": "abhimangs",
     "repo": "abhimangs/Obsidian-Luminex",
-    "screenshot": "Assets/Obsidian-Cover.png",
+    "screenshot": "assets/cover-obsidian.png",
     "modes": ["dark", "light"]
   },
   {


### PR DESCRIPTION
This pull request updates the cover image path in the community-css-themes.json file to reflect the new location of the image.

Changes made:

Updated the cover image path from **Assets/Obsidian-Cover.png** to **assets/cover-obsidian.png**.
This ensures the correct display of the theme preview in the community themes list.