### PR TITLE
Add Plugin: Anki Integration

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15944,5 +15944,12 @@
     "author": "Feirong.zfr",
     "description": "Manage student repositories.",
     "repo": "yingflower/obsidian-stu-repo-helper"  
-  }
+},
+{
+  "id": "anki-integration",
+  "name": "Anki Integration",
+  "author": "Noah Boos AKA Rift",
+  "description": "An Obsidian Plugin allowing to create Anki Flashcards in different ways.",
+  "repo": "NoahBoos/obsidian-anki-integration"
+}
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/NoahBoos/obsidian-anki-integration

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
