### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16966,6 +16966,13 @@
     "author": "calvinwyoung",
     "description": "Allow saving default settings for the backlinks / \"Linked mentions\" pane at the bottom of notes.",
     "repo": "calvinwyoung/obsidian-backlink-settings"
+},
+{
+    "id": "obsidian-gyazo",
+    "name": "Gyazo Image Uploader",
+    "author": "tsuuuuuuun",
+    "description": "Seamlessly integrate Gyazo with Obsidian for easy image uploads and sharing, similar to Scrapbox's functionality",
+    "repo": "tsuuuuuuun/obsidian-gyazo"
 }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16971,7 +16971,7 @@
     "id": "gyazo-uploader",
     "name": "Gyazo Image Uploader",
     "author": "tsuuuuuuun",
-    "description": "Seamlessly integrate Gyazo with Obsidian for easy image uploads and sharing, similar to Scrapbox's functionality",
+    "description": "Seamlessly integrate Gyazo for easy image uploads and sharing, similar to Scrapbox's functionality",
     "repo": "tsuuuuuuun/obsidian-gyazo"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16971,8 +16971,8 @@
     "id": "gyazo-uploader",
     "name": "Gyazo Image Uploader",
     "author": "tsuuuuuuun",
-    "description": "Seamlessly integrate Gyazo for easy image uploads and sharing, similar to Scrapbox's functionality",
-    "repo": "tsuuuuuuun/obsidian-gyazo"
+    "description": "Seamlessly integrate Gyazo for easy image uploads and sharing, similar to Scrapbox's functionality.",
+    "repo": "Tsuuuuuuun/obsidian-gyazo"
 }
 ]
 

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16968,7 +16968,7 @@
     "repo": "calvinwyoung/obsidian-backlink-settings"
 },
 {
-    "id": "obsidian-gyazo",
+    "id": "gyazo-uploader",
     "name": "Gyazo Image Uploader",
     "author": "tsuuuuuuun",
     "description": "Seamlessly integrate Gyazo with Obsidian for easy image uploads and sharing, similar to Scrapbox's functionality",


### PR DESCRIPTION
# Add Gyazo Image Uploader Plugin

## Description

This plugin integrates Gyazo with Obsidian, allowing users to easily upload and share images directly from their notes. It provides a seamless experience similar to Scrapbox's functionality, where users can quickly upload images from their clipboard and get Markdown image links inserted into their notes.

## Features

- Direct image upload from clipboard to Gyazo
- Automatic Markdown image link insertion
- Simple interface with ribbon icon and command palette support
- Secure API token management through settings

## Technical Details

- Uses Gyazo's official API for image uploads
- Implements clipboard API for image handling
- Follows Obsidian's plugin development guidelines
- Includes both English and Japanese documentation

## Testing

The plugin has been tested on mac OS.

![obsidian-gyazo-demo](https://github.com/user-attachments/assets/93c3555d-c8dc-4ea4-9f0d-b8343044df62)


