### PR TITLE
add prop2folder plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14642,5 +14642,5 @@
     "author": "David Folch Agulles",
     "repo": "davidfolch/obsidian-prop2folder-plugin",
     "description": "Automatically move notes to a directory based on the value of a specified property (e.g., 'type') in their YAML frontmatter. Optionally create directories if they do not exist and delete empty directories after moving notes."
-},
+}
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14635,5 +14635,12 @@
     "author": "wenlzhang",
     "description": "Maintain note links when splitting or reorganizing notes.",
     "repo": "wenlzhang/obsidian-link-maintainer"
-  }
+},
+{
+    "id": "prop2folder",
+    "name": "Prop to Folder",
+    "author": "David Folch Agulles",
+    "repo": "davidfolch/obsidian-prop2folder-plugin",
+    "description": "Automatically move notes to a directory based on the value of a specified property (e.g., 'type') in their YAML frontmatter. Optionally create directories if they do not exist and delete empty directories after moving notes."
+},
 ]


### PR DESCRIPTION
### Description

This Pull Request adds the Prop2Folder plugin to the community plugins list for Obsidian.

**Prop2Folder Plugin** is designed to automatically organize notes within Obsidian based on a specified YAML property in the frontmatter. This plugin helps users maintain a structured and automated organization of their notes.

#### Key Features:
- **Automatic Note Organization**: Moves notes into folders based on a specified YAML property.
- **Customizable Directory Format**: Supports folder name formatting as-is, lowercase, or capitalized.
- **Configurable Base Directory**: Allows setting a base directory for subfolder creation.
- **Empty Directory Deletion**: Option to automatically delete empty directories after moving notes.
- **Process Existing Notes**: Command to organize all existing notes in the vault.

#### Repository:
[https://github.com/davidfolch/obsidian-prop2folder-plugin](https://github.com/davidfolch/obsidian-prop2folder-plugin)
