### PR TITLE
Add theme: Enhanced file explorer tree

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2444,7 +2444,7 @@
     "name": "Enhanced file explorer tree",
     "author": "LennZone",
     "repo": "LennZone/enhanced-file-explorer-tree",
-    "screenshot": "enhanced-file-explorer-tree.png",
+    "screenshot": "thumbnail.png",
     "modes": ["dark", "light"]
    }
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2443,8 +2443,8 @@
   {
     "name": "Enhanced file explorer tree",
     "author": "LennZone",
-    "repo": "LennZone/obsidian-enhanced-file-explorer",
-    "screenshot": "obsidian-enhanced-file-explorer.png",
+    "repo": "LennZone/obsidian-enhanced-file-explorer-tree",
+    "screenshot": "obsidian-enhanced-file-explorer-tree.png",
     "modes": ["dark", "light"]
    }
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2439,5 +2439,12 @@
     "repo": "MrParalloid/obsidian-things",
     "screenshot": "things-screenshot.jpg",
     "modes": ["dark", "light"]
-  }
+  },
+  {
+    "name": "Enhanced file explorer tree",
+    "author": "LennZone",
+    "repo": "LennZone/obsidian-enhanced-file-explorer",
+    "screenshot": "obsidian-enhanced-file-explorer.png",
+    "modes": ["dark", "light"]
+   }
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2443,8 +2443,8 @@
   {
     "name": "Enhanced file explorer tree",
     "author": "LennZone",
-    "repo": "LennZone/obsidian-enhanced-file-explorer-tree",
-    "screenshot": "obsidian-enhanced-file-explorer-tree.png",
+    "repo": "LennZone/enhanced-file-explorer-tree",
+    "screenshot": "enhanced-file-explorer-tree.png",
     "modes": ["dark", "light"]
    }
 ]


### PR DESCRIPTION
# I am submitting a new Community Theme

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my theme: 
https://github.com/LennZone/obsidian-enhanced-file-explorer-tree

## Theme checklist

<!--- Confirm that you have done the following before submitting your theme -->
- [x] My repo contains all required files (please *do not* add them to this `obsidian-releases` repo).
  - [x] `manifest.json`
  - [x] `theme.css`
  - [x] The screenshot file (16:9 aspect ratio, recommended size is 512px by 288px for fast loading).
- [x] I have indicated which modes (dark, light, or both) are compatible with my theme.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my theme's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Themes/App+themes/Theme+guidelines and have self-reviewed my theme to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other themes that I'm using. I have given proper attribution to these other themes in my `README.md`.
