### PR TITLE
Add plugin: QuickLink

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17533,5 +17533,12 @@
     "author": "Christ Degni",
     "description": "Autocomplete text to type more efficiently.",
     "repo": "c-degni/text-autocomplete"
+  },
+  {
+    "id": "quicklink",
+    "name": "QuickLink",
+    "author": "Jamba Hailar",
+    "description": "Quickly create links to files using @ trigger character",
+    "repo": "Jamailar/QuickLink-Obsidian"
   }
 ]


### PR DESCRIPTION
I am submitting a new Community Plugin

Repo URL  
Link to my plugin: https://github.com/Jamailar/QuickLink-Obsidian

Release Checklist  
- [x] I have tested the plugin on  
  - [x] Windows  
  - [x] macOS  
  - [x] Linux  
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)  
  - [x] main.js  
  - [x] manifest.json  
  - [x] styles.css (optional)  
- [x] GitHub release name matches the exact version number specified in my manifest.json (Note: Use the exact version number, don't include a prefix `v`)  
- [x] The id in my manifest.json matches the id in the community-plugins.json file.  
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.  
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugin's adherence to these policies.  
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.  
- [x] I have added a license in the LICENSE file.  
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.  
- [x] I have given proper attribution to these other projects in my README.md.

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
