### PR TITLE
Add plugin: Auto Note Importer

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16717,6 +16717,48 @@
     "repo": "chrisgrieser/proofreader"
   },
   {
+    "id": "reader-mode",
+    "name": "Reader Mode",
+    "author": "Dominik Mayer",
+    "description": "Ensures notes are always opened in reader mode.",
+    "repo": "dominikmayer/obsidian-reader-mode"
+  },
+  {
+    "id": "date-range-expander",
+    "name": "Date Range Expander",
+    "author": "Mil",
+    "description": "Quickly add a range of day references given a date duration.",
+    "repo": "mildeveloper/obsidian-date-range-expander"
+  },
+  {
+    "id": "completed-tasks",
+    "name": "Completed Tasks",
+    "author": "Mgussekloo",
+    "description": "Automatically sort completed tasks to the bottom of the list.",
+    "repo": "mgussekloo/obsidian-completedtasks"
+  },
+  {
+    "id": "quick-peek-sidebar",
+    "name": "Quick Peek Sidebar",
+    "author": "Bradley Wyatt",
+    "description": "Opens the left and/or right side panel by hovering over it.",
+    "repo": "bwya77/obsidian-quick-peek-sidebar"
+  },
+  {	
+    "id": "advanced-note-composer",
+    "name": "Advanced Note Composer",
+    "author": "mnaoumov",
+    "description": "Enhances Note composer core plugin.",
+    "repo": "mnaoumov/obsidian-advanced-note-composer"
+  },
+  {
+    "id": "jw-library-linker",
+    "name": "JW Library Linker",
+    "author": "Martin Sakowski",
+    "description": "Converts JW Library and Bible references to actual links in JW Library.",
+    "repo": "msakowski/obsidian-library-linker"
+  },
+  {
     "id": "auto-note-importer",
     "name": "Auto Note Importer",
     "author": "uppinote",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16715,5 +16715,12 @@
     "author": "pseudometa (aka Chris Grieser)",
     "description": "AI-based proofreading and stylistic improvements for your writing. Changes are inserted as suggestions directly in the editor, similar to suggested changes in word processing apps.",
     "repo": "chrisgrieser/proofreader"
+  },
+  {
+    "id": "obsidian-auto-note-importer",
+    "name": "Auto Note Importer",
+    "author": "uppinote",
+    "description": "Automatically import notes from an external database like Airtable into your Obsidian Vault.",
+    "repo": "uppinote20/obsidian-auto-note-importer",
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16721,6 +16721,6 @@
     "name": "Auto Note Importer",
     "author": "uppinote",
     "description": "Automatically import notes from an external database like Airtable into your Obsidian Vault.",
-    "repo": "uppinote20/obsidian-auto-note-importer",
+    "repo": "uppinote20/obsidian-auto-note-importer"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16665,9 +16665,8 @@
     "author": "Jay Bridge",
     "description": "Just open and edit a CSV file in workspace view, no more. Keep it simple.",
     "repo": "LIUBINfighter/csv-lite"
-  }
-	,
-{
+  },
+  {
 	"id": "double-row-toolbar",
 	"name": "Double row toolbar",
 	"author": "Lorens Osman",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16758,6 +16758,90 @@
     "repo": "msakowski/obsidian-library-linker"
   },
   {
+    "id": "rainbow-folders-fixer",
+    "name": "Rainbow Folders Fixer",
+    "author": "Dee",
+    "description": "Stop rainbow folders from changing colors when you scroll through the File explorer.",
+    "repo": "dee158/obsidian-rainbow-folders-fixer"
+},
+{
+    "id": "table-of-contents-automatic-but-compatible-with-publish",
+	"name": "TOC compatible with Publish",
+	"description": "This generates a table of contents that is compatible with publish.",
+	"author": "Brian Collery",
+	"repo": "BrMacCath/Table-of-Contents"
+  },
+  {
+    "id": "image-embedder",
+    "name": "Image Embedder",
+    "author": "Natalie Sumbo",
+    "description": "Automatically downloads and embeds images from URLs when pasting",
+    "repo": "sky150/obsidian-image-embedder"
+  },
+  {
+    "id": "about-blank",
+    "name": "About Blank",
+    "author": "Ai-Jani",
+    "description": "Customize the empty file (New tab) itself a little bit by adding \"Commands\" or \"Open files\". And edit these: Grouping, Set icon, Ask before execution, Register as a new command.",
+    "repo": "Ai-Jani/about-blank"
+  },
+  {
+    "id": "daily-note-automater",
+    "name": "Daily Notes Automater",
+    "author": "David Pedrero",
+    "description": "Automates the creation of a daily note",
+    "repo": "davidpedrero/obsidian-daily-notes-automater"
+   },
+    {
+    "id": "jupymd",
+    "name": "JupyMD",
+    "author": "Deniz Terzioglu",
+    "description": "Link and sync Markdown notes with Jupyter notebooks via Jupytext.",
+    "repo": "d-eniz/jupymd"
+  },
+  {
+    "id": "reference-link-render",
+    "name": "Reference Link Render",
+    "author": "njko39",
+    "description": "Enables reference-style Markdown links in reading mode and hides link definitions, like in Kramdown",
+    "repo": "njko39/obsidian-reference-link-plugin"
+  },
+  {
+    "id": "reveal-folded",
+    "name": "Reveal Folded",
+    "description": "Reveal the current file in the file explorer while collapsing all other tree items.",
+    "author": "d7sd6u",
+    "repo": "d7sd6u/obsidian-reveal-folded"
+  },
+  {
+  "id": "data-fetcher",
+  "name": "Data Fetcher",
+  "author": "qf3l3k",
+  "description": "Fetch data from multiple sources (REST APIs, RPC, gRPC, GraphQL) and insert results into notes",
+  "repo": "qf3l3k/obsidian-api-fetcher"
+ },
+ {
+  "id": "tick-tones",
+  "name": "Tick Tones",
+  "author": "DontBlameMe",
+  "description": "Plays a tone when you tick a checkbox",
+  "repo": "DontBlameMe99/Tick-Tones"
+  },
+  {
+    "id": "model-viewer",
+    "name": "Model Viewer",
+    "author": "Janis Pritzkau",
+    "description": "View and embed interactive 3D models directly in your vault, powered by Google's <model-viewer> component. Supports the glTF and GLB file formats.",
+    "repo": "janispritzkau/obsidian-model-viewer"
+  },
+  {
+    "id": "sentence-rhythm",
+    "name": "Sentence Rhythm",
+    "author": "Adam Fletcher",
+    "description": "Adds toggleable colored highlights to sentences based on their length so you can easily see the rhythm of your writing.",
+    "repo": "adamfletcher/obsidian-sentence-rhythm"
+  },
+  {
     "id": "auto-note-importer",
     "name": "Auto Note Importer",
     "author": "uppinote",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16840,13 +16840,13 @@
     "author": "Adam Fletcher",
     "description": "Adds toggleable colored highlights to sentences based on their length so you can easily see the rhythm of your writing.",
     "repo": "adamfletcher/obsidian-sentence-rhythm"
-  }
+}
 ,
-  {
+{
     "id": "auto-note-importer",
     "name": "Auto Note Importer",
     "author": "uppinote",
     "description": "Automatically import notes from an external database like Airtable into your Vault.",
     "repo": "uppinote20/obsidian-auto-note-importer"
-  }
+}
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16717,10 +16717,10 @@
     "repo": "chrisgrieser/proofreader"
   },
   {
-    "id": "obsidian-auto-note-importer",
+    "id": "auto-note-importer",
     "name": "Auto Note Importer",
     "author": "uppinote",
-    "description": "Automatically import notes from an external database like Airtable into your Obsidian Vault.",
+    "description": "Automatically import notes from an external database like Airtable into your Vault.",
     "repo": "uppinote20/obsidian-auto-note-importer"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16840,7 +16840,8 @@
     "author": "Adam Fletcher",
     "description": "Adds toggleable colored highlights to sentences based on their length so you can easily see the rhythm of your writing.",
     "repo": "adamfletcher/obsidian-sentence-rhythm"
-  },
+  }
+,
   {
     "id": "auto-note-importer",
     "name": "Auto Note Importer",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/uppinote20/obsidian-auto-note-importer

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
