### PR TITLE
Add plugin: KoReader Highlight Importer

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14819,10 +14819,10 @@
     "repo": "slow-groovin/simple-disguise"
   },
   {
-	"id": "obsidian-koreader-highlights",
+	"id": "koreader-highlights-importer",
 	"name": "KoReader Highlight Importer",
 	"author": "Tahsin Kocaman",
-	"description": "Imports highlights and metadata from KoReader into Obsidian notes",
+	"description": "Imports highlights and metadata from KoReader",
 	"repo": "t5k6/obsidian-koreader-highlights"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14454,14 +14454,14 @@
     "description": "Insert a new line above or below the current line.",
     "repo": "freddyouellette/obsidian-insert-new-line-plugin"
   },
-	{
+  {
     "id": "cypher",
     "name": "Cypher",
     "author": "Atharva Wankhede",
     "description": "Hides text in a simple diagrammatic cypher to make reading unrecognizable for viewers.",
     "repo": "aths7/cypher"
   },
-{
+  {
 	"id": "calloutx",
 	"name": "CalloutX",
 	"author": "br4in",
@@ -14817,5 +14817,12 @@
     "author": "slow-groovin",
     "description": "disguise/obscure/hide the markdown content in a very simple way.",
     "repo": "slow-groovin/simple-disguise"
+  },
+  {
+	"id": "obsidian-koreader-highlights",
+	"name": "KoReader Highlight Importer",
+	"author": "Tahsin Kocaman",
+	"description": "Imports highlights and metadata from KoReader into Obsidian notes",
+	"repo": "t5k6/obsidian-koreader-highlights"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/t5k6/obsidian-koreader-highlights

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
