### PR TITLE
Add plugin: Isolate Folder

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16448,7 +16448,5 @@
   "author": "Cyberistic",
   "description": "Isolate a folder in the file explorer, hiding all other folders and files. Similar to 'Open Folder' in other apps. Useful for focusing, recording, or if you don't want others to see all your notes.",
   "repo": "Cyberistic/obsidian-isolate-folder"
-}
-	
-	
+},
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16443,11 +16443,11 @@
   "repo": "schaier-io/obsidian-github-tracker-plugin"
 }, 
 	{
-  "id": "Isolate-Folder",
+  "id": "isolate-folder",
   "name": "Isolate Folder",
   "author": "Cyberistic",
   "description": "Isolate a folder in the file explorer, hiding all other folders and files. Similar to 'Open Folder' in other apps. Useful for focusing, recording, or if you don't want others to see all your notes.",
-  "repo": "https://github.com/Cyberistic/obsidian-isolate-folder"
+  "repo": "Cyberistic/obsidian-isolate-folder"
 }
 	
 	

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16441,5 +16441,14 @@
   "author": "schaier-io",
   "description": "Track GitHub issues and pull requests in your vault",
   "repo": "schaier-io/obsidian-github-tracker-plugin"
+}, 
+	{
+  "id": "Isolate-Folder",
+  "name": "Isolate Folder",
+  "author": "Cyberistic",
+  "description": "Isolate a folder in the file explorer, hiding all other folders and files. Similar to 'Open Folder' in other apps. Useful for focusing, recording, or if you don't want others to see all your notes.",
+  "repo": "https://github.com/Cyberistic/obsidian-isolate-folder"
 }
+	
+	
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16448,5 +16448,5 @@
   "author": "Cyberistic",
   "description": "Isolate a folder in the file explorer, hiding all other folders and files. Similar to 'Open Folder' in other apps. Useful for focusing, recording, or if you don't want others to see all your notes.",
   "repo": "Cyberistic/obsidian-isolate-folder"
-},
+}
 ]


### PR DESCRIPTION
Add plugin: Isolate Folder

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Cyberistic/obsidian-isolate-folder
 
## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [X]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
