### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16441,5 +16441,11 @@
   "author": "schaier-io",
   "description": "Track GitHub issues and pull requests in your vault",
   "repo": "schaier-io/obsidian-github-tracker-plugin"
+},
+{
+  "id": "note-switcher",
+  "name": "Note Switcher",
+  "repo": "Christian1723/note-switcher",
+  "owner": "Christian1723"
 }
 ]


### PR DESCRIPTION
Add Note Switcher plugin to the community plugins list.

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)

### description

- **Plugin Name**: Note Switcher
- **Version**: 1.0.1
- **Link to Repository**: https://github.com/Christian1723/note-switcher
- **Descpription **: This Plugin allows the quick change between notes in Obsidian within the chosen folder or the complete vault. 

### Author
- **Name**: Christian1723 

### Installation
- **How to install?**
  - You can install the plugin out of the Community-Plugin-Directory from Obsidian

### Lizenz
- **Lizenz**: MIT
