### PR TITLE
Add Plugin: PhraseSync

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17359,13 +17359,13 @@
     "description": "Sync notes or plugins between vaults.",
     "repo": "zigholding/obsidian-notesync-plugin"
   },
-{
-  "id": "phrasesync",
-  "name": "PhraseSync",
-  "author": "Digvijay S. Todiwal",
-  "description": "Auto-suggests internal links mid-sentence from note titles, headings, and block references.",
-  "repo": "digvijay-s-todiwal/phrasesync",
-  "version": "1.0.0"
-},
+  {
+    "id": "phrasesync",
+    "name": "PhraseSync",
+    "author": "Digvijay S. Todiwal",
+    "description": "Auto-suggests internal links mid-sentence from note titles, headings, and block references.",
+    "repo": "digvijay-s-todiwal/phrasesync",
+    "version": "1.0.0"
+  }
 
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17358,5 +17358,14 @@
     "author": "ZigHolding",
     "description": "Sync notes or plugins between vaults.",
     "repo": "zigholding/obsidian-notesync-plugin"
-  }
+  },
+{
+  "id": "phrasesync",
+  "name": "PhraseSync",
+  "author": "Digvijay S. Todiwal",
+  "description": "Auto-suggests internal links mid-sentence from note titles, headings, and block references.",
+  "repo": "digvijay-s-todiwal/phrasesync",
+  "version": "1.0.0"
+}
+
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17366,6 +17366,6 @@
   "description": "Auto-suggests internal links mid-sentence from note titles, headings, and block references.",
   "repo": "digvijay-s-todiwal/phrasesync",
   "version": "1.0.0"
-}
+},
 
 ]


### PR DESCRIPTION
# ✅ I am submitting a new Community Plugin

## 📦 Repo URL

https://github.com/digvijay-s-todiwal/phrasesync

## ✅ Release Checklist

- [x] I have tested the plugin on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
  - [ ] Android _(if applicable)_
  - [ ] iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css`
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugin's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.  
      I have given proper attribution to these other projects in my `README.md`.

---

### 🧠 PhraseSync Plugin Description

**PhraseSync** automatically suggests internal links as you type — including note titles, `#headings`, and `^block references`. It enables:

- Real-time, inline phrase suggestions
- Suggestions mid-sentence without `[[` trigger
- Support for multi-word, hyphenated, and capitalized phrases
- Smart linking for headings and block references (`[[Note#Heading|Text]]` / `[[Note#^blockID|Text]]`)
- Dynamic re-indexing on vault updates
- Built using Obsidian’s `EditorSuggest` and CodeMirror APIs

Ready for inclusion. Thank you for reviewing!
