### PR TITLE
Add plugin: Auto Delete Attachments

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17358,5 +17358,12 @@
     "author": "ZigHolding",
     "description": "Sync notes or plugins between vaults.",
     "repo": "zigholding/obsidian-notesync-plugin"
-  }
+  },
+{
+  "id": "auto-delete-attachments",
+  "name": "Auto Delete Attachments",
+  "author": "Sohil Athare",
+  "description": "Automatically deletes attachments from the Assets/Attachments folder when removed from notes.",
+  "repo": "Sohil1926/obsidian-auto-delete-attachments"
+}
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:
https://github.com/Sohil1926/obsidian-auto-delete-attachments

## Release Checklist
- [X ] I have tested the plugin on
  - [X]  Windows
  - [X]  macOS
  - [X]  Linux
  - [X ]  Android _(if applicable)_
  - [X]  iOS _(if applicable)_
- [X] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X ] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X ] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
