### PR TITLE
Add plugin: Folder Navigator

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16539,6 +16539,13 @@
     "description": "Tag files using folders and symlinks system (ftags).",
     "author": "d7sd6u",
     "repo": "d7sd6u/obsidian-crosslink-advanced"
+},
+{
+    "id": "folder-navigator",
+	"name": "Folder Navigator",
+    "author": "wenlzhang",
+    "description": "Quickly navigate to folders in your vault using fuzzy search.",
+    "repo": "wenlzhang/obsidian-folder-navigator"
   }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/wenlzhang/obsidian-folder-navigator

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
