### PR TITLE
Add Rsyn Plugin to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15048,5 +15048,12 @@
     "author": "Ben Rotholtz",
     "description": "Track your goals with a calendar view",
     "repo": "GizmoRay/obsidian-goal-tracker"  
+  },
+  {
+    "id": "rsync-plugin",
+    "name": "Rsync",
+    "author": "Ganapathy Raman",
+    "description": "A plugin to sync files using Rsync.",
+    "repo": "GanapathyRaman/rsync-plugin"  
   }
 ]


### PR DESCRIPTION
Added a new Rsync plugin

* [Community Plugin](?template=plugin.md)

### Plugin: Rsync Plugin

- **Author**: Ganapathy Raman
- **Description**: A plugin to sync notes using `rsync`. Automates backups and syncs notes with remote storage.
- **Repository**: [GanapathyRaman/rsync-plugin](https://github.com/GanapathyRaman/rsync-plugin)
- **Version**: 1.0.0
- **License**: MIT License