### PR TITLE
Add PDF Paste Sanitizer plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17372,5 +17372,12 @@
     "author": "ZigHolding",
     "description": "Sync notes or plugins between vaults.",
     "repo": "zigholding/obsidian-notesync-plugin"
-  }
+  },
+{
+    "id": "pdf-paste-sanitizer",
+    "name": "PDF Paste Sanitizer",
+    "author": "Lulu Xue",
+    "description": "Cleans up formatting when pasting text from PDFs: fixes bullets, tabs, and broken line breaks.",
+    "repo": "lu-lu-xue/obsidian-pdf-sanitizer"
+}
 ]


### PR DESCRIPTION
## Community Plugin Submission

### Plugin Name

PDF Paste Sanitizer

### Author

Lulu Xue

### Repo URL

https://github.com/lu-lu-xue/obsidian-pdf-sanitizer

### Manifest file

https://github.com/lu-lu-xue/obsidian-pdf-sanitizer/blob/main/manifest.json

### Description

Cleans up formatting when pasting text from PDFs. Replaces typographic bullets, fixes line breaks, and converts tabs to spaces.
I’ve only tested this on macOS so far. I plan to test on Windows and Linux soon.

---

- [x] I have tested this plugin on:
  - [  ] Windows
  - [x] macOS
  - [  ] Linux (optional)

- [x] My GitHub release contains:
  - [x] `main.js`
  - [x] `manifest.json`
