### PR TITLE
Add plugin: Easy Copy

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16628,7 +16628,7 @@
   "id": "easy-copy",
   "name": "Easy Copy",
   "author": "Moy",
-  "description": "Easily copy the text inside inline code, or quickly obtain a elegant link to heading.",
+  "description": "Easily copy the text within inline code, bold text (and many other formats), or quickly generate an elegant link to a heading or block.",
   "repo": "Moyf/easy-copy"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16623,6 +16623,13 @@
     "author": "Van Nam",
     "description": "Track task completion with a visual progress bar in your sidebar, auto update column Kanban",
     "repo": "vannamhh/progress-tracker"
-  }
+},
+{
+  "id": "easy-copy",
+  "name": "Easy Copy",
+  "author": "Moy",
+  "description": "Easily copy the text inside inline code, or quickly obtain a elegant link to heading.",
+  "repo": "Moyf/easy-copy"
+}
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Moyf/easy-copy

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
