### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15049,4 +15049,12 @@
     "description": "Track your goals with a calendar view",
     "repo": "GizmoRay/obsidian-goal-tracker"  
   }
+{
+    "id": "obsidian-note-path",
+    "name": "Note Path",
+    "author": "zhaoscsc",
+    "description": "在状态栏显示当前笔记的路径",
+    "repo": "zhaoscsc/obsidian-note-path",
+    "branch": "main"
+},	
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15056,5 +15056,4 @@
     "description": "在状态栏显示当前笔记的路径",
     "repo": "zhaoscsc/obsidian-note-path",
     "branch": "main"
-},	
-]
+},]


### PR DESCRIPTION
---
plugins: true
---

## Obsidian Note Path Plugin

A simple plugin that displays the current note's path in the status bar.

## Author
- GitHub: zhaoscsc
- Discord: (如果有 Discord 账号可以填写)

## Repo
https://github.com/zhaoscsc/obsidian-note-path

## Screenshots
(如果有截图可以添加)

## Features
- Shows the full path of the current note in status bar
- Click to copy path to clipboard
- Simple and lightweight