### PR TITLE
Add plugin: Frontmatter Metadata Link Classes

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17873,7 +17873,7 @@
   {
     "id": "frontmatter-link-classes",
     "name": "Frontmatter Metadata Link Classes",
-    "author": "zmeeva.io",
+    "author": "Varvara Zmeeva / zmeeva.io",
     "description": "Adds classes to internal links based on frontmatter metadata.",
     "repo": "zmeeeeeva/obsidian-plugin-metadata-link-classes"
   }

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17876,5 +17876,12 @@
     "author": "Varvara zmeeva",
     "description": "Adds classes to internal links based on frontmatter metadata.",
     "repo": "zmeeeeeva/obsidian-plugin-metadata-link-classes"
+  },
+  {
+    "id": "frontmatter-link-classes",
+    "name": "Frontmatter Metadata Link Classes",
+    "author": "zmeeva.io",
+    "description": "Adds classes to internal links based on frontmatter metadata.",
+    "repo": "zmeeeeeva/obsidian-plugin-metadata-link-classes"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17873,13 +17873,6 @@
   {
     "id": "frontmatter-link-classes",
     "name": "Frontmatter Metadata Link Classes",
-    "author": "Varvara zmeeva",
-    "description": "Adds classes to internal links based on frontmatter metadata.",
-    "repo": "zmeeeeeva/obsidian-plugin-metadata-link-classes"
-  },
-  {
-    "id": "frontmatter-link-classes",
-    "name": "Frontmatter Metadata Link Classes",
     "author": "zmeeva.io",
     "description": "Adds classes to internal links based on frontmatter metadata.",
     "repo": "zmeeeeeva/obsidian-plugin-metadata-link-classes"

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17869,5 +17869,12 @@
     "author": "Lukas Mayr",
     "description": "Simple way to sync basic flashcards with Anki with zero time tweaking settings and 100 % of your time learning.",
     "repo": "lukmay/simple-anki-sync"
+  },
+  {
+    "id": "frontmatter-link-classes",
+    "name": "Frontmatter Metadata Link Classes",
+    "author": "Varvara zmeeva",
+    "description": "Adds classes to internal links based on frontmatter metadata.",
+    "repo": "zmeeeeeva/obsidian-plugin-metadata-link-classes"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: https://github.com/zmeeeeeva/obsidian-plugin-metadata-link-classes

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
