### PR TITLE
Add todoist-task-creator

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17708,5 +17708,12 @@
     "author": "vlwkaos",
     "description": "Change Excluded files setting per workspace, active note and more.",
     "repo": "vlwkaos/obsidian-smart-excluded"
+  },
+  {
+  "id": "todoist-task-creator",
+  "name": "Todoist Task Creator",
+  "author": "Jonathan Hernandez",
+  "description": "A simple plugin to create tasks in Todoist.",
+  "repo": "jonathanhher/todoist-task-creator"
   }
 ]


### PR DESCRIPTION
I am submitting a new Community Plugin

**Repo URL:** https://github.com/jonathanhher/todoist-task-creator

---
### Release Checklist

**I have tested the plugin on:**
- [x] Windows - [ ] macOS - [ ] Linux - [ ] Android - [ ] iOS **My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz):**
- [x] `main.js`
- [x] `manifest.json`
- [x] `styles.css` (optional)

- [x] My GitHub release name matches the exact version number specified in my `manifest.json` (Note: Use the exact version number, don't include a prefix `v`)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My `README.md` describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the `LICENSE` file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using. I have given proper attribution to these other projects in my `README.md`.