### PR TITLE
Rebrand `Fix Require Modules` plugin to `CodeScript Toolkit`

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -10053,10 +10053,10 @@
     },
     {
         "id": "fix-require-modules",
-        "name": "Fix Require Modules",
+        "name": "CodeScript Toolkit",
         "author": "mnaoumov",
-        "description": "Fixes require() calls, supporting JavaScript and TypeScript modules, enabling easy invocation, and adding code buttons for enhanced scripting capabilities",
-        "repo": "mnaoumov/obsidian-fix-require-modules"
+        "description": "Allows to do a lot of things with JavaScript/TypeScript scripts from inside the Obsidian itself",
+        "repo": "mnaoumov/obsidian-codescript-toolkit"
     },
     {
         "id": "auto-definition-link",


### PR DESCRIPTION
The plugin now does way more than the name says, so it is not as discoverable by the users.

From what I understood, I have to keep the plugin id, even if it doesn't match the rebranded plugin name.