### PR TITLE
Rename plugin from 'markdown-hijacker' to 'synaptic-bridge' and update repo

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17319,10 +17319,10 @@
 },
 {
     "id": "markdown-hijacker",
-    "name": "Markdown Hijacker",
+    "name": "Synaptic Bridge",
     "author": "Yongmini",
     "description": "Beyond the Vault. One hub for every Markdown, everywhere",
-    "repo": "especialkim/markdown-hijacker"
+    "repo": "especialkim/synaptic-bridge"
 },
 {
     "id": "auto-note-importer",


### PR DESCRIPTION
…e repo

- Changed the plugin name to 'Synaptic Bridge' to avoid the aggressive nuance of 'hijacker' and to better reflect the plugin's purpose.
- Updated the repository URL to match the new plugin name.
- The plugin id remains unchanged to ensure existing users continue to receive updates seamlessly.

# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/especialkim/synaptic-bridge

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
