### PR TITLE
Add PDF Paste Sanitizer plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17376,6 +17376,8 @@
   {
     "id": "pdf-paste-sanitizer",
     "name": "PDF Paste Sanitizer",
+    "author": "Lulu",
+    "description": "Cleans up formatting when pasting text from PDFs: fixes bullets, tabs, and broken line breaks.",
     "repo": "lu-lu-xue/obsidian-pdf-sanitizer"		
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17372,5 +17372,10 @@
     "author": "ZigHolding",
     "description": "Sync notes or plugins between vaults.",
     "repo": "zigholding/obsidian-notesync-plugin"
+  },
+  {
+    "id": "pdf-paste-sanitizer",
+    "name": "PDF Paste Sanitizer",
+    "repo": "lu-lu-xue/obsidian-pdf-sanitizer"		
   }
 ]


### PR DESCRIPTION
Add PDF Paste Sanitizer plugin

Adds a plugin that sanitizes text copied from PDFs when pasting into Obsidian. It
- replaces typographic bullets
- converts tabs to spaces
- joins broken lines.

GitHub repo: [obsidian-pdf-sanitizer plugin](https://github.com/lu-lu-xue/obsidian-pdf-sanitizer)
