### PR TITLE
Add Xiaohongshu-Importer-for-Obsidian to community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,13 @@
 [
     {
+        "id": "Xiaohongshu-Importer-for-Obsidian",
+        "name": "Xiaohongshu Importer",
+        "author": "bnchiang96",
+        "description": "Import Xiaohongshu (小红书) notes into Obsidian with media and categorization.",
+        "repo": "bnchiang96/Xiaohongshu-Importer-for-Obsidian",
+        "branch": "main"
+    },
+    {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
         "author": "Argentina Ortega Sainz",
@@ -15104,7 +15112,7 @@
     "author": "mbramani",
     "description": "Summarize YouTube videos using Gemini AI. Extract transcripts, generate summaries, and create structured notes.",
     "repo": "mbramani/obsidian-yt-video-summarizer"
-   },	
+   },
   {
     "id": "whatsapp-export-note",
     "name": "WhatsApp export note",
@@ -15216,7 +15224,7 @@
     "author": "Giorgos Sarigiannidis",
     "description": "Add variables in Templates and set their values on-the-fly during the Note creation.",
     "repo": "gsarig/obsidian-varinote"
-  },	
+  },
   {
     "id": "vector-search",
     "name": "Vector Search",
@@ -15279,7 +15287,7 @@
     "author": "Pavlo Kobyliatskyi",
     "description": "Memorizing words or phrases",
     "repo": "pavlokobyliatskyi/obsidian-memodack-plugin"
-  }, 
+  },
   {
     "id": "ai-hub",
     "name": "AI integration Hub",
@@ -15520,7 +15528,7 @@
   },
   {
     "id": "last-position",
-    "name": "Last Position",		
+    "name": "Last Position",
     "author": "saktawdi",
     "description": "Automatically scroll to the last viewed position when opening the markdown document.",
     "repo": "Saktawdi/obsidian-last-position"
@@ -15621,7 +15629,7 @@
     "name": "Rsync",
     "author": "Ganapathy Raman",
     "description": "Sync notes and automate backups using Rsync.",
-    "repo": "GanapathyRaman/rsync-plugin"  
+    "repo": "GanapathyRaman/rsync-plugin"
   },
   {
     "id": "extended-markdown-syntax",
@@ -15635,7 +15643,7 @@
     "name": "Paste Image Into Property",
     "author": "Nito",
     "description": "Allows pasting images from the clipboard into frontmatter properties in live preview.",
-    "repo": "Nitero/obsidian-paste-image-into-property"  
+    "repo": "Nitero/obsidian-paste-image-into-property"
   },
   {
     "id": "my-thesaurus",
@@ -15656,7 +15664,7 @@
     "name": "GridExplorer",
     "author": "Devon22",
     "description": "Browse note files in a grid view.",
-    "repo": "Devon22/obsidian-gridexplorer"  
+    "repo": "Devon22/obsidian-gridexplorer"
   },
   {
     "id": "infio-copilot",
@@ -15682,7 +15690,7 @@
   {
     "id": "cursor-position-history",
     "name": "Cursor Position History",
-    "author": "Florian Gubler", 
+    "author": "Florian Gubler",
     "description": "Remember the previous positions of the cursor across files: auto-scroll to the correct position in a new file. Navigate backward and forward through your cursor position history without losing context.",
     "repo": "fgubler/obsidian-cursor-position-history"
   },
@@ -15728,7 +15736,7 @@
         "description": "Convert indented code blocks with hierarchy markers into formatted ASCII tree diagrams.",
         "repo": "michalekmatej/obsidian.md-ascii-tree-generator"
     },
-    {	
+    {
         "id": "koi-sync",
         "name": "KOI Sync",
         "author": "Luke Miller",
@@ -15763,7 +15771,7 @@
     "description": "Generate blog posts from your notes using OpenAI",
     "repo": "garethng/obsidian-blog-generator"
    },
-  {    
+  {
     "id": "spaced-repetition-ai",
     "name": "Spaced Repetition AI",
     "author": "Belinda Mo, Athena Leong",


### PR DESCRIPTION
Adds the Xiaohongshu Importer plugin to the Obsidian Community Plugins list.
- Imports Xiaohongshu (小红书) notes with optional media downloads and categorization.
- Repo: https://github.com/bnchiang96/Xiaohongshu-Importer-for-Obsidian
- Release: https://github.com/bnchiang96/Xiaohongshu-Importer-for-Obsidian/releases/tag/1.0.0