### PR TITLE
Add plugin: Japanese note taking helper

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17288,5 +17288,12 @@
     "author": "Muxin Li",
     "description": "Instantly creates a TickTick task from the current block of text using a keyboard shortcut. Task includes a copy of the text, and the URI to that exact block of text in your notes. Requires Advanced URI plugin.",
     "repo": "muxinli/ticktick-quick-add-obsidian"
+},
+{
+    "id": "japanese-helper",
+    "name": "Japanese note taking helper",
+    "author": "OverFitter",
+    "description": "An Obsidian plugin to streamline Japanese note-taking with romaji to kana conversion",
+    "repo": "OverFitted/obsidian-japanese-helper"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17293,7 +17293,7 @@
     "id": "japanese-helper",
     "name": "Japanese note taking helper",
     "author": "OverFitter",
-    "description": "An Obsidian plugin to streamline Japanese note-taking with romaji to kana conversion",
+    "description": "Streamline Japanese note-taking with romaji to kana conversion",
     "repo": "OverFitted/obsidian-japanese-helper"
 }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/OverFitted/obsidian-japanese-helper

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
