### PR TITLE
Updated github username

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -8332,9 +8332,9 @@
     {
         "id": "table-checkboxes",
         "name": "Markdown table checkboxes",
-        "author": "DylanGiesberts",
+        "author": "0x-DLN",
         "description": "Add support for stateful checkboxes inside Markdown tables.",
-        "repo": "DylanGiesberts/obsidian-table-checkboxes"
+        "repo": "0x-DLN/obsidian-table-checkboxes"
     },
     {
         "id": "image2latex",


### PR DESCRIPTION
Hey, I just updated my plugin but I realized that it's not being updated in the community plugins tab due to my GitHub username being different.


Here's the old PR for reference, you are free to do a new check of course. I've filled out the form below accurately.
https://github.com/obsidianmd/obsidian-releases/pull/2447


# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/0x-DLN/obsidian-table-checkboxes

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
