### PR TITLE
Add Timing Integration plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17533,5 +17533,12 @@
     "author": "Christ Degni",
     "description": "Autocomplete text to type more efficiently.",
     "repo": "c-degni/text-autocomplete"
+  },
+  {
+    "id": "timing-tracker",
+    "name": "Timing Integration",
+    "author": "tomoyanakano",
+    "description": "Integrate macOS Timing app for automatic time tracking in Daily and Weekly Notes. Features timeline visualization, productivity analytics, and seamless workflow integration.",
+    "repo": "tomoyanakano/obsidian-timing-plugin"
   }
 ]


### PR DESCRIPTION
I am submitting a new Community Plugin

## Repo URL
Link to my plugin: https://github.com/tomoyanakano/obsidian-timing-plugin

## Release Checklist
- [ ] I have tested the plugin on
  - [ ] Windows
  - [x] macOS
  - [ ] Linux
  - [ ] Android (not applicable - desktop-only plugin)
  - [ ] iOS (not applicable - desktop-only plugin)
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] main.js
  - [x] manifest.json
  - [x] styles.css
- [x] GitHub release name matches the exact version number specified in my manifest.json (Note: Use the exact version number, don't include a prefix v)
- [x] The id in my manifest.json matches the id in the community-plugins.json file. (`timing-tracker`)
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using. I have given proper attribution to these other projects in my README.md.

## Additional Information

### Platform Compatibility
This is a **macOS-only plugin** that integrates with the Timing app via AppleScript. The plugin is marked as `isDesktopOnly: true` in the manifest.json and cannot run on mobile platforms or non-macOS desktop systems.

### Testing Details
- Extensively tested on macOS (Sonoma and Ventura)
- Tested with both Timing Expert and Timing Connect plans
- Verified with various Daily Note formats and folder structures
- Tested timeline view with different zoom levels and data densities

### Privacy & Security
- No external API calls - all processing is done locally
- Uses only standard macOS AppleScript for Timing integration
- No data collection or telemetry
- All timing data stays within the user's Obsidian vault

### Previous Issues Addressed
All issues from the initial review have been fixed:
- ✅ Changed plugin ID from `obsidian-timing-plugin` to `timing-tracker`
- ✅ Removed "Obsidian" from the description
- ✅ Created release with tag `1.0.0` (without 'v' prefix)
- ✅ Release includes all required files (main.js, styles.css, manifest.json)