### PR TITLE
include "VSCode" in the description of the open-vscode plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1508,7 +1508,7 @@
         "id": "open-vscode",
         "name": "Open vault in VS Code",
         "author": "NomarCub",
-        "description": "Ribbon button and command to open vault as a Visual Studio Code workspace.",
+        "description": "Ribbon button and command to open vault as a Visual Studio Code (VSCode) workspace.",
         "repo": "NomarCub/obsidian-open-vscode"
     },
     {


### PR DESCRIPTION
include "VSCode" in the description of the open-vscode plugin so it shows up inside Obsidian when searched
