### PR TITLE
Add plugin: Title As Link Text

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15671,5 +15671,12 @@
     "author": "Mariia Nebesnaia",
     "description": "Move unfinished tasks to the daily note automatically",
     "repo": "nemariia/task-mover"
+  },
+  {
+    "id": "title-as-link-text",
+    "name": "Title As Link Text",
+    "author": "Lex Toumbourou",
+    "description": "Automatically updates link text to use note titles instead of filenames.",
+    "repo": "lextoumbourou/obsidian-title-as-link-text"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

https://github.com/lextoumbourou/obsidian-title-as-link-text

Link to my plugin:

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
