### PR TITLE
Add plugin: [Kindle Vocab]

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17232,5 +17232,12 @@
     "author": "d7sd6u",
     "description": "Add file's ftags as chips at the top of the markdown view.",
     "repo": "d7sd6u/obsidian-viewer-ftags"
+},
+{
+  "id": "kindle-vocab",
+  "name": "Kindle Vocab",
+  "author": "Truong Gia Bao",
+  "description": "Sync your Kindle vocabulary builders with Obsidian.",
+  "repo": "bao-tg/kindle-vocab"
 }
 ]


### PR DESCRIPTION
# Description

Originally developed as a Spring 2025 course project at VinUniversity. It emerged from a personal pain point — the lack of a simple way to export Kindle Vocabulary Builder data into Markdown for use in Obsidian.

# Key features

* Reload your plugins.
* Open **Developer Tools** in Obsidian and load the plugin.
* Enable the plugin under **Settings > Community Plugins**.
* Reload the plugin in Settings after making updates.

# Demonstration and Documentation

For the usage, and demonstration, please refer to this [repository](https://github.com/bao-tg/kindle-vocab)
The developer documentation can be found in my [personal website](https://bao-tg.github.io/blog/obsidian-kindle-vocab)