### PR TITLE
Add plugin: recent-tab-switcher

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16831,7 +16831,7 @@
    "id": "obsidian-recent-tab-switcher",
    "name": "Obsidian Recent Tab Switcher",
    "author": "Tomas Selnekovic (craitec.com)",
-   "description": "Adds a floating action button to quickly switch between two most recently used tabs."	 
+   "description": "Adds a floating action button to quickly switch between two most recently used tabs.",	 
    "repo": "craitec/obsidian-recent-tab-switcher"
  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16830,7 +16830,7 @@
  {
    "id": "obsidian-recent-tab-switcher",
    "name": "Obsidian Recent Tab Switcher",
-   "author": "Tomas Selnekovic (craitec.com)",
+   "author": "Tomas Selnekovic",
    "description": "Adds a floating action button to quickly switch between two most recently used tabs.",	 
    "repo": "craitec/obsidian-recent-tab-switcher"
  }

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16828,9 +16828,10 @@
     "repo": "adamfletcher/obsidian-sentence-rhythm"
  },
  {
-   "id": "recent-tab-switcher",
-   "name": "Recent Tab Switcher",
+   "id": "obsidian-recent-tab-switcher",
+   "name": "Obsidian Recent Tab Switcher",
    "author": "Tomas Selnekovic (craitec.com)",
+   "description": "Adds a floating action button to quickly switch between two most recently used tabs."	 
    "repo": "craitec/obsidian-recent-tab-switcher"
  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16826,6 +16826,12 @@
     "author": "Adam Fletcher",
     "description": "Adds toggleable colored highlights to sentences based on their length so you can easily see the rhythm of your writing.",
     "repo": "adamfletcher/obsidian-sentence-rhythm"
-}
+ },
+ {
+   "id": "recent-tab-switcher",
+   "name": "Recent Tab Switcher",
+   "author": "Tomas Selnekovic (craitec.com)",
+   "repo": "craitec/obsidian-recent-tab-switcher"
+ }
 ]
 


### PR DESCRIPTION
Plugin: recent-tab-switcher

Description: Quickly switch between recently viewed tabs using a floating button.

Works on mobile and on desktop.

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
