### PR TITLE
Add plugin: Habit Dashboard

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17253,5 +17253,12 @@
     "author": "d7sd6u",
     "description": "Add file's ftags as chips at the top of the markdown view.",
     "repo": "d7sd6u/obsidian-viewer-ftags"
+},
+{
+    "id": "habit-dashboard",
+    "name": "Habit Dashboard",
+    "author": "jack-arms",
+    "description": "Full-screen plugin with a dashboard to track habits using properties/frontmatter data on daily notes. See your progress over time on different activities with optional goals, or just have a way to quickly remember the last time you did some chore.",
+    "repo": "jack-arms/obsidian-habit-dashboard"
 }
 ]


### PR DESCRIPTION
Add entry for https://github.com/jack-arms/obsidian-habit-dashboard.
[Update: fix release tag in repo, due to validation failure] 

# I am submitting a new Community Plugin

## Repo URL
Link to my plugin: https://github.com/jack-arms/obsidian-habit-dashboard/

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
