### PR TITLE
Update Image Converter description in community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7577,7 +7577,7 @@
         "id": "image-converter",
         "name": "Image Converter",
         "author": "xRyul",
-        "description": "Convert, compress, resize, annotate, markup, draw, crop, rotate, flip, align images directly in Obsidian. Drag-resize, rename with variables, batch process. WEBP, JPG, PNG, HEIC, TIF.",
+        "description": "Convert, compress, resize, annotate, markup, draw, crop, rotate, flip, align, drag-resize, rename with variables, and batch process images: WEBP, JPG, PNG, HEIC, TIF",
         "repo": "xryul/obsidian-image-converter"
     },
     {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7577,7 +7577,7 @@
         "id": "image-converter",
         "name": "Image Converter",
         "author": "xRyul",
-        "description": "Convert, compress and resize images from one format to another by dragging and dropping or pasting into the note.",
+        "description": "Convert, compress, resize, annotate, markup, draw, crop, rotate, flip, align images directly in Obsidian. Drag-resize, rename with variables, batch process. WEBP, JPG, PNG, HEIC, TIF.",
         "repo": "xryul/obsidian-image-converter"
     },
     {


### PR DESCRIPTION
Update description to better reflects plugins capabilities and allow to find it easier.

# I am submitting a new Community Plugin

## Repo URL
https://github.com/xRyul/obsidian-image-converter

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
