### PR TITLE
Add Table2Excel plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17359,4 +17359,12 @@
     "description": "Sync notes or plugins between vaults.",
     "repo": "zigholding/obsidian-notesync-plugin"
   }
+      ,
+{
+    "id": "table2excel",
+    "name": "table2excel",
+    "author": "Hasan akçakoca",
+    "description": "Copies tables from Obsidian to Excel format and saves them to the clipboard.",
+    "repo": "hasanakcakoca/obsidian-table2excel"
+  }
 ]


### PR DESCRIPTION
Plugin name: Table2Excel
Plugin description: Copies Markdown tables to Excel-compatible format and saves to clipboard
Plugin repo URL: https://github.com/hasanakcakoca/obsidian-table2excel
Release URL: https://github.com/hasanakcakoca/obsidian-table2excel/releases/tag/v1.0.0