### PR TITLE
Add plugin: tidit

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15874,5 +15874,12 @@
 	"author": "Janis Ringli",
 	"description": "Open the bible in your preferred translation in a split-screen view within your workspace",
 	"repo": "janisringli/bible-sidecar-obsidian-plugin"
-}	
+},
+{
+    "id": "tidit",
+    "name": "tidit",
+    "author": "codingthings.com",
+    "description": "tidit adds timestamps to your document as you type — when you want it, how you want it, where you want it.",
+    "repo": "codingthings-com/tidit-obsidian"
+  }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin
tidit adds timestamps to your document as you type — when you want it, how you want it, where you want it. 

## Repo URL
https://github.com/codingthings-com/tidit-obsidian

Link to my plugin: https://github.com/codingthings-com/tidit-obsidian

## Release Checklist
- [ x ] I have tested the plugin on
  - [ ]  Windows
  - [ x ]  macOS
  - [ x ]  Linux
  - [ ]  Android _(if applicable)_
  - [ x ]  iOS _(if applicable)_
- [ x ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [ x ] `main.js`
  - [ x ] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ x ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ x ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ x ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ x ] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [ x ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ x ] I have added a license in the LICENSE file.
- [ x ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
