### PR TITLE
Add plugin: Ghosty Posty

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16119,6 +16119,13 @@
     "author": "wenlzhang",
     "description": "Copy and paste formatting attributes (size and color) between canvas elements, similar to the format painter in Word.",
     "repo": "wenlzhang/obsidian-canvas-format-brush"
-  }
+  },
+{
+  "id": "ghosty-posty",
+  "name": "Ghosty Posty",
+  "author": "Matt Birchler",
+  "description": "Publish to Ghost from Obsidian",
+  "repo": "mattbirchler/ghosty-posty"
+}
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16124,7 +16124,7 @@
   "id": "ghosty-posty",
   "name": "Ghosty Posty",
   "author": "Matt Birchler",
-  "description": "Publish to Ghost from Obsidian",
+  "description": "Publish to Ghost with ease.",
   "repo": "mattbirchler/ghosty-posty"
 }
 ]


### PR DESCRIPTION
Adding the Ghosty Posty plugin that lets users post to Ghost from Obsidian.

# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/mattbirchler/ghosty-posty

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
