### PR TITLE
Add theme: Ukiyo

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2318,7 +2318,7 @@
     "name": "Ukiyo",
     "author": "Technerium",
     "repo": "technerium/obsidian-ukiyo",
-    "screenshot": "Showcase.png",
+    "screenshot": "screenshot.png",
     "modes": ["dark", "light"]
   }
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2313,5 +2313,12 @@
     "repo": "druxorey/minimal-dracula-for-obsidian",
     "screenshot": "resources/cover.png",
     "modes": ["dark", "light"]
+  },
+  {
+    "name": "Ukiyo",
+    "author": "Technerium",
+    "repo": "technerium/obsidian-ukiyo",
+    "screenshot": "Showcase.png",
+    "modes": ["dark", "light"]
   }
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2316,7 +2316,7 @@
   },
   {
     "name": "Ukiyo",
-    "author": "Technerium",
+    "author": "kinmury, Technerium",
     "repo": "technerium/obsidian-ukiyo",
     "screenshot": "screenshot.png",
     "modes": ["dark", "light"]


### PR DESCRIPTION
# I am submitting a recently removed Theme from a fork repository

## Repo URL

Link to the theme: 

https://github.com/technerium/obsidian-ukiyo

## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `manifest.json`
  - [x] `theme.css`
  - [x] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my theme's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Themes/App+themes/Theme+guidelines and have self-reviewed my theme to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.

## Note regarding fork

I kept the theme name and version in sync with the original to ensure the change is transparent for users. Please let me know if anything needs to be adjusted in that regard.
