### PR TITLE
Add plugin: Feedly Annotations Sync

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15245,11 +15245,18 @@
     "description": "Add variables in Templates and set their values on-the-fly during the Note creation.",
     "repo": "gsarig/obsidian-varinote"
   },	
-	{
-        "id": "vector-search",
-        "name": "Vector Search",
-        "author": "Ashwin A Murali",
-        "description": "Semantic search for your notes using Ollama and nomic-embed-text embeddings. Requires Ollama installation.",
-        "repo": "ashwin271/obsidian-vector-search"
-	}
+  {
+    "id": "vector-search",
+    "name": "Vector Search",
+    "author": "Ashwin A Murali",
+    "description": "Semantic search for your notes using Ollama and nomic-embed-text embeddings. Requires Ollama installation.",
+    "repo": "ashwin271/obsidian-vector-search"
+  },
+  {
+    "id": "feedly-annotations",
+    "name": "Feedly Annotations Sync",
+    "author": "Nick Felker",
+    "description": "Syncs Feedly highlights and annotations to a folder in your Obsidian vault.",
+    "repo": "fleker/feedly-for-obsidian"
+  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15256,7 +15256,7 @@
     "id": "feedly-annotations",
     "name": "Feedly Annotations Sync",
     "author": "Nick Felker",
-    "description": "Syncs Feedly highlights and annotations to a folder in your Obsidian vault.",
+    "description": "Syncs Feedly highlights and annotations to a folder in your vault.",
     "repo": "fleker/feedly-for-obsidian"
   }
 ]


### PR DESCRIPTION
Add feedly-annotations plugin

# I am submitting a new Community Plugin

## Repo URL
https://github.com/Fleker/feedly-for-obsidian/

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
