### PR TITLE
Add plugin: Thecap cv generator

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15538,5 +15538,12 @@
       "author": "Kirill Gavrilov",
       "description": "Converts raw text timecodes into clickable URLs if a note contains a link to a video",
       "repo": "gavvvr/obsidian-timecodes-plugin"
+  },
+  {
+    "id": "thecap-cv-generator",
+    "name": "Thecap cv generator",
+    "author": "Thecap",
+    "description": "Generate PDF curriculum from your notes.",
+    "repo": "xthecapx/thecap-cv-generator"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Screenshots

### Markdown

<img width="1297" alt="image" src="https://github.com/user-attachments/assets/120ca6fb-3d31-482d-bc24-c800576ccd4d" />

### Modal

<img width="1016" alt="image" src="https://github.com/user-attachments/assets/c6143347-4e79-448e-913b-11a26f167ad6" />

### Command

<img width="727" alt="image" src="https://github.com/user-attachments/assets/f091e85f-6d8f-40cc-8de7-6ec0408024bb" />


## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: Link to my plugin: https://github.com/xthecapx/cv-generator

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
