### PR TITLE
Add plugin: Punctuation Replacer

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15104,7 +15104,7 @@
     "author": "mbramani",
     "description": "Summarize YouTube videos using Gemini AI. Extract transcripts, generate summaries, and create structured notes.",
     "repo": "mbramani/obsidian-yt-video-summarizer"
-   },	
+   },
   {
     "id": "whatsapp-export-note",
     "name": "WhatsApp export note",
@@ -15216,7 +15216,7 @@
     "author": "Giorgos Sarigiannidis",
     "description": "Add variables in Templates and set their values on-the-fly during the Note creation.",
     "repo": "gsarig/obsidian-varinote"
-  },	
+  },
   {
     "id": "vector-search",
     "name": "Vector Search",
@@ -15279,7 +15279,7 @@
     "author": "Pavlo Kobyliatskyi",
     "description": "Memorizing words or phrases",
     "repo": "pavlokobyliatskyi/obsidian-memodack-plugin"
-  }, 
+  },
   {
     "id": "ai-hub",
     "name": "AI integration Hub",
@@ -15520,7 +15520,7 @@
   },
   {
     "id": "last-position",
-    "name": "Last Position",		
+    "name": "Last Position",
     "author": "saktawdi",
     "description": "Automatically scroll to the last viewed position when opening the markdown document.",
     "repo": "Saktawdi/obsidian-last-position"
@@ -15621,7 +15621,7 @@
     "name": "Rsync",
     "author": "Ganapathy Raman",
     "description": "Sync notes and automate backups using Rsync.",
-    "repo": "GanapathyRaman/rsync-plugin"  
+    "repo": "GanapathyRaman/rsync-plugin"
   },
   {
     "id": "extended-markdown-syntax",
@@ -15635,7 +15635,7 @@
     "name": "Paste Image Into Property",
     "author": "Nito",
     "description": "Allows pasting images from the clipboard into frontmatter properties in live preview.",
-    "repo": "Nitero/obsidian-paste-image-into-property"  
+    "repo": "Nitero/obsidian-paste-image-into-property"
   },
   {
     "id": "my-thesaurus",
@@ -15656,7 +15656,7 @@
     "name": "GridExplorer",
     "author": "Devon22",
     "description": "Browse note files in a grid view.",
-    "repo": "Devon22/obsidian-gridexplorer"  
+    "repo": "Devon22/obsidian-gridexplorer"
   },
   {
     "id": "infio-copilot",
@@ -15682,7 +15682,7 @@
   {
     "id": "cursor-position-history",
     "name": "Cursor Position History",
-    "author": "Florian Gubler", 
+    "author": "Florian Gubler",
     "description": "Remember the previous positions of the cursor across files: auto-scroll to the correct position in a new file. Navigate backward and forward through your cursor position history without losing context.",
     "repo": "fgubler/obsidian-cursor-position-history"
   },
@@ -15728,7 +15728,7 @@
         "description": "Convert indented code blocks with hierarchy markers into formatted ASCII tree diagrams.",
         "repo": "michalekmatej/obsidian.md-ascii-tree-generator"
     },
-    {	
+    {
         "id": "koi-sync",
         "name": "KOI Sync",
         "author": "Luke Miller",
@@ -15763,7 +15763,7 @@
     "description": "Generate blog posts from your notes using OpenAI",
     "repo": "garethng/obsidian-blog-generator"
    },
-  {    
+  {
     "id": "spaced-repetition-ai",
     "name": "Spaced Repetition AI",
     "author": "Belinda Mo, Athena Leong",
@@ -15824,7 +15824,7 @@
     "name": "SQLite DB",
     "author": "Stefano Frigerio",
     "description": "Interact with local SQLite files in your notes",
-    "repo": "stfrigerio/sqliteDB"  
+    "repo": "stfrigerio/sqliteDB"
   },
   {
     "id": "tab-group-arrangement",
@@ -15882,7 +15882,7 @@
     "description": "tidit adds timestamps to your document as you type — when you want it, how you want it, where you want it.",
     "repo": "codingthings-com/tidit-obsidian"
 },
-{	
+{
     "id": "copy-local-graph-paths",
     "name": "Copy Local Graph Paths",
     "author": "Amy Z",
@@ -15917,7 +15917,7 @@
     "description": "Provide an easier way to manipulate reading/editing and preview/source mode",
     "repo": "dk949/obsidian-mode-manager"
   },
-  {	
+  {
     "id": "note-placeholder",
     "name": "Note Placeholder",
     "author": "XZSt4nce",
@@ -15931,7 +15931,7 @@
     "description": "Convert URIs to internal links.",
     "repo": "wenlzhang/obsidian-uri-converter"
 },
-{  
+{
     "id": "inline-code-copy",
     "name": "Inline Code Copy",
     "author": "Hongchen Lin",
@@ -15944,7 +15944,7 @@
     "author": "Feirong.zfr",
     "description": "Manage student repositories.",
     "repo": "yingflower/obsidian-stu-repo-helper"
-},  
+},
  {
     "id": "infoflow",
     "name": "InfoFlow",
@@ -15973,7 +15973,7 @@
     "description": "all about CSV.",
     "repo": "Hangeol-Chang/obsidian-csv-allinone"
   },
-  {	  
+  {
     "id": "bookshelf",
     "name": "Bookshelf",
     "author": "Philip Weinke",
@@ -16049,6 +16049,14 @@
     "author": "wenlzhang",
     "description": "Synchronize titles between filename, frontmatter, and first heading in notes.",
     "repo": "wenlzhang/obsidian-file-title-updater"
-  }
+},
+{
+    "id": "punctuation-replacer",
+    "name": "标点符号替换器 (Punctuation Replacer)",
+    "author": "ZanderAlastor",
+    "description": "自动将中文标点符号替换为英文标点符号 (Automatically replace Chinese punctuation with English punctuation)",
+    "repo": "UFOAlastor/PunctuationReplacer",
+    "branch": "main"
+}
 ]
 


### PR DESCRIPTION
I am submitting a new Community Plugin  
Repo URL  
Link to my plugin: https://github.com/UFOAlastor/PunctuationReplacer  

Release Checklist  
- [x] I have tested the plugin on  
  - [x] Windows  
  - [ ] macOS (NOT Tested)  
  - [ ] Linux (NOT Tested)  
  - [ ] Android (if applicable) (NOT Tested)  
  - [ ] iOS (if applicable) (NOT Tested)  
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)  
  - [x] main.js  
  - [x] manifest.json  
  - [x] styles.css (optional)  
- [x] GitHub release name matches the exact version number specified in my manifest.json  
- [x] The id in my manifest.json matches the id in the community-plugins.json file.  
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.  
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies  
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines  
- [x] I have added a license in the LICENSE file.  
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.  
- [x] I have given proper attribution to these other projects in my README.md.  

---

**Punctuation Replacer**  
An Obsidian plugin that automatically converts Chinese punctuation marks to their English equivalents.  

### Key Features  
- Auto-replacement during typing  
- Manual replacement command (Ctrl+Shift+R)  
- Configurable auto-replacement toggle  

### Installation  
1. Open Obsidian Settings → Community plugins  
2. Disable "Safe mode"  
3. Search for "Punctuation Replacer"  
4. Install and enable  

### Support  
- GitHub Repository: https://github.com/UFOAlastor/PunctuationReplacer  
- License: MIT  