### PR TITLE
Add Copy note content plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17234,8 +17234,8 @@
     "repo": "d7sd6u/obsidian-viewer-ftags"
 },
 {
-  "id": "copy-from-sidebar",
-  "name": "Copy From Sidebar",
+  "id": "copy-note-content",
+  "name": "Copy Note Content",
   "author": "AmyJapanese",
   "repo": "https://github.com/AmyJapanese/copy-note-content",
   "description": "Adds a sidebar button to copy the current note's content"

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17232,5 +17232,12 @@
     "author": "d7sd6u",
     "description": "Add file's ftags as chips at the top of the markdown view.",
     "repo": "d7sd6u/obsidian-viewer-ftags"
+},
+{
+  "id": "copy-from-sidebar",
+  "name": "Copy From Sidebar",
+  "author": "AmyJapanese",
+  "repo": "https://github.com/AmyJapanese/copy-note-content",
+  "description": "Adds a sidebar button to copy the current note's content"
 }
 ]


### PR DESCRIPTION
This pull request adds the "Copy Note Content" plugin.

GitHub repository: https://github.com/AmyJapanese/copy-note-content

This plugin adds a sidebar button that allows users to copy the content of the current note to the clipboard.
