### PR TITLE
Add plugin: Hx to WikiLink

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16826,6 +16826,13 @@
     "author": "Adam Fletcher",
     "description": "Adds toggleable colored highlights to sentences based on their length so you can easily see the rhythm of your writing.",
     "repo": "adamfletcher/obsidian-sentence-rhythm"
-}
+  },
+  {
+    "id": "hx-to-wikilink",
+    "name": "Hx to WikiLink",
+    "author": "kip2",
+    "description": "Converts Markdown headings (# to ######) into WikiLinks like [[Heading]].",
+    "repo": "kip2/obsidian-hx-to-wikilink"
+  }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16835,4 +16835,3 @@
     "repo": "kip2/obsidian-hx-to-wikilink"
   }
 ]
-


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/kip2/obsidian-hx-to-wikilink

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
