### PR TITLE
Add plugin: Note Tree Generator

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16840,8 +16840,8 @@
     "author": "Adam Fletcher",
     "description": "Adds toggleable colored highlights to sentences based on their length so you can easily see the rhythm of your writing.",
     "repo": "adamfletcher/obsidian-sentence-rhythm"
-},
-{
+  },
+  {
     "id": "note-tree-generator",
     "name": "Note Tree Generator",
     "author": "detsneik",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16840,6 +16840,12 @@
     "author": "Adam Fletcher",
     "description": "Adds toggleable colored highlights to sentences based on their length so you can easily see the rhythm of your writing.",
     "repo": "adamfletcher/obsidian-sentence-rhythm"
-}
+},
+{
+    "id": "note-tree-generator",
+    "name": "Note Tree Generator",
+    "author": "detsneik",
+    "description": "Generates a structured tree view of your notes based on internal links, with sharing capabilities.",
+    "repo": "detsneik/note-tree-generator"
+  }
 ]
-


### PR DESCRIPTION
This PR adds the Note Tree Generator plugin to the community-plugins.json list.

- Plugin repo: https://github.com/detsneik/note-tree-generator
- Description: Generates a structured tree view of your notes based on internal links, with sharing capabilities.

## Checklist

- [x] Tested the plugin on
	- [x] Windows
	- [ ] macOsS
	- [x] Linux
	- [ ] Android _(if applicable)_
	- [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files as individual files (not just in the source.zip / source.tar.gz):
  - [x] main.js
  - [x] manifest.json
  - [x] styles.css (optional)
- [x] GitHub release name matches the exact version number specified in my manifest.json (Note: Use the exact version number, don't include a prefix v).
- [x] The id in my manifest.json matches the id in the community-plugins.json file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugin's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
I have given proper attribution to these other projects in my README.md.
