### PR TITLE
Add plugin: Navigable File Tree

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14641,6 +14641,6 @@
     "name": "Navigable File Tree",
     "author": "jaschen",
     "description": "a file tree with navigation bar and search/sort features",
-    "repo": "Jaschenn/navigable-file-tree/"
+    "repo": "Jaschenn/navigable-file-tree"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14640,7 +14640,7 @@
     "id": "navigable-file-tree",
     "name": "Navigable File Tree",
     "author": "jaschen",
-    "description": "A file tree plugin with navigation bar for Obsidian",
+    "description": "a file tree with navigation bar and search/sort features",
     "repo": "Jaschenn/navigable-file-tree/"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14635,5 +14635,12 @@
     "author": "wenlzhang",
     "description": "Maintain note links when splitting or reorganizing notes.",
     "repo": "wenlzhang/obsidian-link-maintainer"
+  },
+	  {
+    "id": "navigable-file-tree",
+    "name": "Navigable File Tree",
+    "author": "jaschen",
+    "description": "A file tree plugin with navigation bar for Obsidian",
+    "repo": "Jaschenn/navigable-file-tree/"
   }
 ]


### PR DESCRIPTION
add navigable-file-tree plug

# I am submitting a new Community Plugin

## Repo URL


[Link to my plugin](https://github.com/Jaschenn/navigable-file-tree)

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
