### PR TITLE
Add QuickLink plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16966,6 +16966,16 @@
     "author": "calvinwyoung",
     "description": "Allow saving default settings for the backlinks / \"Linked mentions\" pane at the bottom of notes.",
     "repo": "calvinwyoung/obsidian-backlink-settings"
+},
+{
+    "id": "obsidian-quicklink",
+    "name": "QuickLink",
+    "author": "Jamba Hailar",
+    "description": "Quickly create links to files using @ trigger character",
+    "repo": "Jamailar/QuickLink-Obsidian",
+    "version": "2.0.0",
+    "minAppVersion": "0.12.0"
 }
+	
 ]
 


### PR DESCRIPTION
This PR adds the QuickLink plugin to the community plugins list.

**Plugin Name**: QuickLink  
**Author**: Jamba Hailar  
**Description**: Quickly create links to files using @ trigger character. Supports batch linking, default folders, tag and folder suggestions, and integration with Advanced URI.

The release assets (main.js and manifest.json) are uploaded under version [v2.0.0](https://github.com/Jamailar/QuickLink-Obsidian/releases/tag/2.0.0)

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
