### PR TITLE
Add history-playback entry to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,17 @@
 [
   {
+  "id":            "history-playback",
+  "name":          "History Playback",
+  "author":        "Umarbek",
+  "description":   "Record and replay note edits with a timeline UI.",
+  "repo":          "UmarbekFU/obsidian-history-playback",
+  "version":       "0.1.0",
+  "minAppVersion": "0.14.0",
+  "isDesktopOnly": false,
+  "tags":          ["history","playback","timeline"]
+  },
+  
+  {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",


### PR DESCRIPTION
This PR registers the History Playback plugin (v0.1.0) in the Obsidian Community Plugins list.
- id: history-playback
- repo: UmarbekFU/obsidian-history-playback
- minAppVersion: 0.14.0
- tags: ["history","playback","timeline"]

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
