### PR TITLE
Add plugin: Eccidian encryption

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16511,7 +16511,7 @@
     "author": "qf3l3k",
     "description": "Fetch data from multiple sources (REST APIs, RPC, gRPC, GraphQL) and insert results into notes",
     "repo": "qf3l3k/obsidian-api-fetcher"
-  }
+  },
 {
 	"id": "Eccidian-plugin",
 	"name": "Eccidian Encrypt",


### PR DESCRIPTION
This PR adds the Eccidian plugin, a secure encryption plugin for Obsidian that allows users to encrypt notes using AES or ECC with a custom `.eccidian` extension.

Link: https://github.com/Enthalpiex/Eccidian-Encrypt