### PR TITLE
Add plugin: Mark Open Files

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17015,6 +17015,13 @@
     "author": "lowit",
     "description": "Find and remove outdated tasks.",
     "repo": "lowitea/obsidian-tasks-cleaner"
-  }
+  },
+{
+	"id": "mark-open-files",
+	"name": "Mark Open Files",
+	"author": "Michael Schrauzer",
+	"description": "Enhances the File Explorer by adding a marker to all the File Explorer items that are currently open in the workspace.",
+	"repo": "https://github.com/gasparschott/"
+}
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17021,7 +17021,7 @@
 	"name": "Mark Open Files",
 	"author": "Michael Schrauzer",
 	"description": "Enhances the File Explorer by adding a marker to all the File Explorer items that are currently open in the workspace.",
-	"repo": "https://github.com/gasparschott/"
+	"repo": "gasparschott/mark-open-files"
 }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17021,7 +17021,7 @@
 	"name": "Mark Open Files",
 	"author": "Michael Schrauzer",
 	"description": "Enhances the File Explorer by adding a marker to all the File Explorer items that are currently open in the workspace.",
-	"repo": "gasparschott/mark-open-files"
+	"repo": "gasparschott/obsidian-mark-open-files"
 }
 ]
 


### PR DESCRIPTION
Enhances the File Explorer by adding a marker to all the File Explorer items that are currently open in the workspace.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:
https://github.com/gasparschott/obsidian-mark-open-files

## Release Checklist
- [X] I have tested the plugin on
  - [ ]  Windows
  - [X]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
