### PR TITLE
add quicklink plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16966,6 +16966,15 @@
     "author": "calvinwyoung",
     "description": "Allow saving default settings for the backlinks / \"Linked mentions\" pane at the bottom of notes.",
     "repo": "calvinwyoung/obsidian-backlink-settings"
+},
+{
+  "id": "quicklink",
+  "name": "QuickLink",
+  "author": "Jamba Hailar",
+  "description": "Quickly create links to files using @ trigger character",
+  "repo": "Jamailar/QuickLink-Obsidian",
+  "version": "1.0.0",
+  "minAppVersion": "1.5.8"
 }
 ]
 


### PR DESCRIPTION
<!-- I am submitting a new Community Plugin -->

## Repo URL

Link to my plugin: https://github.com/Jamailar/QuickLink-Obsidian

## Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [x] macOS
  - [x] Linux
- [x] My GitHub release contains all required files:
  - [x] main.js
  - [x] manifest.json
  - [x] styles.css (if needed)
- [x] The version in manifest.json matches the GitHub release tag
- [x] The id in manifest.json matches the id in community-plugins.json
- [x] My README.md has clear instructions
- [x] I have a LICENSE file with a valid open-source license
- [x] I have read [Developer Policies](https://docs.obsidian.md/Developer+policies)

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
