### PR TITLE
Add relay-md to removed plugins list

### DIFF
--- a/community-plugins-removed.json
+++ b/community-plugins-removed.json
@@ -410,11 +410,6 @@
     "reason": "Developer banned from GitHub"
   },
   {
-    "id": "relay-md",
-    "name": "Relay.md",
-    "reason": "Replaced by Relay by System 3"
-    },
-  {
     "id": "repeat-last-commands",
     "name": "Repeat Last Command(s)",
     "reason": "Developer banned from GitHub"
@@ -613,5 +608,10 @@
     "id": "obsidian-vim-im-switch-plugin",
     "name": "Vim Input Method Switch",
     "reason": "No longer maintained"
+  },
+  {
+  "id": "relay-md",
+  "name": "Relay.md",
+  "reason": "Replaced by Relay by System 3"
   }
 ]

--- a/community-plugins-removed.json
+++ b/community-plugins-removed.json
@@ -410,6 +410,11 @@
     "reason": "Developer banned from GitHub"
   },
   {
+    "id": "relay-md",
+    "name": "Relay.md",
+    "reason": "Replaced by Relay by System 3"
+    },
+  {
     "id": "repeat-last-commands",
     "name": "Repeat Last Command(s)",
     "reason": "Developer banned from GitHub"


### PR DESCRIPTION
Adding relay-md entry to removed plugins list with reason "Replaced by Relay by System 3". https://forum.obsidian.md/t/request-to-remove-relay-md-plugin-now-consolidated-with-relay-by-system-3/99149

