### PR TITLE
Add plugin: [Insert SpSymbols Ctr]

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17708,5 +17708,12 @@
     "author": "vlwkaos",
     "description": "Change Excluded files setting per workspace, active note and more.",
     "repo": "vlwkaos/obsidian-smart-excluded"
+  },
+  {
+    "id": "ob-insert-spsymbols-center",
+    "name": "Insert SpSymbols Ctr",
+    "author": "superxpe",
+    "description": "Insert special symbols (arrows, math, Greek letters) through a category-based menu.",
+    "repo": "gyyy2020/obsidian-insert-symbols-center"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:https://github.com/gyyy2020/obsidian-insert-symbols-center

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source. Zip / source. Tar. Gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest. Json (_**Note:** Use the exact version number, don't include a prefix `v` _)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README. Md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
