### PR TITLE
Add new plugin: Folder Property Manager

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16511,6 +16511,13 @@
     "author": "qf3l3k",
     "description": "Fetch data from multiple sources (REST APIs, RPC, gRPC, GraphQL) and insert results into notes",
     "repo": "qf3l3k/obsidian-api-fetcher"
-  }
+  },
+    {
+        "id": "folder-properties-manager",
+        "name": "Folder Property Manager",
+        "author": "elekis",
+        "description": "Get a view of all properties of a folder",
+        "repo": "elekis-git/obsidian-properties-view"
+    }
 ]
 


### PR DESCRIPTION
## Plugin description

Folder Property Manager gives users a global view of all properties across the notes of a folder. It allows better organization and quick access to frontmatter metadata.

## Repo URL

https://github.com/elekis-git/obsidian-properties-view

## Manifest

- ID: folder-properties-manager
- Name: Folder Property Manager
- Author: elekis
- Description: Get a view of all properties of a folder (allow to modify value)

## Checklist

- [x] I’ve verified that the plugin works with the latest version of Obsidian.
- [x] I've included `manifest.json`, `main.js`, and (optionally) `styles.css` in the latest release.
- [x] My GitHub release tag matches the `version` field in `manifest.json`.
- [x] The plugin ID in `manifest.json` matches the ID in this PR.
- [x] I’ve tested the plugin on macOS, Windows, or Linux.

Thanks for reviewing 🙏
