### PR TITLE
Request for TickTick quick add task plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16052,3 +16052,11 @@
   }
 ]
 
+{
+  "id": "ticktick-quickadd-plugin",
+  "name": "TickTick Quick Add Task",
+  "author": "Muxin Li",
+  "description": "Instantly creates a TickTick task from the current block of text in Obsidian using a keyboard shortcut. Task includes a copy of the text, and the URI to that exact block of text in your notes. Requires Advanced URI plugin.",
+  "repo": "muxinli/ticktick-quick-add-obsidian"
+}
+

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16053,10 +16053,10 @@
 ]
 
 {
-  "id": "ticktick-quickadd-plugin",
-  "name": "TickTick Quick Add Task",
-  "author": "Muxin Li",
-  "description": "Instantly creates a TickTick task from the current block of text in Obsidian using a keyboard shortcut. Task includes a copy of the text, and the URI to that exact block of text in your notes. Requires Advanced URI plugin.",
-  "repo": "muxinli/ticktick-quick-add-obsidian"
+    "id": "ticktick-quickadd-plugin",
+    "name": "TickTick Quick Add Task",
+    "author": "Muxin Li",
+    "description": "Instantly creates a TickTick task from the current block of text in Obsidian using a keyboard shortcut. Task includes a copy of the text, and the URI to that exact block of text in your notes. Requires Advanced URI plugin.",
+    "repo": "muxinli/ticktick-quick-add-obsidian"
 }
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -13389,7 +13389,7 @@
         "author": "AnAngryRaven",
         "description": "Enables the ability to open the sidebar by hovering over it.",
         "repo": "AnAngryRaven/obsidian-open-sidebar-on-hover"
-  },
+    },
   {
     "id": "onlyworlds-builder",
     "name": "OnlyWorlds Builder",
@@ -16049,14 +16049,12 @@
     "author": "wenlzhang",
     "description": "Synchronize titles between filename, frontmatter, and first heading in notes.",
     "repo": "wenlzhang/obsidian-file-title-updater"
-  }
+},
+    {
+        "id": "ticktick-quickadd-plugin",
+        "name": "TickTick Quick Add Task",
+        "author": "Muxin Li",
+        "description": "Instantly creates a TickTick task from the current block of text in Obsidian using a keyboard shortcut. Task includes a copy of the text, and the URI to that exact block of text in your notes. Requires Advanced URI plugin.",
+        "repo": "muxinli/ticktick-quick-add-obsidian"
+    }
 ]
-
-{
-    "id": "ticktick-quickadd-plugin",
-    "name": "TickTick Quick Add Task",
-    "author": "Muxin Li",
-    "description": "Instantly creates a TickTick task from the current block of text in Obsidian using a keyboard shortcut. Task includes a copy of the text, and the URI to that exact block of text in your notes. Requires Advanced URI plugin.",
-    "repo": "muxinli/ticktick-quick-add-obsidian"
-}
-

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16051,10 +16051,10 @@
     "repo": "wenlzhang/obsidian-file-title-updater"
 },
     {
-        "id": "ticktick-quickadd-plugin",
+        "id": "ticktick-quickadd-task",
         "name": "TickTick Quick Add Task",
         "author": "Muxin Li",
-        "description": "Instantly creates a TickTick task from the current block of text in Obsidian using a keyboard shortcut. Task includes a copy of the text, and the URI to that exact block of text in your notes. Requires Advanced URI plugin.",
+        "description": "Instantly creates a TickTick task from the current block of text in using a keyboard shortcut. Task includes a copy of the text, and the URI to that exact block of text in your notes. Requires Advanced URI plugin.",
         "repo": "muxinli/ticktick-quick-add-obsidian"
     }
 ]


### PR DESCRIPTION
Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)

TickTick Quick Add Plugin:
- Quick task creation from Obsidian notes to TickTick.
- Secure OAuth integration with automatic token refresh.
- Direct note linking via the Advanced URI plugin.
- Improved settings UI with secure credential input.