### PR TITLE
Add plugin: Kindle Highlights Import

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17700,6 +17700,6 @@
     "name": "Kindle Highlights Import",
     "author": "Leon Luttenberger",
     "description": "Converts the Kindle highlight export HTML into an Obsidian note.",
-    "repo": "LeonLuttenberge/obsidian-kindle-highlight-import"
+    "repo": "LeonLuttenberger/obsidian-kindle-highlight-import"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17700,6 +17700,6 @@
     "name": "Kindle Highlights Import",
     "author": "Leon Luttenberger",
     "description": "Converts the Kindle highlight export HTML into an Obsidian note.",
-    "repo": "LeonLuttenberger/kindle-highlights-import"
+    "repo": "LeonLuttenberge/obsidian-kindle-highlight-import"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17694,5 +17694,12 @@
     "author": "Daniel Agafonov",
     "description": "Easily remove hyperlinks from selected text or the entire note.",
     "repo": "AlphaHasher/obsidian-remove-hyperlinks"
+  },
+  {
+    "id": "kindle-highlights-import",
+    "name": "Kindle Highlights Import",
+    "author": "Leon Luttenberger",
+    "description": "Converts the Kindle highlight export HTML into an Obsidian note.",
+    "repo": "LeonLuttenberger/kindle-highlights-import"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17699,7 +17699,7 @@
     "id": "kindle-highlights-import",
     "name": "Kindle Highlights Import",
     "author": "Leon Luttenberger",
-    "description": "Converts the Kindle highlight export HTML into an Obsidian note.",
+    "description": "Imports the Kindle highlights HTML file and saves it as a note in your vault.",
     "repo": "LeonLuttenberger/obsidian-kindle-highlight-import"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/LeonLuttenberger/obsidian-kindle-highlight-import

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
