### PR TITLE
Repo change: Update workspaces-plus repository location

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1999,7 +1999,7 @@
         "name": "Workspaces Plus",
         "description": "Quickly switch and manage workspaces.",
         "author": "NothingIsLost",
-        "repo": "nothingislost/obsidian-workspaces-plus"
+        "repo": "jsmorabito/obsidian-workspaces-plus"
     },
     {
         "id": "obsidian-read-it-later",


### PR DESCRIPTION
# I am updating the repo location for an existing plugin
- Workspaces Plus has moved from `nothingislost/obsidian-workspaces-plus` to `jsmorabito/obsidian-workspaces-plus`

## Repo URL
Link to my plugin:

https://github.com/jsmorabito/obsidian-workspaces-plus