### PR TITLE
Add Left Outline plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14635,5 +14635,13 @@
     "author": "wenlzhang",
     "description": "Maintain note links when splitting or reorganizing notes.",
     "repo": "wenlzhang/obsidian-link-maintainer"
-  }
+  },
+ {
+    "id": "left-outline",
+    "name": "Left Outline",
+    "author": "diudiu",
+    "description": "Move outline to left sidebar",
+    "repo": "qianyui/obsidian-left-outline",
+    "branch": "main"
+ }
 ]


### PR DESCRIPTION
# Left Outline Plugin for Obsidian

- **GitHub Repository**: [https://github.com/qianyui/obsidian-left-outline](https://github.com/qianyui/obsidian-left-outline)
- **Plugin ID**: left-outline

## Description
This plugin moves the outline view to the left sidebar in Obsidian, enhancing the user interface and accessibility.

## Release Checklist
- [x] I have tested the plugin on:
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz):
  - [x] main.js
  - [x] manifest.json
  - [x] styles.css (optional)
- [x] GitHub release name matches the exact version number specified in my manifest.json (Note: Use the exact version number, don't include a prefix v).
- [x] The id in my manifest.json matches the id in the community-plugins.json file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at [Developer Policies](https://docs.obsidian.md/Developer+policies) and have assessed my plugin's adherence to these policies.
- [x] I have read the tips in [Plugin Guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines) and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
- [x] I have given proper attribution to these other projects in my README.md.

## Additional Notes
If you have any feedback or need further information, feel free to reach out!