### PR TITLE
Add plugin: LINE to Obsidian

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16828,11 +16828,11 @@
     "repo": "adamfletcher/obsidian-sentence-rhythm"
  },
  {
-    "id": "line-to-obsidian",
-    "name": "LINE to Obsidian",
+	"id": "line-to-obsidian",
+	"name": "LINE to Obsidian",
     "author": "Nagare Kameno",
-    "description": "LINEのメッセージをWebhookで受信し、Obsidianのノートとして同期するプラグイン",
-    "repo": "kamekamek/line-to-obsidian"
-  }
+	"description": "Sync messages from LINE app to Obsidian notes via webhook. Securely connects specific LINE users to Obsidian vaults using token authentication.",
+	"repo": "kamekamek/line-to-obsidian"
+}
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16826,6 +16826,13 @@
     "author": "Adam Fletcher",
     "description": "Adds toggleable colored highlights to sentences based on their length so you can easily see the rhythm of your writing.",
     "repo": "adamfletcher/obsidian-sentence-rhythm"
-}
+ },
+ {
+    "id": "line-to-obsidian",
+    "name": "LINE to Obsidian",
+    "author": "Nagare Kameno",
+    "description": "LINEのメッセージをWebhookで受信し、Obsidianのノートとして同期するプラグイン",
+    "repo": "kamekamek/line-to-obsidian"
+  }
 ]
 


### PR DESCRIPTION
## LINE to Obsidian

This plugin provides functionality to sync messages sent from the LINE app as notes in Obsidian.

### Main Features
- Seamless note synchronization from LINE chat to Obsidian
- Backend powered by Firebase Functions
- Security protection with authentication tokens
- Note formatting capabilities

### Repository URL
https://github.com/kamekamek/line-to-obsidian

### Additional Information
- Detailed information about security and privacy is provided in the README
- A release with all necessary files has been created
Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
