### PR TITLE
Add plugin: Quick Peek Sidebar

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16735,5 +16735,12 @@
     "author": "Mgussekloo",
     "description": "Automatically sort completed tasks to the bottom of the list.",
     "repo": "mgussekloo/obsidian-completedtasks"
-  }
+  },
+  {
+    "id": "quick-peek-sidebar",
+    "name": "Quick Peek Sidebar",
+    "author": "Bradley Wyatt",
+    "description": "Opens the left and/or right side panel by hovering over it.",
+    "repo": "bwya77/obsidian-quick-peek-sidebar"
+  }	
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/bwya77/obsidian-quick-peek-sidebar

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
