### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15049,4 +15049,12 @@
     "description": "Track your goals with a calendar view",
     "repo": "GizmoRay/obsidian-goal-tracker"  
   }
+{
+    "id": "obsidian-note-path",
+    "name": "Note Path",
+    "author": "zhaoscsc",
+    "description": "在状态栏显示当前笔记的路径",
+    "repo": "zhaoscsc/obsidian-note-path",
+    "branch": "main"
+},	
 ]


### PR DESCRIPTION
## Note Path Plugin for Obsidian

This plugin adds a status bar item that displays the current note's path. Users can click the path to copy it to clipboard.

### Features
- Shows the full path of the current note in status bar
- Click to copy path to clipboard
- Simple and lightweight

### For more information
- GitHub Repository: https://github.com/zhaoscsc/obsidian-note-path
- Author: zhaoscsc