### PR TITLE
Add plugin: Note Favicon

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15958,5 +15958,12 @@
     "author": "ari.the.elk",
     "description": "A blazingly fast way to browse, search, and embed pictures across your vault",
     "repo": "AriTheElk/obsidian-image-picker"
-    }
+},
+{
+    "id": "obsidian-note-favicon",
+    "name": "Note Favicon",
+    "author": "mdklab",
+    "description": "This plugin extracts a URL from the frontmatter of notes and displays an associated favicon image next to the note title in the file tree. Supports standard URLs and base64-encoded images.",
+    "repo": "mdklab/obsidian-note-favicon"
+  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15960,7 +15960,6 @@
     "repo": "AriTheElk/obsidian-image-picker"
 },
 {
-    "id": "obsidian-note-favicon",
     "id": "note-favicon",
     "name": "Note Favicon",
     "author": "mdklab",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15964,7 +15964,7 @@
     "id": "note-favicon",
     "name": "Note Favicon",
     "author": "mdklab",
-    "description": "This plugin extracts a URL from the frontmatter of notes and displays an associated favicon image next to the note title in the file tree. Supports standard URLs and base64-encoded images.",
+    "description": "Extracts a URL from the frontmatter of notes and displays an associated favicon image next to the note title in the file tree. Supports standard URLs and base64-encoded images.",
     "repo": "mdklab/note-favicon"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15965,6 +15965,6 @@
     "name": "Note Favicon",
     "author": "mdklab",
     "description": "This plugin extracts a URL from the frontmatter of notes and displays an associated favicon image next to the note title in the file tree. Supports standard URLs and base64-encoded images.",
-    "repo": "mdklab/obsidian-note-favicon"
+    "repo": "mdklab/note-favicon"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15961,6 +15961,7 @@
 },
 {
     "id": "obsidian-note-favicon",
+    "id": "note-favicon",
     "name": "Note Favicon",
     "author": "mdklab",
     "description": "This plugin extracts a URL from the frontmatter of notes and displays an associated favicon image next to the note title in the file tree. Supports standard URLs and base64-encoded images.",


### PR DESCRIPTION
Extracts a URL from the frontmatter of notes and displays an associated favicon image next to the note title in the file tree. Supports standard URLs and base64-encoded images.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [ ] I have tested the plugin on
  -  [X]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
