### PR TITLE
Add plugin: Cursor Launcher

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17253,5 +17253,12 @@
     "author": "d7sd6u",
     "description": "Add file's ftags as chips at the top of the markdown view.",
     "repo": "d7sd6u/obsidian-viewer-ftags"
+},
+{
+	"id": "cursor-launcher",
+	"name": "Cursor Launcher",
+	"author": "NGAFTA",
+	"description": "Quickly open any folder in your Obsidian vault with Cursor IDE. Adds a context menu option to launch Cursor directly from your vault's folder structure.",
+	"repo": "ngafta/obsidian-cursor-launcher"
 }
 ]


### PR DESCRIPTION
## Plugin Description
Cursor Launcher allows users to quickly open any folder in their vault with Cursor IDE through a context menu option.

## Plugin ID
cursor-launcher

## Plugin Author
NGAFTA

## Plugin Repository
https://github.com/ngafta/obsidian-cursor-launcher

## Plugin Version
1.0.1

## Plugin Description
Quickly open any folder in your vault with Cursor IDE. Adds a context menu option to launch Cursor directly from your folder structure.

## Plugin Features
- Open any folder in Cursor IDE from the context menu
- Support for Windows and Unix-based systems
- Simple and intuitive interface

## Plugin Requirements
- Cursor IDE must be installed
- The `cursor` command must be available in system's PATH

## Plugin Installation
1. Open Settings
2. Go to Community Plugins
3. Turn off Safe Mode
4. Click Browse and search for "Cursor Launcher"
5. Click Install
6. Enable the plugin