### PR TITLE
Media Extended v4 License Change & Review Request

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -983,7 +983,7 @@
         "id": "media-extended",
         "name": "Media Extended",
         "author": "AidenLx",
-        "description": "Integrate, manage, and play video or audio directly in Obsidian. (Closed source)",
+        "description": "Integrate, manage video or audio directly in your notes, with enhanced playback and timestamp support. (Closed source)",
         "repo": "aidenlx/media-extended"
     },
     {

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -983,7 +983,7 @@
         "id": "media-extended",
         "name": "Media Extended",
         "author": "AidenLx",
-        "description": "Add extended media features for video and audio, including timestamp links and playback speed.",
+        "description": "Integrate, manage, and play video or audio directly in Obsidian. (Closed source)",
         "repo": "aidenlx/media-extended"
     },
     {


### PR DESCRIPTION
We're transitioning Media Extended from MIT to a closed-source license with the upcoming v4 release, which is currently in beta testing. As per Obsidian Developer Policies, we're requesting a review from the Obsidian team prior to our first official release under the new license structure.

- The plugin will be moving from MIT to a closed-source license model
- We have invited @joethei to the private codebase repository for review
- Further technical details and implementation specifics will be discussed in the private repository

We're available to answer any questions or address concerns about this license transition. We understand this requires case-by-case review per your policies and appreciate your time evaluating our submission.

Intro about the codebase of obsidian plugin could be found in /apps/obsidian/README.md (currently updating)