### PR TITLE
Add plugin: Markwhen File Sync

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17215,8 +17215,8 @@
 {
   "id": "markfilesync",
   "name": "Markwhen File Sync",
-  "author": "rpj-07",
+  "author": "rouvenjahnke",
   "description": "Synchronize properties from your notes with a Markwhen timeline file",
-  "repo": "rpj-07/Markwhen-File-Sync"
+  "repo": "rouvenjahnke/Markwhen-File-Sync"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17211,5 +17211,12 @@
     "author": "Boburmirzo Khamrakulov",
     "description": "Create and manage hledger entries directly in your vault.",
     "repo": "bzimor/obsidian_hledger"
+  },
+{
+  "id": "markfilesync",
+  "name": "Markwhen File Sync",
+  "author": "rpj-07",
+  "description": "Synchronize properties from your notes with a Markwhen timeline file",
+  "repo": "rpj-07/Markwhen-File-Sync"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:
https://github.com/rouvenjahnke/markwhen-file-sync

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [ x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ x] I have added a license in the LICENSE file.
- [ x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
