### PR TITLE
Add plugin: Auto Folder Note Paste

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16254,10 +16254,17 @@
     "repo": "sstallion/obsidian-command-line"
 },
 {
-"id": "extended-graph",
-"name": "Extended Graph",
-"author": "Kapirklaa",
-"description": "Extends the features of the core Graph view, display images, manage states, remove links, change node shapes, and more.",
-"repo": "ElsaTam/obsidian-extended-graph"
+    "id": "extended-graph",
+    "name": "Extended Graph",
+    "author": "Kapirklaa",
+    "description": "Extends the features of the core Graph view, display images, manage states, remove links, change node shapes, and more.",
+    "repo": "ElsaTam/obsidian-extended-graph"
+},
+{
+    "id": "auto-folder-note-paste",
+    "name": "Auto Create Folder Note",		
+    "author": "d7sd6u",
+    "description": "Automagically convert the note to a folder note when pasting or drag'n'dropping an attachment.",
+    "repo": "d7sd6u/obsidian-auto-folder-note-paste"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16262,7 +16262,7 @@
 },
 {
     "id": "auto-folder-note-paste",
-    "name": "Auto Create Folder Note",		
+    "name": "Auto Folder Note Paste",		
     "author": "d7sd6u",
     "description": "Automagically convert the note to a folder note when pasting or drag'n'dropping an attachment.",
     "repo": "d7sd6u/obsidian-auto-folder-note-paste"


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/d7sd6u/obsidian-auto-folder-note-paste

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v>
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
