### PR TITLE
Add plugin: Related Notes by Tag

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18065,5 +18065,12 @@
     "author": "peabody28",
     "description": "Open files with custom external applications based on file extension",
     "repo": "peabody28/obsidian-extension-custom-file-viewer"
+  },
+  {
+    "id": "related-notes-by-tag",
+    "name": "Related Notes by Tag",
+    "author": "Chris Howard",
+    "description": "Displays list of notes in the sidebar that share tags with the currently active note.",
+    "repo": "chrishoward-projects/related-notes-by-tag"
   }
 ]


### PR DESCRIPTION
Add plugin: Related Notes by Tag
related-notes-by-tag

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/chrishoward-projects/related-notes-by-tag

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
