### PR TITLE
Add plugin: Jupyter Notebook Viewer

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15048,5 +15048,12 @@
     "author": "Ben Rotholtz",
     "description": "Track your goals with a calendar view",
     "repo": "GizmoRay/obsidian-goal-tracker"  
-  }
+  },
+  {
+       "id": "obsidian-jupyter-notebook-plugin",
+       "name": "Jupyter Notebook Viewer",
+       "author": "Geng",
+       "description": "View and edit Jupyter notebooks in Obsidian",
+       "repo": "gengyabc/obsidian-jupyter-notebook-plugin"
+   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15050,10 +15050,10 @@
     "repo": "GizmoRay/obsidian-goal-tracker"  
   },
   {
-       "id": "obsidian-jupyter-notebook-plugin",
+       "id": "jupyter-notebook-viewer",
        "name": "Jupyter Notebook Viewer",
        "author": "Geng",
-       "description": "View and edit Jupyter notebooks in Obsidian",
+       "description": "View and edit Jupyter notebooks",
        "repo": "gengyabc/obsidian-jupyter-notebook-plugin"
    }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15056,4 +15056,5 @@
        "description": "View and edit Jupyter notebooks",
        "repo": "gengyabc/obsidian-jupyter-notebook-plugin"
    }
+	
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15056,5 +15056,4 @@
        "description": "View and edit Jupyter notebooks",
        "repo": "gengyabc/obsidian-jupyter-notebook-plugin"
    }
-	
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/gengyabc/obsidian-jupyter-notebook-plugin

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
