### PR TITLE
Add history-playback plugin entry to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17575,5 +17575,16 @@
     "author": "Albert O'Shea",
     "description": "Changes click behavior for unsupported files to work similar to Windows File Explorer: single-click selects, double-click opens in default app.",
     "repo": "Alb-O/obsidian-click-unsupported-files"
+  }, 
+  {
+  "id":            "history-playback",
+  "name":          "History Playback",
+  "author":        "Umarbek",
+  "description":   "Record and replay note edits with a timeline UI.",
+  "repo":          "UmarbekFU/obsidian-history-playback",
+  "version":       "0.1.0",
+  "minAppVersion": "0.14.0",
+  "isDesktopOnly": false,
+  "tags":          ["history","playback","timeline"]
   }
 ]


### PR DESCRIPTION
## Plugin Submission

Plugin name: History Playback  
Plugin ID: history-playback  
Author: Umarbek 
Repo URL: https://github.com/UmarbekFU/obsidian-history-playback  
Version: 0.1.0  
Minimum Obsidian version: 0.14.0  
Tags: history, playback, timeline  

Description

This plugin records snapshots of markdown files on modification and provides a timeline-based playback UI inside Obsidian, allowing users to review how their notes evolved.

Installation

1. Install from Community Plugins → Browse → “History Playback”  
2. Enable the plugin in Settings → Plugin Options → History Playback

Usage

- Run the command “Open History Playback” via the command palette.  
- Select a note from the dropdown to load its history.  
- Scroll through timestamps in the textarea, or implement future playback controls.

Release Notes

- v0.1.0 – Initial public release with basic snapshot recording and history list view.

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
