### PR TITLE
Add Confluence Tasks Sync plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,11 +1,4 @@
 [
-   { 
-	"id": "confluence-tasks-sync",
-	"name": "Confluence Tasks Sync",
-	"author": "Adarsh Singh",
-	"description": "Seamlessly sync Confluence tasks with Obsidian. Import tasks automatically, track completion, and maintain bidirectional sync between Confluence and your notes.",
-	"repo": "adarsh1990/obsidian-connie-task-plugin"
-   },
    {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
@@ -17365,5 +17358,12 @@
     "author": "ZigHolding",
     "description": "Sync notes or plugins between vaults.",
     "repo": "zigholding/obsidian-notesync-plugin"
-  }
+},
+{ 
+    "id": "confluence-tasks-sync",
+    "name": "Confluence Tasks Sync",
+    "author": "Adarsh Singh",
+    "description": "Seamlessly sync Confluence tasks with Obsidian. Import tasks automatically, track completion, and maintain bidirectional sync between Confluence and your notes.",
+    "repo": "adarsh1990/obsidian-connie-task-plugin"
+}	
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,12 @@
 [
-    {
+   { 
+	"id": "confluence-tasks-sync",
+	"name": "Confluence Tasks Sync",
+	"author": "Adarsh Singh",
+	"description": "Seamlessly sync Confluence tasks with Obsidian. Import tasks automatically, track completion, and maintain bidirectional sync between Confluence and your notes.",
+	"repo": "adarsh1990/obsidian-connie-task-plugin"
+   },
+   {
         "id": "nldates-obsidian",
         "name": "Natural Language Dates",
         "author": "Argentina Ortega Sainz",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17363,7 +17363,7 @@
     "id": "confluence-tasks-sync",
     "name": "Confluence Tasks Sync",
     "author": "Adarsh Singh",
-    "description": "Seamlessly sync Confluence tasks with Obsidian. Import tasks automatically, track completion, and maintain bidirectional sync between Confluence and your notes.",
+    "description": "Seamlessly sync Confluence tasks with your notes. Import tasks automatically, track completion, and maintain bidirectional sync between Confluence and your notes.",
     "repo": "adarsh1990/obsidian-connie-task-plugin"
 }	
 ]


### PR DESCRIPTION
## Plugin description

Seamlessly sync Confluence tasks with your notes. Import tasks automatically, track completion, and maintain bidirectional sync between Confluence and your note-taking workflow.

## Checklist

**Doing a plugin? Check all the applicable items:**

- [x] The plugin is released under a license compatible with AGPLv3 (or a more permissive license)
- [x] The plugin does not violate existing trademarks or copyrights
- [x] The plugin is original or I have permissions to publish it
- [x] The plugin repo is public
- [x] The plugin files (main.js, manifest.json, styles.css if present) are in the root directory of the repo
- [x] The plugin has proper Github releases with the required files
- [x] The plugin follows the review guidelines
- [x] I will maintain the plugin and provide support
- [x] The plugin is useful for the general public
- [x] The plugin is complete and not a proof of concept
- [x] The plugin is not a duplicate of an existing plugin or doesn't create confusion

**Features and benefits:**

- Configurable Atlassian Domain support for any organization
- Customizable tasks filename for flexible note organization
- Automated sync scheduling (daily at configurable hours)
- Bidirectional sync (import from Confluence, sync completion back)
- Week-based task organization with clear headings
-  Duplicate detection and prevention
-  Rich task details with due dates, page links, and descriptions
-  Secure - no hardcoded credentials, user-configured API tokens

**Enterprise ready:**

- Works with any Atlassian organization domain (company.atlassian.net, etc.)
- Professional error handling and validation
- Comprehensive configuration options