### PR TITLE
Change Wikipedia Search plugins name to Wikipedia Helper 

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -6009,7 +6009,7 @@
         "id": "wikipedia-search",
         "name": "Wikipedia Helper",
         "author": "StrangeGirlMurph",
-        "description": "A better Wikipedia plugin: Search, link, insert and open Wikipedia/Wikimedia articles.",
+        "description": "Search, link, insert and open Wikipedia/Wikimedia articles.",
         "repo": "StrangeGirlMurph/obsidian-wikipedia-helper"
     },
     {


### PR DESCRIPTION
My plugin has come quite far over the last years and isn't really only about Wikipedia Search anymore. Therefore I would like to change its name to Wikipedia Helper and with that change the repo name and give it a more descriptive description. 