### PR TITLE
Add plugin: Quick Flashcards

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16966,6 +16966,14 @@
     "author": "calvinwyoung",
     "description": "Allow saving default settings for the backlinks / \"Linked mentions\" pane at the bottom of notes.",
     "repo": "calvinwyoung/obsidian-backlink-settings"
+},
+{
+    "id": "quick-flashcards",
+    "name": "Quick Flashcards 📚",
+    "author": "Emmanuel Fabiani",
+    "description": "Turn #Q ... :: ... pairs in any note into interactive flashcards with persistent grading, targeted reviews, and spaced repetition.",
+    "repo": "HelyeFab/obsidian-quick-flashcards"
 }
+
 ]
 


### PR DESCRIPTION
## Quick Flashcards 📚

- [GitHub repository](https://github.com/HelyeFab/obsidian-quick-flashcards)
- [Plugin page](https://github.com/HelyeFab/obsidian-quick-flashcards) <!-- Optional, can be same as repository if you don't have a separate page -->

This plugin turns notes with `#Q question :: answer` pairs into interactive flashcards with spaced repetition. Review questions when they're due, track your progress, and optimize your learning using proven memory techniques.

### Features

- Simple `#Q question :: answer` syntax in any note
- Spaced repetition system with 4 confidence levels
- Due cards tracking and statistics
- Rich content support including markdown, code blocks, and emoji
- Mobile-friendly interface

## Compliance

- [x] This plugin adheres to the [Obsidian Plugin Guidelines](https://docs.obsidian.md/Developer+guides/Plugin+guidelines)
- [x] The GitHub repository has a description
- [x] The plugin offers [clear documentation](https://github.com/HelyeFab/obsidian-quick-flashcards) on how to use it
- [x] The main plugin functionality works offline (no internet connection required)
- [x] The GitHub repository has an appropriate [open source license](https://github.com/HelyeFab/obsidian-quick-flashcards/blob/main/LICENSE)
- [x] The plugin meets the documentation requirements, as specified in [Documentation requirements](https://docs.obsidian.md/Developer+guides/Plugin+guidelines#Documentation+requirements)

