### PR TITLE
Add plugin: Fold Properties By Default

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15356,5 +15356,13 @@
     "author": "Metin Ur",
     "description": "Secure content encryption using age encryption library",
     "repo": "Mr-1311/obsidian-age-encrypt"
+  },
+  {
+    "id": "obsidian-fold-properties-by-default",
+    "name": "Fold Properties By Default",
+    "author": "Tommy Bergeron",
+    "description": "Always have editor/metadata properties folded by default.",
+    "repo": "tbergeron/obsidian-fold-properties-by-default"
   }
+
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15361,7 +15361,7 @@
     "id": "obsidian-fold-properties-by-default",
     "name": "Fold Properties By Default",
     "author": "Tommy Bergeron",
-    "description": "Always have editor/metadata properties folded by default.",
+    "description": "Always have editor/metadata properties folded by default",
     "repo": "tbergeron/obsidian-fold-properties-by-default"
   }
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15358,11 +15358,10 @@
     "repo": "Mr-1311/obsidian-age-encrypt"
   },
   {
-    "id": "obsidian-fold-properties-by-default",
+    "id": "fold-properties-by-default",
     "name": "Fold Properties By Default",
     "author": "Tommy Bergeron",
     "description": "Always have editor/metadata properties folded by default",
     "repo": "tbergeron/obsidian-fold-properties-by-default"
   }
-
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/tbergeron/obsidian-fold-properties-by-default

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
