### PR TITLE
Add theme: Handwriting (Kalam)

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2516,5 +2516,13 @@
   "repo": "aidanastridge/Publisher",
   "screenshot": "src/thumbnail.png",
   "modes": ["dark", "light"]
-  }
+  },
+  {
+  "name": "Handwriting Theme (Kalam)",
+  "author": "Kumar Anurag",
+  "repo": "kmranrg/obsidian-handwriting-theme",
+  "screenshot": "screenshot.png",
+  "modes": ["light"],
+  "publish": false
+}
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2518,11 +2518,10 @@
   "modes": ["dark", "light"]
   },
   {
-  "name": "Handwriting Theme (Kalam)",
+  "name": "Handwriting (Kalam)",
   "author": "Kumar Anurag",
   "repo": "kmranrg/obsidian-handwriting-theme",
   "screenshot": "screenshot.png",
-  "modes": ["light"],
-  "publish": false
+  "modes": ["light"]
 }
 ]


### PR DESCRIPTION
## Summary

This PR adds a new community theme: **Handwriting (Kalam)**

A clean, pen-style handwriting theme using the [Kalam](https://fonts.google.com/specimen/Kalam) font, designed for those who prefer a natural and friendly note-taking experience.

## Features

- Sky blue body text for calm readability
- Deep blue headings for structure
- Purple bold for elegant emphasis
- Inline `code` and MathJax styling
- Works in both **Preview** and **Live Preview** modes
- Suitable for academic notes, journaling, and creative writing

## Files Added

- `theme.css`
- `manifest.json`
- `screenshot.png`

Let me know if any adjustments are needed — excited to contribute this to the community!
