### PR TITLE
Add plugin: Folder Filelist

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17442,5 +17442,12 @@
       "author": "RavenHogWarts",
       "description": "An enhanced code editor using Ace editor, providing syntax highlighting, code folding, and other advanced editing features.",
       "repo": "RavenHogWarts/obsidian-ace-code-editor"
-  }
+  },
+{
+		"id": "folder-filelist",
+		"name": "Folder Filelist",
+		"author": "Bill Anderson",
+		"description": "Create and maintain a list of wikilinks to files in specified folders.",
+		"repo": "band/obsidian-folder-filelist"
+}
 ]


### PR DESCRIPTION
adding Folder Filelist entry

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/band/obsidian-folder-filelist

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Winx
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
