### PR TITLE
Add theme: Emerald Echo

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2301,7 +2301,7 @@
     "modes": ["dark", "light"]
   },
   {
-    "name": "Emerald Green",
+    "name": "Emerald Echo",
     "author": "Malcolm Mielle",
     "repo": "MalcolmMielle/Emerald-Echo",
     "screenshot": "screenshot.png",

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2299,5 +2299,12 @@
     "repo": "aaaaalexis/obsidian-cupertino",
     "screenshot": "cupertino.png",
     "modes": ["dark", "light"]
+  },
+  {
+    "name": "Emerald Green",
+    "author": "Malcolm Mielle",
+    "repo": "MalcolmMielle/Emerald-Echo",
+    "screenshot": "screenshot.png",
+    "modes": ["dark", "light"]
   }
 ]


### PR DESCRIPTION
Add the Emerald-Echo theme

# I am submitting a new Community Theme

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my theme:  https://codeberg.org/MalcolmMielle/Emerald-Echo

(Also mirrored on Github: https://github.com/MalcolmMielle/Emerald-Echo but wondering if it's possible to only use Codeberg instead)

## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `manifest.json`
  - [x] `theme.css`
  - [x] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my theme's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Themes/App+themes/Theme+guidelines and have self-reviewed my theme to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.
