### PR TITLE
Add EditNext Ranker

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16966,6 +16966,13 @@
     "author": "calvinwyoung",
     "description": "Allow saving default settings for the backlinks / \"Linked mentions\" pane at the bottom of notes.",
     "repo": "calvinwyoung/obsidian-backlink-settings"
+},
+{
+    "id": "editnext-ranker",
+    "name": "EditNext Ranker",
+    "author": "EditNext AI",
+    "description": "Use AI to identify which documents need editing most. Prioritize your writing workflow based on editing effort scores.",
+    "repo": "shreyas-makes/editnext-plugin"
 }
 ]
 


### PR DESCRIPTION
## EditNext Ranker

* **Repository:** https://github.com/shreyas-makes/editnext-plugin
* **Release:** https://github.com/shreyas-makes/editnext-plugin/releases/tag/0.1.0
* **ID:** editnext-ranker

### Description

Use AI and readability analysis to identify which notes need editing the most. Assigns an "editing effort score" to your documents and helps you prioritize your writing workflow.

### Checklist

- [x] My plugin follows the [plugin guidelines](https://docs.obsidian.md/Developer+policies)
- [x] I have read and understood the [contributing guidelines](https://github.com/obsidianmd/obsidian-releases/blob/master/README.md#submit-your-plugin-or-theme)
- [x] I have tested the latest version of my plugin
- [x] I have a valid license (MIT, ISC, or Creative Commons) in both my plugin repo and in my `manifest.json`