### PR TITLE
Add plugin: [Kindle Vocab]

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17232,5 +17232,12 @@
     "author": "d7sd6u",
     "description": "Add file's ftags as chips at the top of the markdown view.",
     "repo": "d7sd6u/obsidian-viewer-ftags"
+},
+{
+    "id": "kindle-vocab",
+    "name": "Kindle Vocab",
+    "author": "Truong Gia Bao",
+    "description": "Create the Markdown file from your Kindle Vocab Builder in your vault.",
+    "repo": "bao-tg/kindle-vocab"
 }
 ]


### PR DESCRIPTION
# Description

Originally developed as a Spring 2025 course project at VinUniversity. It emerged from a personal pain point — the lack of a simple way to export Kindle Vocabulary Builder data into Markdown for use in Obsidian.

# Key features

- Generate Markdown from your Kindle lookups (`vocab.db`)
- Integrate your own dictionary files (CSV)
- Mark words as "Learned/Unlearned" with checkbox interactivity
- View stats like % learned
- Sort words by timestamp or unlearned-first

# Demonstration and Documentation

For the usage, and demonstration, please refer to this [repository](https://github.com/bao-tg/kindle-vocab)  
The developer documentation can be found in my [personal website](https://bao-tg.github.io/blog/obsidian-kindle-vocab)

