### PR TITLE
Add plugin: Kindle Vocab

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17232,5 +17232,12 @@
     "author": "d7sd6u",
     "description": "Add file's ftags as chips at the top of the markdown view.",
     "repo": "d7sd6u/obsidian-viewer-ftags"
+},
+{
+    "id": "kindle-vocab",
+    "name": "Kindle Vocab",
+    "author": "Truong Gia Bao",
+    "description": "Create the Markdown file from your Kindle Vocab Builder in your vault.",
+    "repo": "bao-tg/kindle-vocab"
 }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

[https://github.com/bao-tg/kindle-vocab](https://github.com/bao-tg/kindle-vocab)

## Release Checklist

- [x] I have tested this on:
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
- [x] My GitHub release contains:
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` (optional)
- [x] GitHub release tag is exactly `1.0.0` (no `v` prefix)
- [x] The `id` in `manifest.json` matches the `id` in `community-plugins.json`
- [x] My `README.md` clearly explains how to use the plugin
- [x] I have read the [developer policies](https://docs.obsidian.md/Developer+policies)
- [x] I have reviewed the [plugin guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines)
- [x] I’ve added a `LICENSE` file
- [x] My plugin respects code licenses and gives credit in `README.md`
