### PR TITLE
Remove Luminex Theme from Obsidian Community Themes

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2182,13 +2182,6 @@
     "modes": ["dark"]
   },
   {
-    "name": "Luminex",
-    "author": "abhimangs",
-    "repo": "abhimangs/Obsidian-Luminex",
-    "screenshot": "assets/cover-obsidian.png",
-    "modes": ["dark", "light"]
-  },
-  {
     "name": "Shadeflow",
     "author": "Artorias",
     "repo": "artorias305/obsidian-shadeflow",


### PR DESCRIPTION
As I have developed a new theme called "Vortex," I am officially removing the "Luminex" theme from the Obsidian community themes. Since Luminex is no longer supported and has been superseded by "Vortex," this update ensures that the community repository stays current and organized with the most up-to-date themes. Thank you for your understanding!