### PR TITLE
Change typo in repo name for obsidian-fast-text-color

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12177,7 +12177,7 @@
         "name": "Fast Text Color",
         "author": "Leon Holtmeier",
         "description": "Quickly apply fully integrated text coloring and formatting with a custom syntax and a keyboard-centric interface.",
-        "repo": "Superschnizel/obisdian-fast-text-color"
+        "repo": "Superschnizel/obsidian-fast-text-color"
     },
     {
         "id": "guid-renamer",


### PR DESCRIPTION
There was a Typo in the repo name:

obisdian-fast-text-color

i corrected the name and need to update the link to 

obsidian-fast-text-color