### PR TITLE
Add plugin: logos-refs

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16938,6 +16938,13 @@
   "author": "mattang687",
   "description": "Automatically moves completed checkboxes to the end of the list",
   "repo": "mattang687/obsidian-checkbox-sort"
+},
+{
+  "id": "logos-refs",
+  "name": "logos-refs",
+  "author": "Joey Kilgore",
+  "description": "Easily take refs from Logos into Obsidian",
+  "repo": "joey-kilgore/logos-refs"
 }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16943,7 +16943,7 @@
   "id": "logos-refs",
   "name": "logos-refs",
   "author": "Joey Kilgore",
-  "description": "Easily take refs from Logos into Obsidian",
+  "description": "Easily take refs from Logos and connect them within your notes",
   "repo": "joey-kilgore/logos-refs"
 }
 ]


### PR DESCRIPTION
logos-refs allows for incorporating Logos (a powerful bible reference software) into your obsidian workflow and notes.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/joey-kilgore/logos-refs

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
