### PR TITLE
Add plugin: Yandex Wiki Integration

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17764,5 +17764,12 @@
     "author": "Holo",
     "description": "Standard calculator with a simple button layout.",
     "repo": "gfxholo/calculite"
+  },
+  {
+    "id": "yandex-wiki-integration",
+    "name": "Yandex Wiki Integration",
+    "author": "Pavel Sokolov",
+    "description": "Integration plugin with Yandex Wiki knowledge base",
+    "repo": "CubieProg/Obsidian-Yandex-Wiki-Integration"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17771,5 +17771,12 @@
     "author": "Pavel Sokolov",
     "description": "Integration with Yandex Wiki knowledge base",
     "repo": "CubieProg/Obsidian-Yandex-Wiki-Integration"
+  },
+  {
+    "id": "yandex-wiki-integration",
+    "name": "Yandex Wiki Integration",
+    "author": "Pavel Sokolov",
+    "description": "Integration plugin with Yandex Wiki knowledge base",
+    "repo": "CubieProg/Obsidian-Yandex-Wiki-Integration"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17775,6 +17775,7 @@
   {
     "id": "yandex-wiki-integration",
     "name": "Yandex Wiki Integration",
+	  
     "author": "Pavel Sokolov",
     "description": "Integration plugin with Yandex Wiki knowledge base",
     "repo": "CubieProg/Obsidian-Yandex-Wiki-Integration"

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17771,13 +17771,6 @@
     "author": "Pavel Sokolov",
     "description": "Integration with Yandex Wiki knowledge base",
     "repo": "CubieProg/Obsidian-Yandex-Wiki-Integration"
-  },
-  {
-    "id": "yandex-wiki-integration",
-    "name": "Yandex Wiki Integration",
-	  
-    "author": "Pavel Sokolov",
-    "description": "Integration plugin with Yandex Wiki knowledge base",
-    "repo": "CubieProg/Obsidian-Yandex-Wiki-Integration"
   }
 ]
+

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17769,7 +17769,7 @@
     "id": "yandex-wiki-integration",
     "name": "Yandex Wiki Integration",
     "author": "Pavel Sokolov",
-    "description": "Integration plugin with Yandex Wiki knowledge base",
+    "description": "Integration with Yandex Wiki knowledge base",
     "repo": "CubieProg/Obsidian-Yandex-Wiki-Integration"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
