### PR TITLE
Update Cover Image Path in Theme Files

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2262,7 +2262,7 @@
     "name": "Vortex",
     "author": "abhimangs",
     "repo": "abhimangs/obsidian-vortex",
-    "screenshot": "assets/cover.png",
+    "screenshot": "cover.png",
     "modes": ["dark", "light"]
   },
   {


### PR DESCRIPTION
This PR updates the location of the cover image used in the theme from `assets/cover.png` to `cover.png`