### PR TITLE
Add QuickHub Capture

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17258,7 +17258,7 @@
     "id": "quickhub-capture",
     "name": "QuickHub Capture",
     "author": "ThomasEdwardYorke",
-    "description": "iOS/iPadOS のショートカットから GitHub 経由で Obsidian Vault にクイックメモを取り込む",
+    "description": "iOS/iPadOS から GitHub 経由でVaultにクイックメモを取り込むプラグイン",
     "repo": "ThomasEdwardYorke/quickhub-capture"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -16069,7 +16069,7 @@
     "name": "Wordflow Tracker",
     "author": "LeCheenaX",
     "description": "Track the changes and stats of your edited note files automatically. Record the modified notes and statistics to your daily note",
-    "repo": "LeCheenaX/WordFlow-Tracker"  
+    "repo": "LeCheenaX/WordFlow-Tracker"
 },
 {
     "id": "mathtype",
@@ -16209,7 +16209,7 @@
 "name": "Collapsible Code Blocks",
 "author": "Bradley Wyatt",
 "description": "Makes code blocks collapsible in preview mode as well as enabling scroll-able code blocks.",
-"repo": "bwya77/collapsible-code-blocks"  
+"repo": "bwya77/collapsible-code-blocks"
 },
 {
     "id": "cmd-search",
@@ -16234,7 +16234,7 @@
 },
 {
     "id": "auto-folder-note-paste",
-    "name": "Auto Folder Note Paste",		
+    "name": "Auto Folder Note Paste",
     "author": "d7sd6u",
     "description": "Automagically convert the note to a folder note when pasting or drag'n'dropping an attachment.",
     "repo": "d7sd6u/obsidian-auto-folder-note-paste"
@@ -16331,10 +16331,10 @@
     "repo": "semanticdata/obsidian-pomodoro"
   },
   {
-    "id": "generate-timeline", 
-    "name": "Generate Timeline", 
+    "id": "generate-timeline",
+    "name": "Generate Timeline",
     "author": "Shanshuimei",
-    "description": "Generate timelines from tag or folder automatically by any time properties.", 
+    "description": "Generate timelines from tag or folder automatically by any time properties.",
     "repo": "Shanshuimei/obsidian-generate-timeline"
   },
   {
@@ -16363,7 +16363,7 @@
     "name": "HiNote",
     "author": "Kai",
     "description": "Add comments to highlighted notes, use AI for thinking, and flashcards for memory.",
-    "repo": "CatMuse/HiNote"  
+    "repo": "CatMuse/HiNote"
   },
   {
     "id": "private-mode",
@@ -16475,9 +16475,9 @@
     "name": "Jira Issue Manager",
     "author": "Alamion",
     "description": "Get Jira issues, create and update them. Issue status and worklog management.",
-    "repo": "Alamion/obsidian-jira-sync"  
+    "repo": "Alamion/obsidian-jira-sync"
 },
