### PR TITLE
Add plugin: Chronica – Life in Frames

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16826,6 +16826,13 @@
     "author": "Adam Fletcher",
     "description": "Adds toggleable colored highlights to sentences based on their length so you can easily see the rhythm of your writing.",
     "repo": "adamfletcher/obsidian-sentence-rhythm"
-}
+},
+ {
+    "id": "chronica-life-in-frames",
+    "name": "Chronica – Life in Frames",
+    "author": "Neovasky",
+    "description": "Visualize your life in weeks, track events, and plan with a timeline relative to your birthday.",
+    "repo": "neovasky/chronica-life-in-frames"
+  }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16827,12 +16827,12 @@
     "description": "Adds toggleable colored highlights to sentences based on their length so you can easily see the rhythm of your writing.",
     "repo": "adamfletcher/obsidian-sentence-rhythm"
 },
- {
-    "id": "chronica-life-in-frames",
-    "name": "Chronica – Life in Frames",
-    "author": "Neovasky",
-    "description": "Visualize your life in weeks, track events, and plan with a timeline relative to your birthday.",
-    "repo": "neovasky/chronica-life-in-frames"
-  }
+{
+  "id": "chronica-life-in-frames",
+  "name": "Chronica – Life in Frames",
+  "author": "Neovasky",
+  "description": "Visualize your life in weeks, track events, and plan with a timeline relative to your birthday.",
+  "repo": "neovasky/chronica-life-in-frames"
+}
 ]
 


### PR DESCRIPTION
<!-- Plugin description -->
Chronica helps you visualize your life in weeks, using your birthday as a starting point.
Track events, take notes, and plan using a minimalist, interactive timeline inspired by "Life in Weeks".

- Weekly and yearly views  
- Cell shape customization  
- Event notes and week-based notes  
- Multiple-week event support  
- Fully relative to birthday (not Jan 1)

<!-- Leave this section as-is. It will be used by the bot -->
## Checklist

- [x] I have tested this plugin on Windows, macOS, and Linux
- [x] My GitHub release contains the required files: `main.js`, `manifest.json`, and `styles.css` (if needed)
