### PR TITLE
Add plugin: Tab Group Arrangement

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15825,5 +15825,12 @@
     "author": "Stefano Frigerio",
     "description": "Interact with local SQLite files in your notes",
     "repo": "stfrigerio/sqliteDB"  
-  }	
+  },
+  {
+    "id": "editor-group-arrangement",
+    "name": "Editor Group Arrangement",
+    "author": "situ2001",
+    "description": "Arrange the editor group in a more flexible way. For now, it supports arranging evenly and expanded like VSCode. User can make action and switch mode of arrangement by clicking the status bar or executing commands.",
+    "repo": "situ2001/obsidian-editor-group-arrangement"
+  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15827,10 +15827,10 @@
     "repo": "stfrigerio/sqliteDB"  
   },
   {
-    "id": "editor-group-arrangement",
-    "name": "Editor Group Arrangement",
+    "id": "tab-group-arrangement",
+    "name": "Tab Group Arrangement",
     "author": "situ2001",
-    "description": "Arrange the editor group in a more flexible way. For now, it supports arranging evenly and expanded like VSCode. User can make action and switch mode of arrangement by clicking the status bar or executing commands.",
-    "repo": "situ2001/obsidian-editor-group-arrangement"
+    "description": "Arrange the tab group in a more flexible way. For now, it supports arranging evenly and expanded like VSCode. User can make action and switch mode of arrangement by clicking the status bar or executing commands.",
+    "repo": "situ2001/obsidian-tab-group-arrangement"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/situ2001/obsidian-editor-group-arrangement

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
