### PR TITLE
Add Invisible Line Break plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "invisible-linebreak",
+    "name": "Invisible Line Break",
+    "author": "resolutesx",
+    "description": "Add invisible line breaks in reading mode using trigger words",
+    "repo": "resolutesx/obsidian-line-break"
+  },
+  {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",

--- a/community-snippets.json
+++ b/community-snippets.json
@@ -1,9 +1,8 @@
 [
   {
-    "id": "invisible-linebreak",
-    "name": "Invisible Line Break",
-    "author": "resolutesx",
-    "description": "Add invisible line breaks in reading mode using trigger words",
-    "repo": "resolutesx/obsidian-line-break"
+    "name": "Plugin name on the right",
+    "author": "Silver",
+    "description": "Move the plugin name to the right end in your command palette for easier scanning.",
+    "repo": "ericaxu/test-snippets"
   }
 ]

--- a/community-snippets.json
+++ b/community-snippets.json
@@ -1,8 +1,9 @@
 [
   {
-    "name": "Plugin name on the right",
-    "author": "Silver",
-    "description": "Move the plugin name to the right end in your command palette for easier scanning.",
-    "repo": "ericaxu/test-snippets"
+    "id": "invisible-linebreak",
+    "name": "Invisible Line Break",
+    "author": "resolutesx",
+    "description": "Add invisible line breaks in reading mode using trigger words",
+    "repo": "resolutesx/obsidian-line-break"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## https://github.com/resolutesx/obsidian-releases

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/resolutesx/obsidian-line-break

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - []  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
