### PR TITLE
Add theme: Handwriting (Kalam)

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2516,5 +2516,13 @@
   "repo": "aidanastridge/Publisher",
   "screenshot": "src/thumbnail.png",
   "modes": ["dark", "light"]
-  }
+  },
+  {
+  "name": "Handwriting Theme (Kalam)",
+  "author": "Kumar Anurag",
+  "repo": "kmranrg/obsidian-handwriting-theme",
+  "screenshot": "screenshot.png",
+  "modes": ["light"],
+  "publish": false
+}
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2518,11 +2518,10 @@
   "modes": ["dark", "light"]
   },
   {
-  "name": "Handwriting Theme (Kalam)",
+  "name": "Handwriting (Kalam)",
   "author": "Kumar Anurag",
   "repo": "kmranrg/obsidian-handwriting-theme",
   "screenshot": "screenshot.png",
-  "modes": ["light"],
-  "publish": false
+  "modes": ["light"]
 }
 ]


### PR DESCRIPTION
A clean handwriting-style theme for Obsidian using the Kalam font, designed for note-taking with colored headings, code support, and math rendering.