### PR TITLE
adjust description of image context menus plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1473,7 +1473,7 @@
         "id": "copy-url-in-preview",
         "name": "Image Context Menus",
         "author": "NomarCub",
-        "description": "Copy, open in default app, show in system explorer, reveal in navigation context menu for images. Also Open PDF externally context menu.",
+        "description": "Image context menus (mostly on right click): Copy to clipboard, Open in default app, Show in system explorer, Reveal file in navigation, Open in new tab.",
         "repo": "NomarCub/obsidian-copy-url-in-preview"
     },
     {


### PR DESCRIPTION
adjust description of image context menus plugin to new and cut functionality as of new update: https://github.com/NomarCub/obsidian-copy-url-in-preview/releases/tag/1.10.0