### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13990,7 +13990,7 @@
 "name": "Automatic List Reordering",
 "author": "Omri Levi",
 "description": "Automatically reorder checklists and numbered lists as you edit them.",
-"repo": "OmriLeviGit/Auto-List-Reordering"
+"repo": "OmriLeviGit/Auto-List-Reordering-Obsidian"
 },
 {
     "id": "three-noun-prompts",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13987,10 +13987,10 @@
 },
 {
 "id": "automatic-renumbering",
-"name": "Automatic List Renumbering",
+"name": "Automatic Checklist Reordering",
 "author": "Omri Levi",
-"description": "Automatically renumber numbered lists as you edit them.",
-"repo": "OmriLeviGit/Automatic-Renumbering-Obsidian"
+"description": "Automatically reorder checkbox lists as you edit them.",
+"repo": "OmriLeviGit/Automatic-Checklist-Reordering-Obsidian"
 },
 {
     "id": "three-noun-prompts",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13990,7 +13990,7 @@
 "name": "Automatic List Reordering",
 "author": "Omri Levi",
 "description": "Automatically reorder checklists and numbered lists as you edit them.",
-"repo": "OmriLeviGit/auto-list-reordering"
+"repo": "OmriLeviGit/Auto-List-Reordering"
 },
 {
     "id": "three-noun-prompts",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13987,10 +13987,10 @@
 },
 {
 "id": "automatic-renumbering",
-"name": "Automatic Checklist Reordering",
+"name": "Automatic List Reordering",
 "author": "Omri Levi",
-"description": "Automatically reorder checkbox lists as you edit them.",
-"repo": "OmriLeviGit/Automatic-Checklist-Reordering-Obsidian"
+"description": "Automatically reorder checklists and numbered lists as you edit them.",
+"repo": "OmriLeviGit/auto-list-reordering"
 },
 {
     "id": "three-noun-prompts",


### PR DESCRIPTION
# I am changing the plugin's name and repo link

## Repo URL
https://github.com/OmriLeviGit/Auto-List-Reordering-Obsidian

As the renumbering feature was implemented in 1.8.3, i have made some edits and removed the main feature from newer versions, leaving only the secondary feature for automatic checkbox sorting.
The old name does not fit the description so i have changed it.

I left the plugin ID as it is, and already made changes to the manifest.