### PR TITLE
Add checkbox-sort to community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16441,5 +16441,12 @@
   "author": "schaier-io",
   "description": "Track GitHub issues and pull requests in your vault",
   "repo": "schaier-io/obsidian-github-tracker-plugin"
-}
+},
+{
+  "id": "obsidian-checkbox-sort",
+  "name": "Obsidian Checkbox Sort",
+  "author": "mattang687",
+  "description": "Automatically moves completed checkboxes to the end of the list",
+  "repo": "mattang687/obsidian-checkbox-sort"
+},
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16448,5 +16448,5 @@
   "author": "mattang687",
   "description": "Automatically moves completed checkboxes to the end of the list",
   "repo": "mattang687/obsidian-checkbox-sort"
-},
+}
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16443,8 +16443,8 @@
   "repo": "schaier-io/obsidian-github-tracker-plugin"
 },
 {
-  "id": "obsidian-checkbox-sort",
-  "name": "Obsidian Checkbox Sort",
+  "id": "checkbox-sort",
+  "name": "Checkbox Sort",
   "author": "mattang687",
   "description": "Automatically moves completed checkboxes to the end of the list",
   "repo": "mattang687/obsidian-checkbox-sort"


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/mattang687/obsidian-checkbox-sort

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
