### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "journalistic-importer",
+    "name": "Journalistic Importer",
+    "author": "Homero Kemmerich",
+    "description": "Import Journalistic entries into Obsidian.",
+    "repo": "HomeroKemmerich/journalistic-importer"
+  },
+  {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,12 +1,5 @@
 [
   {
-    "id": "journalistic-importer",
-    "name": "Journalistic Importer",
-    "author": "Homero Kemmerich",
-    "description": "Import Journalistic entries into Obsidian.",
-    "repo": "HomeroKemmerich/journalistic-importer"
-  },
-  {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",
@@ -17505,5 +17498,12 @@
     "author": "Lucy Dryaeva",
     "description": "Manage layouts with context",
     "repo": "ShadiestGoat/obsidian-layout-manager"
+  },
+  {
+    "id": "journalistic-importer",
+    "name": "Journalistic Importer",
+    "author": "Homero Kemmerich",
+    "description": "Import Journalistic entries into Obsidian.",
+    "repo": "HomeroKemmerich/journalistic-importer"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17503,7 +17503,7 @@
     "id": "journalistic-importer",
     "name": "Journalistic Importer",
     "author": "Homero Kemmerich",
-    "description": "Import Journalistic entries into Obsidian.",
+    "description": "Import your Journalistic exported entries.",
     "repo": "HomeroKemmerich/journalistic-importer"
   }
 ]


### PR DESCRIPTION
Adds Journalistic importer plugin

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [HomeroKemmerich/journalistic-importer](https://github.com/HomeroKemmerich/journalistic-importer)

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
