### PR TITLE
Add plugin: Prop to Folder

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14642,5 +14642,5 @@
     "author": "David Folch Agulles",
     "repo": "davidfolch/obsidian-prop2folder-plugin",
     "description": "Automatically move notes to a directory based on the value of a specified property (e.g., 'type') in their YAML frontmatter. Optionally create directories if they do not exist and delete empty directories after moving notes."
-},
+}
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14635,5 +14635,12 @@
     "author": "wenlzhang",
     "description": "Maintain note links when splitting or reorganizing notes.",
     "repo": "wenlzhang/obsidian-link-maintainer"
-  }
+},
+{
+    "id": "prop2folder",
+    "name": "Prop to Folder",
+    "author": "David Folch Agulles",
+    "repo": "davidfolch/obsidian-prop2folder-plugin",
+    "description": "Automatically move notes to a directory based on the value of a specified property (e.g., 'type') in their YAML frontmatter. Optionally create directories if they do not exist and delete empty directories after moving notes."
+},
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

[https://github.com/davidfolch/obsidian-prop2folder-plugin](https://github.com/davidfolch/obsidian-prop2folder-plugin)
Link to my plugin:

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.