### PR TITLE
Add plugin: Bibtex Entry View

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,13 +1,5 @@
 [
   {
-    "id": "obsidian-plugin-bibtex-entry-view",
-    "name": "Bibtex Entry View",
-    "author": "Kyoungdeuk",
-    "description": "Load the bibtex entry of a given bibkey from a given .bib file and show the entry in the code block of 'bibkey'.",
-    "repo": "awfrok/obsidian-plugin-bibtex-entry-view"
-  },
-
-  {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",
@@ -18178,5 +18170,12 @@
     "author": "Ayush Raj",
     "description": "A clipboard manager that stores clipboard history and provides search functionality with real-time updates",
     "repo": "ayu5h-raj/clipboard-manager"
+  },
+  {
+    "id": "obsidian-plugin-bibtex-entry-view",
+    "name": "Bibtex Entry View",
+    "author": "Kyoungdeuk",
+    "description": "Load the bibtex entry of a given bibkey from a given .bib file and show the entry in the code block of 'bibkey'.",
+    "repo": "awfrok/obsidian-plugin-bibtex-entry-view"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18176,6 +18176,6 @@
     "name": "Bibtex Entry View",
     "author": "Kyoungdeuk",
     "description": "Load the bibtex entry of a given bibkey from a given .bib file and show the entry in the code block of 'bibkey'.",
-    "repo": "awfrok/obsidian-plugin-bibtex-entry-view"
+    "repo": "awfrok/obsidian-plugin-bibtex-entry-vie"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18177,5 +18177,5 @@
     "author": "Kyoungdeuk",
     "description": "Load the bibtex entry of a given bibkey from a given .bib file and show the entry in the code block of 'bibkey'.",
     "repo": "awfrok/obsidian-plugin-bibtex-entry-view"
-  },
+  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18176,6 +18176,6 @@
     "name": "Bibtex Entry View",
     "author": "Kyoungdeuk",
     "description": "Load the bibtex entry of a given bibkey from a given .bib file and show the entry in the code block of 'bibkey'.",
-    "repo": "awfrok/obsidian-plugin-bibtex-entry-vie"
+    "repo": "awfrok/obsidian-plugin-bibtex-entry-view"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18172,7 +18172,7 @@
     "repo": "ayu5h-raj/clipboard-manager"
   },
   {
-    "id": "obsidian-plugin-bibtex-entry-view",
+    "id": "bibtex-entry-view",
     "name": "Bibtex Entry View",
     "author": "Kyoungdeuk",
     "description": "Load the bibtex entry of a given bibkey from a given .bib file and show the entry in the code block of 'bibkey'.",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,13 @@
 [
   {
+    "id": "obsidian-plugin-bibtex-entry-view",
+    "name": "Bibtex Entry View",
+    "author": "Kyoungdeuk",
+    "description": "Load the bibtex entry of a given bibkey from a given .bib file and show the entry in the code block of 'bibkey'.",
+    "repo": "awfrok/obsidian-plugin-bibtex-entry-view"
+  },
+
+  {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18175,7 +18175,7 @@
     "id": "bibtex-entry-view",
     "name": "Bibtex Entry View",
     "author": "Kyoungdeuk",
-    "description": "Load the bibtex entry of a given bibkey from a given .bib file and show the entry in the code block of 'bibkey'.",
+    "description": "Load the bibtex entry of a given bibkey from a given bib file and show the entry in the code block of bibkey.",
     "repo": "awfrok/obsidian-plugin-bibtex-entry-view"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18177,5 +18177,5 @@
     "author": "Kyoungdeuk",
     "description": "Load the bibtex entry of a given bibkey from a given .bib file and show the entry in the code block of 'bibkey'.",
     "repo": "awfrok/obsidian-plugin-bibtex-entry-view"
-  }
+  },
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: [awfrok/obsidian-plugin-bibtex-entry-view](https://github.com/awfrok/obsidian-plugin-bibtex-entry-view)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
