### PR TITLE
Add plugin: Jupytext Support

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15572,6 +15572,6 @@
     "name": "Jupytext Support",
     "author": "Deniz Terzioglu",
     "description": "Creates and syncs Jupyter Notebooks from markdown notes through Jupytext in Obsidian.",
-    "repo": "d-eniz/jupytext-obsidian-plugin"
+    "repo": "d-eniz/jupytext-support"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15559,5 +15559,12 @@
     "author": "Anareaty",
     "description": "Allows to quickly add HTML checkboxes to your notes and makes them clickable.",
     "repo": "anareaty/html-checkboxes"
+  },
+  {
+    "id": "jupytext-obsidian-plugin",
+    "name": "Jupytext Support for Obsidian",
+    "author": "Deniz Terzioglu",
+    "description": "Creates and syncs Jupyter Notebooks from markdown notes through Jupytext in Obsidian.",
+    "repo": "d-eniz/jupytext-obsidian-plugin"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15571,7 +15571,7 @@
   "id": "jupytext-support",
     "name": "Jupytext Support",
     "author": "Deniz Terzioglu",
-    "description": "Creates and syncs Jupyter Notebooks from markdown notes through Jupytext in Obsidian.",
+    "description": "Creates and syncs Jupyter Notebooks from markdown notes through Jupytext",
     "repo": "d-eniz/jupytext-support"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15568,8 +15568,8 @@
     "repo": "groldsf/obsidian_check_plugin"
   },
   {
-  "id": "jupytext-obsidian-plugin",
-    "name": "Jupytext Support for Obsidian",
+  "id": "jupytext-support",
+    "name": "Jupytext Support",
     "author": "Deniz Terzioglu",
     "description": "Creates and syncs Jupyter Notebooks from markdown notes through Jupytext in Obsidian.",
     "repo": "d-eniz/jupytext-obsidian-plugin"


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/d-eniz/jupytext-support

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
