### PR TITLE
Add plugin: md-to-slack

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14782,6 +14782,13 @@
     "author": "zero",
     "description": "打造您的极致插件管理体验，让插件管理变得更加直观、高效，同时提升您的工作流程和个性化设置。",
     "repo": "0011000000110010/obsidian-manager"
-  }
+  },
+  {
+    "id": "md-to-slack",
+    "name": "Md to Slack",
+    "author": "Nathan Cashmore",
+    "description": "Converts markdown messages to Slack Block Kit messages",
+    "repo": "NateCashmore/md-to-slack-plugin"
+  }	
 ]
 


### PR DESCRIPTION
Addition of md-to-slack plugin which converts markdown messages to Slack Block Kit messages.