### PR TITLE
Rebrand `Refresh Preview` plugin to `Refresh Any View`

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12223,10 +12223,10 @@
   },
   {
     "id": "refresh-preview",
-    "name": "Refresh Preview",
+    "name": "Refresh Any View",
     "author": "mnaoumov",
-    "description": "Allows to refresh preview mode without reopening the note",
-    "repo": "mnaoumov/obsidian-refresh-preview"
+    "description": "Allows to refresh any view without reopening it.",
+    "repo": "mnaoumov/obsidian-refresh-any-view"
   },
   {
     "id": "hash-pasted-image",


### PR DESCRIPTION
The plugin now does more than the name says, so it is not as discoverable by the users.

From what I understood, I have to keep the plugin id, even if it doesn't match the rebranded plugin name.
