### PR TITLE
Add Markdown Hijacker plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16644,6 +16644,13 @@
     "author": "Shawn",
     "description": "Share selected text as beautiful images.",
     "repo": "iqijun/obsidian-image-share"
+  },
+  {
+    "id": "markdown-hijacker",
+    "name": "Markdown Hijacker",
+    "author": "Yongmini",
+    "description": "Beyond the Vault. One hub for every Markdown, everywhere",
+    "repo": "especialkim/obsidian-markdown-hijacker"
   }
 ]
 


### PR DESCRIPTION
### Submit Markdown Hijacker plugin

Markdown Hijacker is a plugin for syncing external folders into your Obsidian vault.
GitHub: https://github.com/especialkim/obsidian-markdown-hijacker