### PR TITLE
Add plugin: Study Tracker

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16090,7 +16090,7 @@
     "name": "Wordflow Tracker",
     "author": "LeCheenaX",
     "description": "Track the changes and stats of your edited note files automatically. Record the modified notes and statistics to your daily note",
-    "repo": "LeCheenaX/WordFlow-Tracker"  
+    "repo": "LeCheenaX/WordFlow-Tracker"
 },
 {
     "id": "mathtype",
@@ -16230,7 +16230,7 @@
 "name": "Collapsible Code Blocks",
 "author": "Bradley Wyatt",
 "description": "Makes code blocks collapsible in preview mode as well as enabling scroll-able code blocks.",
-"repo": "bwya77/collapsible-code-blocks"  
+"repo": "bwya77/collapsible-code-blocks"
 },
 {
     "id": "cmd-search",
@@ -16255,7 +16255,7 @@
 },
 {
     "id": "auto-folder-note-paste",
-    "name": "Auto Folder Note Paste",		
+    "name": "Auto Folder Note Paste",
     "author": "d7sd6u",
     "description": "Automagically convert the note to a folder note when pasting or drag'n'dropping an attachment.",
     "repo": "d7sd6u/obsidian-auto-folder-note-paste"
@@ -16352,10 +16352,10 @@
     "repo": "semanticdata/obsidian-pomodoro"
   },
   {
-    "id": "generate-timeline", 
-    "name": "Generate Timeline", 
+    "id": "generate-timeline",
+    "name": "Generate Timeline",
     "author": "Shanshuimei",
-    "description": "Generate timelines from tag or folder automatically by any time properties.", 
+    "description": "Generate timelines from tag or folder automatically by any time properties.",
     "repo": "Shanshuimei/obsidian-generate-timeline"
   },
   {
@@ -16384,7 +16384,7 @@
     "name": "HiNote",
     "author": "Kai",
     "description": "Add comments to highlighted notes, use AI for thinking, and flashcards for memory.",
-    "repo": "CatMuse/HiNote"  
+    "repo": "CatMuse/HiNote"
   },
   {
     "id": "private-mode",
@@ -16496,9 +16496,9 @@
     "name": "Jira Issue Manager",
     "author": "Alamion",
     "description": "Get Jira issues, create and update them. Issue status and worklog management.",
-    "repo": "Alamion/obsidian-jira-sync"  
+    "repo": "Alamion/obsidian-jira-sync"
 },
-{  
+{
     "id": "theme-toggle",
     "name": "Theme toggle",
     "author": "@gapmiss",
@@ -16511,6 +16511,14 @@
     "author": "qf3l3k",
     "description": "Fetch data from multiple sources (REST APIs, RPC, gRPC, GraphQL) and insert results into notes",
     "repo": "qf3l3k/obsidian-api-fetcher"
+  },
+ {
+    "id": "study-tracker",
+    "name": "Study Tracker",
+    "author": "orsenthil",
+    "description": "An Obsidian plugin to track study sessions for notes. Keep count of how many times you've studied each note, helping you track your progress and maintain a consistent study schedule.",
+    "repo": "orsenthil/obsidian-study-tracker"
   }
+
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16516,7 +16516,7 @@
     "id": "study-tracker",
     "name": "Study Tracker",
     "author": "orsenthil",
-    "description": "An Obsidian plugin to track study sessions for notes. Keep count of how many times you've studied each note, helping you track your progress and maintain a consistent study schedule.",
+    "description": "A plugin to track study sessions for notes. It keeps count of how many times you've studied each note, helping you track your progress and maintain a consistent study schedule.",
     "repo": "orsenthil/obsidian-study-tracker"
   }
 


### PR DESCRIPTION
Submitting a new community plugin to track study session counts in obsidian.

## Repo URL

<!--- Paste a link to your repo here for easy access -->

Link to my plugin: https://github.com/orsenthil/obsidian-study-tracker

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
