### PR TITLE
Add Xiaohongshu Importer plugin (v1.0.1)

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15104,7 +15104,7 @@
     "author": "mbramani",
     "description": "Summarize YouTube videos using Gemini AI. Extract transcripts, generate summaries, and create structured notes.",
     "repo": "mbramani/obsidian-yt-video-summarizer"
-   },	
+   },
   {
     "id": "whatsapp-export-note",
     "name": "WhatsApp export note",
@@ -15216,7 +15216,7 @@
     "author": "Giorgos Sarigiannidis",
     "description": "Add variables in Templates and set their values on-the-fly during the Note creation.",
     "repo": "gsarig/obsidian-varinote"
-  },	
+  },
   {
     "id": "vector-search",
     "name": "Vector Search",
@@ -15279,7 +15279,7 @@
     "author": "Pavlo Kobyliatskyi",
     "description": "Memorizing words or phrases",
     "repo": "pavlokobyliatskyi/obsidian-memodack-plugin"
-  }, 
+  },
   {
     "id": "ai-hub",
     "name": "AI integration Hub",
@@ -15520,7 +15520,7 @@
   },
   {
     "id": "last-position",
-    "name": "Last Position",		
+    "name": "Last Position",
     "author": "saktawdi",
     "description": "Automatically scroll to the last viewed position when opening the markdown document.",
     "repo": "Saktawdi/obsidian-last-position"
@@ -15621,7 +15621,7 @@
     "name": "Rsync",
     "author": "Ganapathy Raman",
     "description": "Sync notes and automate backups using Rsync.",
-    "repo": "GanapathyRaman/rsync-plugin"  
+    "repo": "GanapathyRaman/rsync-plugin"
   },
   {
     "id": "extended-markdown-syntax",
@@ -15635,7 +15635,7 @@
     "name": "Paste Image Into Property",
     "author": "Nito",
     "description": "Allows pasting images from the clipboard into frontmatter properties in live preview.",
-    "repo": "Nitero/obsidian-paste-image-into-property"  
+    "repo": "Nitero/obsidian-paste-image-into-property"
   },
   {
     "id": "my-thesaurus",
@@ -15656,7 +15656,7 @@
     "name": "GridExplorer",
     "author": "Devon22",
     "description": "Browse note files in a grid view.",
-    "repo": "Devon22/obsidian-gridexplorer"  
+    "repo": "Devon22/obsidian-gridexplorer"
   },
   {
     "id": "infio-copilot",
@@ -15682,7 +15682,7 @@
   {
     "id": "cursor-position-history",
     "name": "Cursor Position History",
-    "author": "Florian Gubler", 
+    "author": "Florian Gubler",
     "description": "Remember the previous positions of the cursor across files: auto-scroll to the correct position in a new file. Navigate backward and forward through your cursor position history without losing context.",
     "repo": "fgubler/obsidian-cursor-position-history"
   },
@@ -15728,7 +15728,7 @@
         "description": "Convert indented code blocks with hierarchy markers into formatted ASCII tree diagrams.",
         "repo": "michalekmatej/obsidian.md-ascii-tree-generator"
     },
-    {	
+    {
         "id": "koi-sync",
         "name": "KOI Sync",
         "author": "Luke Miller",
@@ -15763,7 +15763,7 @@
     "description": "Generate blog posts from your notes using OpenAI",
     "repo": "garethng/obsidian-blog-generator"
    },
-  {    
+  {
     "id": "spaced-repetition-ai",
     "name": "Spaced Repetition AI",
     "author": "Belinda Mo, Athena Leong",
@@ -15804,5 +15804,13 @@
     "author": "Marc André Ueberall",
     "description": "Weather generator for the HârnMaster: Roleplaying in the World of Kèthîra rule system.",
     "repo": "marcueberall/obsidian-harn-weather"
-  }
+  },
+    {
+        "id": "Xiaohongshu-Importer-for-Obsidian",
+        "name": "Xiaohongshu Importer",
+        "author": "bnchiang96",
+        "description": "Import Xiaohongshu (小红书) notes into Obsidian with media and categorization.",
+        "repo": "bnchiang96/Xiaohongshu-Importer-for-Obsidian",
+        "branch": "main"
+    }
 ]


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/obsidianmd/obsidian-releases/blob/master/CONTRIBUTING.md).
- [x] This pull request includes a plugin published on GitHub with a valid, non-empty release.
- [x] The plugin is compatible with the most recent desktop release of the Obsidian app or specifies a compatible `minAppVersion`.

### Description
Adds the Xiaohongshu Importer plugin (v1.0.1) to the community plugins list. This plugin allows users to import Xiaohongshu (小红书) notes with optional media downloads and categorization.

**Changes in v1.0.1:**
- Added hardcoded '其他' category as the last option.
- Removed 'Others' from default list.
- Fixed "Download media" label clickability.
- Increased margin-top and margin-bottom for the download row.
- Made the "Import" button full width.
- Fixed issue where the cover photo was downloaded twice.
- Updated plugin ID to 'xiaohongshu-importer' (lowercase alphanumeric with dashes).
- Removed 'Obsidian' from the description.
- Ensured main.js and manifest.json are included in the release ZIP.

### Plugin Details
- **Repository**: https://github.com/bnchiang96/Xiaohongshu-Importer-for-Obsidian
- **Release**: https://github.com/bnchiang96/Xiaohongshu-Importer-for-Obsidian/releases/tag/1.0.1
- **Plugin ID**: xiaohongshu-importer