### PR TITLE
Update plugin description for: Extended Markdown Syntax

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15627,7 +15627,7 @@
     "id": "extended-markdown-syntax",
     "name": "Extended Markdown Syntax",
     "author": "Kotaindah55",
-    "description": "Extend your markdown syntax using delimiters instead of HTML tags, such as underlining, superscript, subscript, highlighting, aligning.",
+    "description": "Extend your Markdown syntax using delimiters instead of HTML tags, such as underlining, superscript, subscript, highlighting, and spoiler.",
     "repo": "kotaindah55/extended-markdown-syntax"
   },
   {


### PR DESCRIPTION
# I made a few changes on my plugin description

## Reason

- Capitalize the letter "M" in the "Markdown".
- "Aligning" feature has no longer been included in the latest release.

## Repo URL

Link to my plugin: https://github.com/kotaindah55/extended-markdown-syntax

## Checklist

- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
