### PR TITLE
Add plugin: LinkTagAutoFill 

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17337,5 +17337,12 @@
     "author": "Sangrak Choi",
     "description": "Create a new note with today's date in the current directory",
     "repo": "kargnas/obsidian-create-note-with-date"
+},
+{
+  "id": "obsidian-linktag-autofill",
+  "name": "LinkTagAutoFill",
+  "description": "An intelligent Obsidian plugin that automatically generates relevant tags for your notes using AI language models. LinkTagAutoFill brings a new level of automation and insight to your note organization workflow.",
+  "repo": "LeonTing1010/obsidian-linktag-autofill",
+  "branch": "master" 
 }
 ]


### PR DESCRIPTION
> > # I am submitting a new Community Plugin
> > ## Repo URL
> > **Link to my plugin**: https://github.com/LeonTing1010/obsidian-linktag-autofill
> > ## Release Checklist
> > 
> > * [x]   I have tested the plugin on
> >   
> >   * [x]   Windows
> >   * [x]   macOS
> >   * [x]   Linux
> >   * [ ]   Android _(if applicable)_
> >   * [ ]   iOS _(if applicable)_
> > * [x]   My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz):
> >   
> >   * [x]   main.js
> >   * [x]   manifest.json
> >   * [x]   styles.css
> > * [x]   GitHub release name matches the exact version number specified in my manifest.json (Note: Use the exact version number, don't include a prefix v)
> > * [x]   The id in my manifest.json matches the id in the community-plugins.json file.
> > * [x]   My README.md describes the plugin's purpose and provides clear usage instructions.
> > * [x]   I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
> > * [x]   I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
> > * [x]   I have added a license in the LICENSE file.
> > * [x]   My project respects and is compatible with the original license of any code from other plugins that I'm using.
> >   I have given proper attribution to these other projects in my README.md.

