### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15749,4 +15749,11 @@
     "description": "Record chat in ordinary markdown list.",
     "repo": "sleepingraven/obsidian-chat-clips"
   }
+  {
+    "id": "convert-ai-math",
+    "name": "Ai Math to Obsidian",
+    "author": "Darko Pejakovic and lights7",
+    "description": "Converts Ai Math to Obsidian when pasting content.",
+    "repo": "lights7/ai_math_to_obsidian"
+  }
 ]


### PR DESCRIPTION
This is a plugin can convert ChatGPT, DeepSeek, Liner, Claude, Llama and Grok's Math equations to Obsidian while pasting content.

It was forked from Darko Pejakovic's [Convert KaTeX to MathJax plugin](https://github.com/pejakovic/obsidian-convert-katex-to-mathjax), which can copy ChatGPT 's KaTeX into  Obsidian's MathJax.

I asked Darko Pejakovic and he allow me to decide what to do, so I add him as a coauthor.

lights7

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
