### PR TITLE
Add plugin: Todo.txt Mode

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17502,7 +17502,7 @@
   {
     "id": "todo-txt-mode",
     "name": "Todo.txt Mode",
-    "author": "calvinwyoung",
+    "author": "rioskit",
     "description": "Support for todo.txt file format with syntax highlighting and task management",
     "repo": "rioskit/obsidian-todo-txt-mode"
   }

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17498,5 +17498,12 @@
     "author": "Lucy Dryaeva",
     "description": "Manage layouts with context",
     "repo": "ShadiestGoat/obsidian-layout-manager"
+  },
+  {
+    "id": "todo-txt-mode",
+    "name": "Todo.txt Mode",
+    "author": "calvinwyoung",
+    "description": "Support for todo.txt file format with syntax highlighting and task management",
+    "repo": "rioskit/obsidian-todo-txt-mode"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

[rioskit/obsidian-todo-txt-mode: Obsidian plugin for todo.txt file format support](https://github.com/rioskit/obsidian-todo-txt-mode)

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
