### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14313,6 +14313,13 @@
     "author": "vellikhor",
     "description": "Create large quantities of notes easily at one time.",
     "repo": "vellikhor/mass-create"
+    },
+    {
+    "id": "html-markdown-shortcuts",
+    "name": "HTML MD SC",
+    "author": "renebrucknerjnr",
+    "description": "Adds HTML markdown with CSS snippets, as well as shortcuts for them.",
+    "repo": "renebrucknerjnr/obsidian-html-md-shortcuts"
     }
 ]
 


### PR DESCRIPTION
Added html-markdown-shortcuts (HTML MD SC) to the list without deleting vellikhor's Mass Create.

by renebrucknerjnr

# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/renebrucknerjnr/obsidian-html-md-shortcuts

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
