### PR TITLE
Add plugin: GitHub Tasks

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18020,7 +18020,7 @@
   {
     "id": "github-tasks",
     "name": "GitHub Tasks",
-    "author": "mikethicke",
+    "author": "Mike Thicke",
     "description": "Sync issues and pull requests from your GitHub account to tasks.",
     "repo": "Epistemic-Technology/obsidian-github-tasks"
   }

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18016,5 +18016,12 @@
     "author": "Young Lee",
     "description": "Recommends semantically similar notes to the currently viewed note.",
     "repo": "joybro/obsidian-similar-notes"
+  },
+  {
+    "id": "github-tasks",
+    "name": "GitHub Tasks",
+    "author": "mikethicke",
+    "description": "Sync issues and pull requests from your GitHub account to tasks.",
+    "repo": "Epistemic-Technology/obsidian-github-tasks"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Epistemic-Technology/obsidian-github-tasks

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [X]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
