### PR TITLE
Remove relay-md plugin (consolidated into Relay by System 3)

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -9506,13 +9506,6 @@
         "repo": "KubaMiszcz/MultiStateCheckBoxSwitcher"
     },
     {
-        "id": "relay-md",
-        "name": "Relay.md",
-        "description": "Quickly and easily share notes with your team. Uses topics to limit reach so that only team members subscribed to your topics will automatically receive the shared notes straight into their vault!",
-        "author": "xeroc",
-        "repo": "relay-md/relay-md-obsidian-plugin"
-    },
-    {
         "id": "insighta",
         "name": "InsightA",
         "author": "Hongjian Tang",


### PR DESCRIPTION
Removes the relay-md plugin from community plugins as it has been consolidated into Relay by System 3.
- The relay-md repository is now private
- https://forum.obsidian.md/t/request-to-remove-relay-md-plugin-now-consolidated-with-relay-by-system-3/99149
