### PR TITLE
Replace unmaintained plugin at-people

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7325,8 +7325,8 @@
         "id": "at-people",
         "name": "At People",
         "description": "Use the familiar @ notation to cross link to people files in a people folder.",
-        "author": "Tobias Davis",
-        "repo": "saibotsivad/obsidian-at-people"
+        "author": "Terry van Walen (original by Tobias Davis)",
+        "repo": "TerryvanWalen/obsidian-at-people"
     },
     {
         "id": "archwiki-reader",


### PR DESCRIPTION
# I am replacing an existing Community Plugin
This plugin seems to have been unmaintained for the past 2 years. There are several open PR's and issues on the repo where no response was provided by the author. Github user hExPY has also tried to email the author but did not get a response. This fork aims to address the raised issues and restore active development


## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/TerryvanWalen/obsidian-at-people

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ ] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [ ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
