### PR TITLE
Add plugin: Image to HTML

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16119,6 +16119,13 @@
     "author": "wenlzhang",
     "description": "Copy and paste formatting attributes (size and color) between canvas elements, similar to the format painter in Word.",
     "repo": "wenlzhang/obsidian-canvas-format-brush"
+},
+{
+    "id": "img2html",
+    "name": "Image to HTML",
+    "author": "0x1DA9430",
+    "description": "Paste images as HTML format instead of wikilink or markdown format.",
+    "repo": "0x1DA9430/obsidian-img2html"
   }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16121,11 +16121,11 @@
     "repo": "wenlzhang/obsidian-canvas-format-brush"
 },
 {
-    "id": "img2html",
-    "name": "Image to HTML",
-    "author": "0x1DA9430",
-    "description": "Paste images as HTML format instead of wikilink or markdown format.",
-    "repo": "0x1DA9430/obsidian-img2html"
-  }
+"id": "img2html",
+"name": "Image to HTML",
+"author": "0x1DA9430",
+"description": "Paste images as HTML format instead of wikilink or markdown format.",
+"repo": "0x1DA9430/obsidian-img2html"
+}
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16121,11 +16121,11 @@
     "repo": "wenlzhang/obsidian-canvas-format-brush"
 },
 {
-"id": "img2html",
-"name": "Image to HTML",
-"author": "0x1DA9430",
-"description": "Paste images as HTML format instead of wikilink or markdown format.",
-"repo": "0x1DA9430/obsidian-img2html"
+    "id": "img2html",
+    "name": "Image to HTML",
+    "author": "0x1DA9430",
+    "description": "Paste images as HTML format instead of wikilink or markdown format.",
+    "repo": "0x1DA9430/img2html"
 }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:
https://github.com/0x1DA9430/obsidian-img2html

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
