### PR TITLE
Rename plugin: Obsidian-Task-Progress-Bar to Obsidian-Task-Genius

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -3788,9 +3788,9 @@
     },
     {
         "id": "obsidian-task-progress-bar",
-        "name": "Task Progress Bar",
+        "name": "Task Genius",
         "author": "Boninall",
-        "description": "A task progress bar for tasks.",
+        "description": "Comprehensive task management that includes progress bars, task status cycling, and advanced task tracking features.",
         "repo": "Quorafind/Obsidian-Task-Progress-Bar"
     },
     {


### PR DESCRIPTION
# I am renaming an old plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Quorafind/Obsidian-Task-Genius/tree/master

Original name is Obsidian-Task-Progress-Bar
I want to rename it because it contains features that are not much progress-bar related after refactoring
