### PR TITLE
Add plugin: Note UID Generator

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17409,10 +17409,10 @@
     "repo": "artemDvoryadkin/obsidian-vim-marker-sharpener"
   },
   {
-  	"id": "pure-chat-llm",
-  	"name": "Pure Chat LLM",
-  	"author": "Justice Vellacott",
-  	"description": "Turn notes into conversations with chatGPT",
+    "id": "pure-chat-llm",
+    "name": "Pure Chat LLM",
+    "author": "Justice Vellacott",
+    "description": "Turn notes into conversations with chatGPT",
     "repo": "TheJusticeMan/pure-chat-llm"
   },
   {
@@ -17421,12 +17421,40 @@
     "author": "insile",
     "description": "用于英语学习中背单词与单词管理的插件",
     "repo": "insile/OpenWords"
-},
-{
+  },
+  {
+    "id": "smooth-navigator",
+    "name": "Smooth Navigator",
+    "author": "Michael Schrauzer",
+    "description": "Smoothly cycle through open files and splits via the keyboard.",
+    "repo": "gasparschott/smooth-navigator"
+  },
+  {
+    "id": "duplicate-line",
+    "name": "Duplicate line",
+    "author": "Marcin Sztolcman",
+    "description": "Duplicate line or selection with single hotkey.",
+    "repo": "msztolcman/obsidian-duplicate-line"
+  },
+  {
+    "id": "github-tracker",
+    "name": "GitHub Tracker",
+    "author": "schaier-io",
+    "description": "Track GitHub issues and pull requests in your vault",
+    "repo": "schaier-io/obsidian-github-tracker-plugin"
+  },
+  {
     "id": "course-module-loader",
     "name": "Course Module Loader",
     "author": "Sebastian Kamilli",
     "description": "Downloads and unzips course module zip files from a URL into a specified vault folder, skipping existing files.",
     "repo": "QuintSmart/obsidian-course-module-loader"
- }
+  },
+  {
+    "id": "note_uid_generator",
+    "name": "Note UID Generator",
+    "author": "Valentin Pelletier",
+    "description": "Automatically or manually generates Unique IDs (UIDs) for notes and registers them in metadata (frontmatter).",
+    "repo": "Netajam/obsidian_note_uid_generator"
+  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17423,27 +17423,6 @@
     "repo": "insile/OpenWords"
   },
   {
-    "id": "smooth-navigator",
-    "name": "Smooth Navigator",
-    "author": "Michael Schrauzer",
-    "description": "Smoothly cycle through open files and splits via the keyboard.",
-    "repo": "gasparschott/smooth-navigator"
-  },
-  {
-    "id": "duplicate-line",
-    "name": "Duplicate line",
-    "author": "Marcin Sztolcman",
-    "description": "Duplicate line or selection with single hotkey.",
-    "repo": "msztolcman/obsidian-duplicate-line"
-  },
-  {
-    "id": "github-tracker",
-    "name": "GitHub Tracker",
-    "author": "schaier-io",
-    "description": "Track GitHub issues and pull requests in your vault",
-    "repo": "schaier-io/obsidian-github-tracker-plugin"
-  },
-  {
     "id": "course-module-loader",
     "name": "Course Module Loader",
     "author": "Sebastian Kamilli",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Netajam/obsidian_note_uid_generator

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
