### PR TITLE
Add plugin: Move To Folder

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17533,5 +17533,15 @@
     "author": "Christ Degni",
     "description": "Autocomplete text to type more efficiently.",
     "repo": "c-degni/text-autocomplete"
-  }
+  },
+{
+  "id": "move-to-folder",
+  "name": "Move To Folder",
+  "author": "KaramazovBrothers",
+  "description": "Automatically move new notes to folders based on their name prefix.",
+  "repo": "KaramazovBrothers/moveToFolder",
+  "version": "1.0.0",
+  "minAppVersion": "0.12.0",
+  "isDesktopOnly": true
+}
 ]


### PR DESCRIPTION
Automatically move new notes to folders based on their name prefix.

Plugin name: Move To Folder
Author: Dima Korolev
GitHub repo: https://github.com/KaramazovBrothers/moveToFolder
Description: Automatically move new notes to folders based on their name prefix.
Minimum Obsidian version: 0.12.0
Is desktop only: true
