### PR TITLE
Add plugin: Image Preview on Icon Hover

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15088,7 +15088,7 @@
     "id": "image-preview-on-icon-hover",
     "name": "Image Preview on Icon Hover",
     "author": "rama1997",
-    "description": "Adds custom image previews when hovering over various icons in Obsidian's UI.",
+    "description": "Adds custom image previews when hovering over various UI icons.",
     "repo": "rama1997/Image-Preview-On-Icon-Hover"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15083,6 +15083,13 @@
     "author": "Daniel Bauer",
     "description": "Adds autocompletion to Dataview metadata fields",
     "repo": "dnlbauer/obsidian-dataview-autocompletion"
+  },
+  {
+    "id": "image-preview-on-icon-hover",
+    "name": "Image Preview on Icon Hover",
+    "author": "rama1997",
+    "description": "Adds custom image previews when hovering over various icons in Obsidian's UI.",
+    "repo": "rama1997/Image-Preview-On-Icon-Hover"
   }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/rama1997/Image-Preview-On-Icon-Hover

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
