### PR TITLE
Add Chronica – Life in Frames to community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16826,6 +16826,13 @@
     "author": "Adam Fletcher",
     "description": "Adds toggleable colored highlights to sentences based on their length so you can easily see the rhythm of your writing.",
     "repo": "adamfletcher/obsidian-sentence-rhythm"
+},
+ {
+  "id": "chronica-life-in-frames",
+  "name": "Chronica – Life in Frames",
+  "author": "Neovasky",
+  "description": "Visualize your life in weeks, track events, and plan with a timeline relative to your birthday.",
+  "repo": "neovasky/chronica-life-in-frames"
 }
 ]
 


### PR DESCRIPTION

Added Chronica Plugin

# I am submitting a new Community Plugin

## Repo URL

https://github.com/neovasky/chronica-life-in-frames

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css`
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugin's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.  
      I have given proper attribution to these other projects in my `README.md`.

