### PR TITLE
Add plugin: Vault File Renamer

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15587,5 +15587,12 @@
     "author": "Cormac",
     "description": "Improve copy-paste from PDFs by cleaning newlines and hyphens.",
     "repo": "Cormac-C/obsidian-paste-plugin"
+  },
+  {
+    "id": "vault-file-renamer",
+    "name": "Vault File Renamer",
+    "author": "Louan Fontenele",
+    "description": "Automatically standardizes file names to GitHub style (lowercase, no accents, only -, ., _) while preserving folder structure and file contents. ",
+    "repo": "louanfontenele/obsidian-vault-file-renamer"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/louanfontenele/obsidian-vault-file-renamer

## Release Checklist

- [x] I have tested the plugin on:
  - [x] Windows
  - [x] macOS
  - [x] Linux
  - [x] Android _(if applicable)_
  - [x] iOS _(if applicable)_

- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz):
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_

- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)

- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.

- [x] My README.md describes the plugin's purpose and provides clear usage instructions.

- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugin's adherence to these policies.

- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.

- [x] I have added a license in the LICENSE file.

- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
  I have given proper attribution to these other projects in my README.md.
