### PR TITLE
 Add plugin: Custom File Viewer

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17288,5 +17288,12 @@
     "author": "Mouadhbendjedidi",
     "description": "A Customizable Discord RPC",
     "repo": "Mouadhbendjedidi/themed-obsidian-discord-rpc"
+  },
+  {
+    "id": "custom-file-viewer",
+    "name": "Custom File Viewer",
+    "author": "peabody28",
+    "description": "Open files with custom external applications based on file extension",
+    "repo": "peabody28/obsidian-extension-custom-file-viewer"
   }
 ]


### PR DESCRIPTION
## Features

- Automatically opens files (e.g., `.py`, `.sh`, `.yaml`, etc.) with the application you specify.
- Configurable mapping of file extensions to application paths.
- Separate default app for all unmapped extensions.
- Optional ignore list for specific file types (e.g., `.md`, images, video).
- Seamless integration into the Obsidian file explorer — just click a file, and it opens in your external app.