### PR TITLE
Add plugin: wiki-2-obsidian

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16056,6 +16056,6 @@
   "author": "Johannes Hans",
   "description": "Generates Obsidian Notes from Wikipedia entries",
   "repo": "CommandJoo/Wiki2Obsidian"
-},
+}
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16049,6 +16049,13 @@
     "author": "wenlzhang",
     "description": "Synchronize titles between filename, frontmatter, and first heading in notes.",
     "repo": "wenlzhang/obsidian-file-title-updater"
-  }
+},
+{
+  "id": "wiki-2-obsidian",
+  "name": "Wiki 2 Obsidian",
+  "author": "Johannes Hans",
+  "description": "Generates Obsidian Notes from Wikipedia entries",
+  "repo": "CommandJoo/Wiki2Obsidian"
+},
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/CommandJoo/Wiki2Obsidian

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
