### PR TITLE
Add Plugin: unique-id-generator & callout-autocomplete

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16497,20 +16497,34 @@
     "author": "Alamion",
     "description": "Get Jira issues, create and update them. Issue status and worklog management.",
     "repo": "Alamion/obsidian-jira-sync"  
-},
-{  
+  },
+  {  
     "id": "theme-toggle",
     "name": "Theme toggle",
     "author": "@gapmiss",
     "description": "Dark/light theme toggle via ribbon icon or command.",
     "repo": "gapmiss/theme-toggle"
-},
- {
+  },
+  {
     "id": "data-fetcher",
     "name": "Data Fetcher",
     "author": "qf3l3k",
     "description": "Fetch data from multiple sources (REST APIs, RPC, gRPC, GraphQL) and insert results into notes",
     "repo": "qf3l3k/obsidian-api-fetcher"
+  },
+  {
+   "id": "unique-id-generator",
+   "name": "UID Generator",
+   "author": "Albert Bekaev",
+   "description": "Adds unique IDs to frontmatter.",
+   "repo": "albertuss/obsidian-uid-generator"
+  },
+  {
+   "id": "callout-autocomplete",
+   "name": "Callout Autocomplete",
+   "author": "Albert Bekaev",
+   "description": "Add-on for Callout Manager plugin.",
+   "repo": "albertuss/obsidian-callout-autocomplete"
   }
 ]
 


### PR DESCRIPTION
### Plugin Submission

#### Plugin Name
- Unique ID Generator
- Callout Autocomplete

#### Plugin Description
- **Unique ID Generator**: A plugin that generates unique IDs for notes in Obsidian.
- **Callout Autocomplete**: A plugin that provides autocomplete suggestions for callouts in Obsidian.

#### Plugin Repository
- **Unique ID Generator**: https://github.com/albertuss/obsidian-uid-generator
- **Callout Autocomplete**: https://github.com/albertuss/obsidian-callout-autocomplete

#### Checklist
- [x] I confirm that the plugin meets the [Obsidian plugin guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines).
- [x] I confirm that the plugin has a LICENSE file in the repository.
- [x] I confirm that the plugin has been tested and works with the latest version of Obsidian.