### PR TITLE
Add plugin: [Kindle Vocab Plugin]

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,4 +1,4 @@
-[
+[ 
     {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
@@ -17253,5 +17253,12 @@
     "author": "d7sd6u",
     "description": "Add file's ftags as chips at the top of the markdown view.",
     "repo": "d7sd6u/obsidian-viewer-ftags"
+},
+{
+  "id": "obsidian-kindle-vocab-plugin",
+  "name": "Kindle Vocab Plugin",
+  "author": "Truong Gia Bao",
+  "description": "Sync your Kindle vocabulary builders with Obsidian.",
+  "repo": "bao-tg/obsidian-kindle-vocab-plugin"
 }
 ]


### PR DESCRIPTION
# Description

**Kindle Vocab Plugin** is an Obsidian plugin that lets you import vocabulary lookups from your Kindle device and convert them into structured, interactive Markdown notes.

# Features

- Generate Markdown from your Kindle lookups (`vocab.db`)
- Integrate custom dictionary files (CSV format)
- Mark words as "Learned/Unlearned" using checkboxes
- View statistics such as percentage learned
- Sort words by timestamp or prioritize unlearned items

# Usage and documentation

For the usage, please check in this [repository](https://github.com/bao-tg/obsidian-kindle-vocab-plugin).
The developer documentation can be found in my [personal website](https://bao-tg.github.io/blog/obsidian-kindle-vocab).