### PR TITLE
Add plugin: Format Automatically with Prettier

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16484,6 +16484,13 @@
     "description": "Dark/light theme toggle via ribbon icon or command.",
     "repo": "gapmiss/theme-toggle"
 },
+{
+    "id": "prettier-format",
+    "name": "Format Automatically with Prettier",
+    "author": "Dylan Armstrong",
+    "description": "Format files with Prettier using built-in settings for configuration.",
+    "repo": "dylanarmstrong/obsidian-prettier-plugin"
+},
  {
     "id": "data-fetcher",
     "name": "Data Fetcher",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16484,13 +16484,6 @@
     "description": "Dark/light theme toggle via ribbon icon or command.",
     "repo": "gapmiss/theme-toggle"
 },
-{
-    "id": "prettier-format",
-    "name": "Format Automatically with Prettier",
-    "author": "Dylan Armstrong",
-    "description": "Format files with Prettier using built-in settings for configuration.",
-    "repo": "dylanarmstrong/obsidian-prettier-plugin"
-},
  {
     "id": "data-fetcher",
     "name": "Data Fetcher",
@@ -17029,6 +17022,13 @@
 	"author": "Michael Schrauzer",
 	"description": "Enhances the File Explorer by adding a marker to all the File Explorer items that are currently open in the workspace.",
 	"repo": "gasparschott/obsidian-mark-open-files"
-}
+},
+  {
+    "id": "prettier-format",
+    "name": "Format Automatically with Prettier",
+    "author": "Dylan Armstrong",
+    "description": "Format files with Prettier using built-in settings for configuration.",
+    "repo": "dylanarmstrong/obsidian-prettier-plugin"
+  }
 ]
 


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/dylanarmstrong/obsidian-prettier-plugin

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
