### PR TITLE
Add Gemini Copilot plugin to community plugins list

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15048,5 +15048,12 @@
     "author": "Ben Rotholtz",
     "description": "Track your goals with a calendar view",
     "repo": "GizmoRay/obsidian-goal-tracker"  
+  },
+  {
+    "id": "obsidian-gemini-copilot",
+    "name": "gemini-copilot",
+    "author": "ikpark09",
+    "description": "Obsidian copilot plugin that leverages the Gemini API. Provides note title generation, summary, and tag generation.",
+    "github": "ikpark09/obsidian-gemini-copilot"
   }
 ]


### PR DESCRIPTION
Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
