### PR TITLE
Add Canva Embed plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7,15 +7,6 @@
         "repo": "argenos/nldates-obsidian"
     },
     {
-	"id": "canva-obsidian",
-	"name": "Canva Embed",
-	"author": "Jenna Lin",
-	"description": "Embed and display Canva designs directly in your notes with responsive viewing support",
-	"repo": "Jenna225/obsidian-canva-plugin",
-	"branch": "main"
-
-    },
-    {
         "id": "hotkeysplus-obsidian",
         "name": "Hotkeys++",
         "author": "Argentina Ortega Sainz",
@@ -14791,6 +14782,15 @@
     "author": "zero",
     "description": "打造您的极致插件管理体验，让插件管理变得更加直观、高效，同时提升您的工作流程和个性化设置。",
     "repo": "0011000000110010/obsidian-manager"
+  },
+  {
+	"id": "canva-obsidian",
+	"name": "Canva Embed",
+	"author": "Jenna Lin",
+	"description": "Embed and display Canva designs directly in your notes with responsive viewing support",
+	"repo": "Jenna225/obsidian-canva-plugin",
+	"branch": "main"
+
   }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14784,13 +14784,11 @@
     "repo": "0011000000110010/obsidian-manager"
   },
   {
-	"id": "canva-obsidian",
+	"id": "canva-embed",
 	"name": "Canva Embed",
 	"author": "Jenna Lin",
 	"description": "Embed and display Canva designs directly in your notes with responsive viewing support",
-	"repo": "Jenna225/obsidian-canva-plugin",
-	"branch": "main"
-
+	"repo": "Jenna225/obsidian-canva-plugin"
   }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7,6 +7,15 @@
         "repo": "argenos/nldates-obsidian"
     },
     {
+	"id": "canva-obsidian",
+	"name": "Canva Embed",
+	"author": "Jenna Lin",
+	"description": "Embed and display Canva designs directly in your notes with responsive viewing support",
+	"repo": "Jenna225/obsidian-canva-plugin",
+	"branch": "main"
+
+    },
+    {
         "id": "hotkeysplus-obsidian",
         "name": "Hotkeys++",
         "author": "Argentina Ortega Sainz",


### PR DESCRIPTION
# Add Canva Embed Plugin

This PR adds the Canva Embed plugin to the community plugins list. 
The plugin allows users to embed Canva designs directly in their Obsidian notes.

## Plugin Details
- Name: Canva Embed
- Features: Embed Canva designs, responsive viewer, URL validation
- Repository:[ [obsidian-canva-plugin]](https://github.com/Jenna225/obsidian-canva-plugin.git)
- Release: v1.0.0

## Checklist
- [x] GitHub release created
- [x] README.md included
- [x] MIT License added
- [x] manifest.json and versions.json properly configured

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
