### PR TITLE
Add plugin: Custom Commands

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16952,5 +16952,13 @@
     "author": "@tazihad",
     "description": "Easy Keep View mimics the Google Keep interface, allowing you to view and manage your notes with image thumbnails and excerpts.",
     "repo": "tazihad/obsidian-easy-keep-view"
+},
+{
+  "id": "custom-commands",
+  "name": "Custom Commands",
+  "description": "Create custom commands to be executed in the command palette, and by hotkey. Currently supports opening specific notes, creating notes, inserting snippets, and executing sequences of commands.",
+  "author": "Staaaaaaaaaan",
+  "repo": "Staaaaaaaaaan/obsidian-custom-commands"
 }
 ]
+


### PR DESCRIPTION
Adding the custom commands plugin

# I am submitting a new Community Plugin

## Repo URL

https://github.com/Staaaaaaaaaan/obsidian-custom-commands

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [x ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
