### PR TITLE
Add plugin: Google Contacts Sync

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16511,6 +16511,13 @@
     "author": "qf3l3k",
     "description": "Fetch data from multiple sources (REST APIs, RPC, gRPC, GraphQL) and insert results into notes",
     "repo": "qf3l3k/obsidian-api-fetcher"
+  },
+  {
+    "id": "google-contacts-sync",
+    "name": "Google Contacts Sync",
+    "author": "aleksejs1",
+    "description": "Synchronize your Google Contacts directly into Obsidian.",
+    "repo": "aleksejs1/obsidian-contact-sync-plugin"
   }
 ]
 


### PR DESCRIPTION
Add plugin Google Contacts Sync for synchronize your Google Contacts directly into Obsidian