### PR TITLE
Add QuickNotes plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17253,5 +17253,12 @@
     "author": "d7sd6u",
     "description": "Add file's ftags as chips at the top of the markdown view.",
     "repo": "d7sd6u/obsidian-viewer-ftags"
+},
+{
+  "id": "quicknotes",
+  "name": "QuickNotes",
+  "author": "Zer0",
+  "description": "Quickly create notes in a specified folder.",
+  "repo": "ZeroMB/Obsidian-QuickNotes"
 }
 ]


### PR DESCRIPTION
## Plugin Information
- Plugin name: QuickNotes
- Plugin ID: quicknotes
- Repository URL: https://github.com/ZeroMB/Obsidian-QuickNotes
- Release tag: 1.0.0
- Minimum Obsidian version: 0.15.0

## Checklist
- [x] I have read the plugin guidelines
- [x] My plugin follows the plugin structure
- [x] I have tested my plugin
- [x] My repository is public
- [x] etc...