### PR TITLE
feat: add AI Voice Memo plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15048,5 +15048,12 @@
     "author": "Ben Rotholtz",
     "description": "Track your goals with a calendar view",
     "repo": "GizmoRay/obsidian-goal-tracker"  
-  }
+  },
+    {
+        "id": "obsidian-ai-voice-memo",
+        "name": "AI Voice Memo",
+        "author": "J&S Group, LLC",
+        "description": "Record, transcribe, and organize voice memos with AI-powered features",
+        "repo": "BioInfo/Obsidian-AIMemo"
+    }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15050,7 +15050,7 @@
     "repo": "GizmoRay/obsidian-goal-tracker"  
   },
     {
-        "id": "obsidian-ai-voice-memo",
+        "id": "ai-voice-memo",
         "name": "AI Voice Memo",
         "author": "J&S Group, LLC",
         "description": "Record, transcribe, and organize voice memos with AI-powered features",


### PR DESCRIPTION
Link to your repository: https://github.com/BioInfo/Obsidian-AIMemo

What does this plugin do?
AI Voice Memo allows users to record, transcribe, and organize voice memos directly within Obsidian. It features AI-powered transcription (Whisper), automatic organization, and support for both desktop and mobile platforms.

Checklist:
- [x] I confirm I have read the [submission requirements](https://github.com/obsidianmd/obsidian-releases#submit-your-plugin)
- [x] I have tested my plugin on the latest Obsidian desktop app
- [x] I have tested my plugin on the latest Obsidian mobile app (if the plugin works on mobile)
- [x] I have created a proper GitHub release using the exact version specified in my plugin's [manifest.json](https://github.com/BioInfo/Obsidian-AIMemo/blob/main/manifest.json)
- [x] The plugin ID in my submission matches the ID in my plugin's [manifest.json](https://github.com/BioInfo/Obsidian-AIMemo/blob/main/manifest.json)