### PR TITLE
Add plugin: Syncthing status icon

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14809,7 +14809,6 @@
     "name": "Syncthing status icon",
     "author": "Diego Viero",
     "description": "Displas a status icon inside the status bar showing whether syncthing is running locally or not.",
-    "repo": "Diego-Viero/Syncthing-status-icon-Obsidian-plugin "
+    "repo": "Diego-Viero/Syncthing-status-icon-Obsidian-plugin"
   }
 ]
-

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14803,6 +14803,13 @@
     "author": "theopavlove",
     "description": "Adds a customizable GitHub-like floating table of contents.",
     "repo": "theopavlove/obsidian-dynamic-outline"
+  },
+  {
+    "id": "syncthing-status-icon",
+    "name": "Syncthing status icon",
+    "author": "Diego Viero",
+    "description": "Displas a status icon inside the status bar showing whether syncthing is running locally or not.",
+    "repo": "Diego-Viero/Syncthing-status-icon-Obsidian-plugin "
   }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/Diego-Viero/Syncthing-status-icon-Obsidian-plugin

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
- [x] I have given proper attribution to these other projects in my `README.md`.
