### PR TITLE
Add plugin: Simple Tab Indent

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17309,5 +17309,12 @@
     "author": "Brians Tjipto",
     "description": "Uses AI to answer questions and create notes about your vault with proper citations",
     "repo": "brianstm/obsidian-vault-llm-assistant"
-  }
+},
+{
+  "id": "simple-tab-indent",
+  "name": "Simple Tab Indent",
+  "description": "Pressing Tab inserts a zero-width space + real tab, giving true indentation without triggering Markdown code blocks. Includes a settings panel to change the CSS tab width.",
+  "author": "Thiago Frias",
+  "repo": "hoomersinpsom/simple-tab-indent"
+}
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17311,10 +17311,10 @@
     "repo": "brianstm/obsidian-vault-llm-assistant"
 },
 {
-  "id": "simple-tab-indent",
-  "name": "Simple Tab Indent",
-  "description": "Pressing Tab inserts a zero-width space + real tab, giving true indentation without triggering Markdown code blocks. Includes a settings panel to change the CSS tab width.",
-  "author": "Thiago Frias",
-  "repo": "hoomersinpsom/simple-tab-indent"
+    "id": "simple-tab-indent",
+    "name": "Simple Tab Indent",
+    "description": "Pressing Tab inserts a zero-width space + real tab, giving true indentation without triggering Markdown code blocks. Includes a settings panel to change the CSS tab width.",
+    "author": "Thiago Frias",
+    "repo": "hoomersinpsom/simple-tab-indent"
 }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
https://github.com/hoomersinpsom/simple-tab-indent

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
