### PR TITLE
Add plugin: better-mindmap

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16966,6 +16966,13 @@
     "author": "calvinwyoung",
     "description": "Allow saving default settings for the backlinks / \"Linked mentions\" pane at the bottom of notes.",
     "repo": "calvinwyoung/obsidian-backlink-settings"
+},
+{
+    "id": "better-mindmap",
+    "name": "Better Mind Map",
+    "author": "Utkarsh Raj",
+    "description": "Mind‑map plugin to preview notes",
+    "repo": "linem-davton/obsidian-better-mindmap"
 }
 ]
 


### PR DESCRIPTION
Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)

<!--
Thank you for submitting your plugin to the Obsidian community plugin list!
Please fill out the following information so we can evaluate your submission.
-->

## Plugin description
A better mind-mapping plugin for Obsidian. Provides live-rendered mind maps from indented Markdown structure, optimized layout, and basic interaction support (zoom, expand/collapse).

## How to test this plugin
1. Enable the plugin in Obsidian
2. Open a note with indented lists
3. Open the mind map view using the command palette or ribbon
4. Interact with the map to test layout and responsiveness

## Checklist
- [x] I have tested this plugin on:
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] My GitHub release contains:
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` (if used)
- [x] GitHub release version matches `manifest.json`
- [x] `id` in `manifest.json` matches the plugin folder name
- [x] README.md includes purpose and usage
- [x] I have read the [community plugin guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines)


