### PR TITLE
Add plugin: Explorer Colors

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15188,5 +15188,12 @@
     "author": "Nick de Bruin",
     "description": "Creates a searchable gallery and sidecar files for attachments such as images and videos. The sidecar files allow you to add notes and tags to your media files.",
     "repo": "Nick-de-Bruin/obsidian-media-companion"
+  },
+  {
+    "id": "obsidian-explorer-colors",
+    "name": "Explorer Colors",
+    "author": "Scott Van der Zwet",
+    "description": "Set cascading colors for files and folders.",
+    "repo": "VaguelyElectric/obsidian-explorer-colors"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15190,10 +15190,10 @@
     "repo": "Nick-de-Bruin/obsidian-media-companion"
   },
   {
-    "id": "obsidian-explorer-colors",
+    "id": "explorer-colors",
     "name": "Explorer Colors",
     "author": "Scott Van der Zwet",
-    "description": "Set cascading colors for files and folders.",
+    "description": "Set custom colors for files and folders.",
     "repo": "VaguelyElectric/obsidian-explorer-colors"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/VaguelyElectric/obsidian-explorer-colors

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
