### PR TITLE
Add Macros Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16512,12 +16512,13 @@
     "description": "Fetch data from multiple sources (REST APIs, RPC, gRPC, GraphQL) and insert results into notes",
     "repo": "qf3l3k/obsidian-api-fetcher"
   },
-]{
-  "id": "macros-plugin",
-  "name": "Macros Plugin",
-  "author": "JamesCliffordSpratt",
-  "description": "Advanced nutrition tracking for Obsidian with dynamic macros blocks, FatSecret integration, and pie chart visualizations.",
-  "repo": "JamesCliffordSpratt/obsidian-macros-plugin",
-  "version": "1.0.0"
-}
+ {
+    "id": "macros-plugin",
+    "name": "Macros Plugin",
+    "author": "JamesCliffordSpratt",
+    "description": "Advanced nutrition tracking with dynamic macros blocks, FatSecret integration, and pie chart visualizations.",
+    "repo": "JamesCliffordSpratt/obsidian-macros-plugin",
+    "version": "1.0.0"
+  }
+]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16511,6 +16511,13 @@
     "author": "qf3l3k",
     "description": "Fetch data from multiple sources (REST APIs, RPC, gRPC, GraphQL) and insert results into notes",
     "repo": "qf3l3k/obsidian-api-fetcher"
-  }
-]
+  },
+]{
+  "id": "macros-plugin",
+  "name": "Macros Plugin",
+  "author": "JamesCliffordSpratt",
+  "description": "Advanced nutrition tracking for Obsidian with dynamic macros blocks, FatSecret integration, and pie chart visualizations.",
+  "repo": "JamesCliffordSpratt/obsidian-macros-plugin",
+  "version": "1.0.0"
+}
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16513,12 +16513,11 @@
     "repo": "qf3l3k/obsidian-api-fetcher"
   },
  {
-    "id": "macros-plugin",
-    "name": "Macros Plugin",
+    "id": "macros",
+    "name": "Macros",
     "author": "JamesCliffordSpratt",
     "description": "Advanced nutrition tracking with dynamic macros blocks, FatSecret integration, and pie chart visualizations.",
-    "repo": "JamesCliffordSpratt/obsidian-macros-plugin",
-    "version": "1.0.0"
+    "repo": "JamesCliffordSpratt/obsidian-macros-plugin"
   }
 ]
 


### PR DESCRIPTION
## New Plugin: Macros

**GitHub Repo:** https://github.com/JamesCliffordSpratt/obsidian-macros

### Checklist

- [x] I have tested this plugin on:
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] I have ensured that the `manifest.json` file includes correct `id`, `name`, `version`, and matches the plugin folder name.
- [x] I have added a valid entry to `community-plugins.json`.

### Description

This plugin brings advanced nutrition tracking to Obsidian:

- Search foods with the FatSecret API and save them to markdown
- Create dynamic `macros` blocks with full nutritional info
- Visualize daily macros using pie charts
- Use meal templates, interactive controls, and block merging

Includes GIFs, YouTube demo, and is MIT licensed.
