### PR TITLE
Add feishu-share plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17573,7 +17573,7 @@
   "id": "feishu-share",
   "name": "飞书分享",
   "author": "Astral719",
-  "description": "一键将 Obsidian 笔记分享到飞书云文档，支持完整格式转换、文件夹管理",
+  "description": "一键将笔记分享到飞书云文档，支持完整格式转换、文件夹管理",
   "repo": "Astral719/obsidian-feishu-share"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17568,5 +17568,12 @@
     "author": "Helpfeel Inc.",
     "description": "Display your Gyazo captures and embed them into your notes.",
     "repo": "nota/gyazo-obsidian-plugin"
-  }
+  },
+  {
+  "id": "feishu-share",
+  "name": "飞书分享",
+  "author": "Astral719",
+  "description": "一键将 Obsidian 笔记分享到飞书云文档，支持完整格式转换和文件夹管理",
+  "repo": "Astral719/obsidian-feishu-share"
+}
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17573,7 +17573,7 @@
   "id": "feishu-share",
   "name": "飞书分享",
   "author": "Astral719",
-  "description": "一键将笔记分享到飞书云文档，支持完整格式转换、文件夹管理",
+  "description": "一键将笔记分享到飞书云文档，支持完整格式转换和文件夹管理",
   "repo": "Astral719/obsidian-feishu-share"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17573,7 +17573,7 @@
   "id": "feishu-share",
   "name": "飞书分享",
   "author": "Astral719",
-  "description": "一键将 Obsidian 笔记分享到飞书云文档，支持完整格式转换和文件夹管理",
+  "description": "一键将 Obsidian 笔记分享到飞书云文档，支持完整格式转换、文件夹管理",
   "repo": "Astral719/obsidian-feishu-share"
 }
 ]


### PR DESCRIPTION
## 插件信息
- **名称**: 飞书分享 (Feishu Share)
- **作者**: Astral719
- **功能**: 一键将 Obsidian 笔记分享到飞书云文档

## 特性
- ✅ 完整的 OAuth 2.0 授权流程
- ✅ 支持文件夹选择和管理
- ✅ 保持 Markdown 格式完整性
- ✅ 直接调用飞书 API，无需代理

## 仓库信息
- **GitHub**: https://github.com/Astral719/obsidian-feishu-share
- **Release**: https://github.com/Astral719/obsidian-feishu-share/releases/tag/v1.0.0

## 测试
- ✅ 插件在 Obsidian 中正常加载
- ✅ 授权流程完整可用
- ✅ 文档分享功能正常
- ✅ 错误处理完善