### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14908,5 +14908,12 @@
     "author": "Amin Sennour",
     "description": "Change the default filename used for new notes",
     "repo": "TheLoneWanderer4/obsidian-uuid-title"
+  },
+  {
+    "id": "quick-move-note",
+    "name": "Quick Move",
+    "author": "Thomas Binu",
+    "description": "Configure custom commands to quickly move notes to a specific folder",
+    "repo": "tmsbn/obsidian-quick-move-note"
   }
 ]


### PR DESCRIPTION
Add plugin: Obsidian Quick Move

The Obsidian Quick Move Plugin allows you to quickly move notes to a specified folder with a single custom command.

https://github.com/tmsbn/obsidian-quick-move-note


Please switch to **Preview** and select one of the following links:

 [Community Plugin](?template=plugin.md)

