### PR TITLE
Add plugin: yearly-diary-comparator

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,12 +1,5 @@
 [
     {
-        "id": "yearly-diary-comparator",
-        "name": "Yearly Diary Comparator",
-        "author": "kiitosu",
-        "description": "Show a side-by-side yearly comparison of diary in daily notes.",
-        "repo": "kiitosu/yearly-diary-comparator"
-    },
-    {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
         "author": "Argentina Ortega Sainz",
@@ -17232,5 +17225,12 @@
     "author": "Chen",
     "description": "Post the file to Typecho.",
     "repo": "Chen2226/obsidian-typecho"
-  }
+  },
+    {
+        "id": "yearly-diary-comparator",
+        "name": "Yearly Diary Comparator",
+        "author": "kiitosu",
+        "description": "Show a side-by-side yearly comparison of diary in daily notes.",
+        "repo": "kiitosu/yearly-diary-comparator"
+    }	
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,12 @@
 [
     {
+        "id": "yearly-diary-comparator",
+        "name": "Yearly Diary Comparator",
+        "author": "kiitosu",
+        "description": "Show a side-by-side yearly comparison of diary in daily notes.",
+        "repo": "kiitosu/yearly-diary-comparator"
+    },
+    {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
         "author": "Argentina Ortega Sainz",


### PR DESCRIPTION
# I am submitting a new Community Plugin
This plugin provides a yearly calendar view for Obsidian daily notes, allowing you to compare your activities or diary entries across different years. By displaying entries for the same date side by side, you can intuitively review changes and track your personal growth year over year.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/kiitosu/yearly-diary-comparator

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
