### PR TITLE
Update author name for Canvas Link Optimizer plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -10145,9 +10145,9 @@
     {
         "id": "canvas-link-optimizer",
         "name": "Canvas Link Optimizer",
-        "author": "khaelar",
+        "author": "Qbject",
         "description": "Optimize Canvas links by displaying a page thumbnail.",
-        "repo": "khaelar/obsidian-canvas-link-optimizer"
+        "repo": "Qbject/obsidian-canvas-link-optimizer"
     },
     {
         "id": "inline-admonitions",


### PR DESCRIPTION
My profile url and name has changed, so I would like to keep the plugin info in this repository valid and up to date