### PR TITLE
Adding gerrit-status plugin to the list of community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17645,5 +17645,12 @@
     "author": "okawak",
     "description": "Send messages from a Discord channel to your Vault",
     "repo": "okawak/discord_message_sender"
+  },
+  {
+    "id": "gerrit-status",
+    "name": "Gerrit Status",
+    "author": "Jan Winkler",
+    "description": "Display Gerrit CL status in your notes",
+    "repo": "fairlight1337/obsidian-gerrit-status"
   }
 ]


### PR DESCRIPTION
gerrit-status allows users to fetch and display Gerrit CL status details in their notes. This plugin implements this logic, is configurable for different Gerrit sites and setups, and the output can be customized based on the users' needs.