-{  
+{
     "id": "theme-toggle",
     "name": "Theme toggle",
     "author": "@gapmiss",
@@ -16503,7 +16503,7 @@
     "name": "On This Day I",
     "author": "Ben Stuart",
     "description": "Summarize a calendar date in years past with Daily Journals",
-    "repo": "benstuart0/on-this-day-i-obsidian"  
+    "repo": "benstuart0/on-this-day-i-obsidian"
   },
   {
     "id": "large-language-models",
@@ -16520,7 +16520,7 @@
     "repo": "d7sd6u/obsidian-hide-index-files"
   },
   {
-    "id": "crosslink-advanced", 
+    "id": "crosslink-advanced",
     "name": "Crosslink Advanced",
     "description": "Tag files using folders and symlinks system (ftags).",
     "author": "d7sd6u",
@@ -16687,7 +16687,7 @@
     "description": "Render colored bars with relative event dates",
     "repo": "playmean/obsidian-event-highlight-plugin"
    },
-   {	
+   {
     "id": "auto-daily-note",
     "name": "Auto Daily Note",
     "author": "John Dolittle",
@@ -16729,7 +16729,7 @@
     "description": "Opens the left and/or right side panel by hovering over it.",
     "repo": "bwya77/obsidian-quick-peek-sidebar"
   },
-  {	
+  {
     "id": "advanced-note-composer",
     "name": "Advanced Note Composer",
     "author": "mnaoumov",
@@ -16820,12 +16820,12 @@
     "description": "Adds toggleable colored highlights to sentences based on their length so you can easily see the rhythm of your writing.",
     "repo": "adamfletcher/obsidian-sentence-rhythm"
 },
-  { 
-    "id": "another-dynamic-highlights", 
-    "name": "aDHL", 
-    "author": "tine-schreibt", 
-    "description": "Create pretty static highlighters from search or regEx. Group by tag and set commands for toggling. Based on Dynamic Highlights. Works well with Highlightr.", 
-    "repo": "tine-schreibt/aDHL" 
+  {
+    "id": "another-dynamic-highlights",
+    "name": "aDHL",
+    "author": "tine-schreibt",
+    "description": "Create pretty static highlighters from search or regEx. Group by tag and set commands for toggling. Based on Dynamic Highlights. Works well with Highlightr.",
+    "repo": "tine-schreibt/aDHL"
 },
 {
     "id": "cbcr-text-eater-de",
@@ -16853,7 +16853,7 @@
     "name": "Rainbow-Colored Sidebar",
     "author": "Kevin Woblick",
     "description": "Automatically color your sidebar like a rainbow. No configuration needed.",
-    "repo": "Kovah/obsidian-rainbow-colored-sidebar"  
+    "repo": "Kovah/obsidian-rainbow-colored-sidebar"
   },
 {
     "id": "vcf-contacts",
@@ -16972,7 +16972,7 @@
     "name": "Notes Explorer",
     "author": "Atmanand Gauns",
     "description": "Explore your notes as cards in gallery or masonry view. A new way to revise your content.",
-    "repo": "tu2-atmanand/obsidian-notes-explorer"  
+    "repo": "tu2-atmanand/obsidian-notes-explorer"
   },
   {
     "id": "markdown-flip",
@@ -17151,7 +17151,7 @@
 },
 {
 	"id": "zhongwen-reader",
-	"name": "Zhongwen Reader", 
+	"name": "Zhongwen Reader",
 	"author": "natipt",
 	"description": "This lightweight plugin helps you read Chinese more easily with a CEDICT based hover-dictionary and vocabulary saving features.",
 	"repo": "natipt/obsidian-zhongwen-reader"
@@ -17184,7 +17184,7 @@
   "description": "Automatically archives web links via Wayback Machine and appends archived versions in notes.",
   "repo": "IshizuEitaro/obsidian-wayback-archiver"
   },
-{  
+{
     "id": "todo-highlighter",
     "name": "TODO Highlighter",
     "author": "Nuraly Dyussenov",
@@ -17253,5 +17253,12 @@
     "author": "d7sd6u",
     "description": "Add file's ftags as chips at the top of the markdown view.",
     "repo": "d7sd6u/obsidian-viewer-ftags"
+},
+{
+    "id": "quickhub-capture",
+    "name": "QuickHub Capture",
+    "author": "ThomasEdwardYorke",
+    "description": "iOS/iPadOS のショートカットから GitHub 経由で Obsidian Vault にクイックメモを取り込む",
+    "repo": "ThomasEdwardYorke/quickhub-capture"
 }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL
Link to my plugin: https://github.com/ThomasEdwardYorke/quickhub-capture

## Release Checklist
- [x] I have tested the plugin on
  - [x] macOS
  - [x] Windows
  - [x] Linux
- [x] My GitHub release contains all required files
  - [x] main.js
  - [x] manifest.json
  - [x] styles.css (optional)
- [x] GitHub release name matches the exact version number in manifest.json
- [x] The `id` in manifest.json matches `community-plugins.json`
- [x] README explains what the plugin does and how to use it
- [x] I have read the developer policies and plugin guidelines
- [x] I have added a license file
