### PR TITLE
Add plugin: Copy Absolute Path

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17680,5 +17680,12 @@
     "author": "TadoTheMiner",
     "description": "Expand your knowledge by visiting random broken links.",
     "repo": "janTatesa/obsidian-open-random-broken-link"
+  },
+  {
+    "id": "copy-absolute-path",
+    "name": "Copy Absolute Path",
+    "author": "Albert O'Shea",
+    "description": "Copy the system absolute path of files and folders to the clipboard.",
+    "repo": "Alb-O/obsidian-copy-absolute-path"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/AMC-Albert/obsidian-copy-absolute-path

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
