### PR TITLE
Add Periodic notes calendar plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14691,13 +14691,20 @@
     "author": "mnaoumov",
     "description": "Allows to insert multiple attachments at a time.",
     "repo": "mnaoumov/obsidian-insert-multiple-attachments"
-   },
-	{
+  },
+  {
     "id": "smart-link-alias",
     "name": "Smart Link Alias",
     "author": "Victor Perez-Cano",
     "description": "Enhance your internal links management with dynamic alias customization. Display short, full, or combined titles for your notes effortlessly.",
     "repo": "vpcano/obsidian-smart-link-alias"
+  },
+  {
+    "id": "periodic-notes-calendar",
+    "name": "Periodic notes calendar",
+    "author": "Luis Cadillo",
+    "description": "Organize periodic notes from daily to yearly with a calendar interface. Navigate and summarize entries using stickers in the calendar view.",
+    "repo": "luiisca/obsidian-periodic-notes-calendar"
   }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/luiisca/obsidian-periodic-notes-calendar

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
