### PR TITLE
feat: added plugin for rounded borders to images

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16511,6 +16511,13 @@
     "author": "qf3l3k",
     "description": "Fetch data from multiple sources (REST APIs, RPC, gRPC, GraphQL) and insert results into notes",
     "repo": "qf3l3k/obsidian-api-fetcher"
-  }
+  },
+	{
+	  "id": "image-border-style",
+  	"name": "Image Border Style",
+  	"author": "Anurag Shenoy",
+  	"description": "Border styling for images in Obsidian notes.",
+  	"repo": "shenoy-anurag/obsidian-image-border-style"
+	}
 ]
 


### PR DESCRIPTION
With this plugin, you can:
- Have nice rounded borders (or not) for images from no-border, to a 2px border all the way to a 32px border.

Default border radius is same as one in Notion.

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
