### PR TITLE
Add plugin: RSS to Note

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17456,5 +17456,13 @@
     "author": "banisterious",
     "description": "Provides advanced word counting features for selected text across all view modes. Goes beyond basic word counting with customizable path exclusion, and more.",
     "repo": "banisterious/obsidian-custom-selected-word-count"
-  }
+  },
+{
+  "id": "rss-to-note",
+  "name": "RSS to Note",
+  "version": "0.1.1",
+  "description": "Fetch RSS feed and save entries as cleaned HMTL markdown notes",
+  "author": "Lars Gjessing",
+  "repo": "Gjessing1/Obsidian-RSS",
+}
 ]


### PR DESCRIPTION
Community plugin for review, rss-to-note

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Gjessing1/Obsidian-RSS

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x]  I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
