### PR TITLE
Add plugin: h& anteriorize

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14461,26 +14461,33 @@
     "description": "Insert a new line above or below the current line.",
     "repo": "freddyouellette/obsidian-insert-new-line-plugin"
   },
-	{
+  {
     "id": "cypher",
     "name": "Cypher",
     "author": "Atharva Wankhede",
     "description": "Hides text in a simple diagrammatic cypher to make reading unrecognizable for viewers.",
     "repo": "aths7/cypher"
   },
-{
+  {
 	"id": "calloutx",
 	"name": "CalloutX",
 	"author": "br4in",
 	"description": "An easy way to explore, visualise, and modify callout icons.",
 	"repo": "br4in/calloutX"
-    },
-    {
+   },
+   {
     "id": "sync-cnblog",
     "name": "Sync Cnblog",
     "author": "zhanglei",
     "description": "将笔记同步到博客园",
     "repo": "lei-ctyh/obsidian-sync-cnblog"
-}
+   },
+   {
+    "id": "h-and-anteriorize",
+    "name": "h& anteriorize",
+    "author": "Jean Oustry",
+    "description": "Hash a note or a folder with sha3 and git partially compatible procedure with sha1. Get EIP-681 + EIP-55 enabled URL to easily put the digest in ethereum blockchain.",
+    "repo": "TheVroum/h_and_anteriorize"
+   }
 ]
 


### PR DESCRIPTION
Adding h&-and-anteriorize

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/TheVroum/h_and_anteriorize

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
