### PR TITLE
Add plugin: Equation Converter

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14369,6 +14369,13 @@
 		"author": "Yunfi",
 		"description": "Upload images in a note, and remove the images from the vault if they're exclusively used within that note.",
 		"repo": "yy4382/obsidian-image-upload"
-  }
+  },
+	{
+    "id": "equation-converter",
+    "name": "Equation Converter",
+    "author": "Nyimbi Odero",
+    "description": "Converts OpenAI-style equation markup to standard markdown equation syntax",
+    "repo": "nyimbi/obsidian-equation-converter"
+}
 ]
 


### PR DESCRIPTION
# Submit a plugin to the community plugin list

## Requirements
- [x] This PR follows the plugin guidelines
- [x] The plugin's `.github/workflows/release.yml` has the correct permissions
- [x] The plugin has at least one release with assets (e.g. `main.js, manifest.json, styles.css`)
- [x] I have added a license in the LICENSE file.

## Plugin information
Link to your plugin repo: https://github.com/nyimbi/obsidian-equation-converter

What does your plugin do? 
Converts OpenAI-style equation markup (\[ \] and \( \)) to standard markdown equation syntax ($$ $$ and $ $). This is particularly useful for users who copy mathematical content from OpenAI interfaces (like ChatGPT) into Obsidian and want to maintain proper equation rendering.

## Release status
Is your plugin ready for the public? Yes

## Checklist
- [x] The title of this PR is in the format "Add Equation Converter plugin"
- [x] The `branch` property in `community-plugins.json` is removed
- [x] Link to repo is valid
- [x] Plugin has valid releases with assets