### PR TITLE
Add plugin: X Post Saver

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18268,5 +18268,12 @@
     "author": "Yuichi-Aragi",
     "description": "A local, snapshot-based version control system. Lets you create finite number of versions of any note.",
     "repo": "Yuichi-Aragi/Version-Control"
+  },
+  {
+    "id": "x-post-saver",
+    "name": "X Post Saver",
+    "author": "Tanaka Mambinge",
+    "description": "Saves X (formerly Twitter) posts' text data to new notes or inside a specific directory in your vault.",
+    "repo": "tanaka-mambinge/x-post-saver"
   }
 ]


### PR DESCRIPTION
Added extension for saving X (Twitter) post data to new notes

# I am submitting a new Community Plugin

## Repo URL

Link to my plugin: [tanaka-mambinge/x-post-saver](https://github.com/tanaka-mambinge/x-post-saver)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
