### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15748,5 +15748,12 @@
     "author": "sleepingraven",
     "description": "Record chat in ordinary markdown list.",
     "repo": "sleepingraven/obsidian-chat-clips"
+  },
+  {
+    "id": "convert-ai-math",
+    "name": "Ai Math to Obsidian",
+    "author": "Darko Pejakovic and lights7",
+    "description": "Converts Ai Math to Obsidian when pasting content.",
+    "repo": "lights7/ai-math-to-obsidian"
   }
 ]


### PR DESCRIPTION
This is a plugin can convert ChatGPT, DeepSeek, Liner, Claude, Llama and Grok's Math equations to Obsidian while pasting content.

It was forked from Darko Pejakovic's [Convert KaTeX to MathJax plugin](https://github.com/pejakovic/obsidian-convert-katex-to-mathjax), which can copy ChatGPT 's KaTeX into  Obsidian's MathJax.

I asked to Darko and he allow me to do what I decide, so I add him as coauthor.

lights7


