### PR TITLE
Add plugin: WordPress Reloaded

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16970,7 +16970,7 @@
 {
 "id": "wordpress-reloaded",
 "name": "WordPress Reloaded",
-"description": "A plugin for publishing Obsidian documents to WordPress. Seamlessly sync your notes to WordPress blogs, supporting Markdown formatting, images, and custom publishing options. forked from https://github.com/devbean/obsidian-wordpress",
+"description": "A plugin for publishing documents to WordPress. Seamlessly sync your notes to WordPress blogs, supporting Markdown formatting, images, and custom publishing options.",
 "author": "bugparty",
 "repo": "bugparty/obsidian-wordpress-reloaded"
 }

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2555,6 +2555,13 @@
         "repo": "devbean/obsidian-wordpress"
     },
     {
+        "id": "obsidian-wordpress-reloaded",
+        "name": "WordPress Reloaded",
+        "description": "A plugin for publishing Obsidian documents to WordPress. Seamlessly sync your notes to WordPress blogs, supporting Markdown formatting, images, and custom publishing options. forked from https://github.com/devbean/obsidian-wordpress",
+        "author": "bugparty",
+        "repo": "bugparty/obsidian-wordpress-reloaded"
+    },
+    {
         "id": "obsidian-icon-shortcodes",
         "name": "Icon Shortcodes",
         "description": "Insert emoji and custom icons with shortcodes.",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2555,13 +2555,6 @@
         "repo": "devbean/obsidian-wordpress"
     },
     {
-        "id": "wordpress-reloaded",
-        "name": "WordPress Reloaded",
-        "description": "A plugin for publishing Obsidian documents to WordPress. Seamlessly sync your notes to WordPress blogs, supporting Markdown formatting, images, and custom publishing options. forked from https://github.com/devbean/obsidian-wordpress",
-        "author": "bugparty",
-        "repo": "bugparty/obsidian-wordpress-reloaded"
-    },
-    {
         "id": "obsidian-icon-shortcodes",
         "name": "Icon Shortcodes",
         "description": "Insert emoji and custom icons with shortcodes.",
@@ -16973,6 +16966,13 @@
     "author": "calvinwyoung",
     "description": "Allow saving default settings for the backlinks / \"Linked mentions\" pane at the bottom of notes.",
     "repo": "calvinwyoung/obsidian-backlink-settings"
+},
+{
+"id": "wordpress-reloaded",
+"name": "WordPress Reloaded",
+"description": "A plugin for publishing Obsidian documents to WordPress. Seamlessly sync your notes to WordPress blogs, supporting Markdown formatting, images, and custom publishing options. forked from https://github.com/devbean/obsidian-wordpress",
+"author": "bugparty",
+"repo": "bugparty/obsidian-wordpress-reloaded"
 }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -2555,7 +2555,7 @@
         "repo": "devbean/obsidian-wordpress"
     },
     {
-        "id": "obsidian-wordpress-reloaded",
+        "id": "wordpress-reloaded",
         "name": "WordPress Reloaded",
         "description": "A plugin for publishing Obsidian documents to WordPress. Seamlessly sync your notes to WordPress blogs, supporting Markdown formatting, images, and custom publishing options. forked from https://github.com/devbean/obsidian-wordpress",
         "author": "bugparty",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL https://github.com/bugparty/obsidian-wordpress-reloaded

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:  https://github.com/bugparty/obsidian-wordpress-reloaded/releases/download/1.1.2/obsidian-wordpress-reloaded-1.1.2.zip

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
