### PR TITLE
Add plugin: Attachment Organizer

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17710,10 +17710,10 @@
     "repo": "vlwkaos/obsidian-smart-excluded"
   },
   {
-    "id": "file-creator",
-    "name": "File Creator",
+    "id": "attachment-organizer",
+    "name": "Attachment Organizer",
     "author": "DudeThatsErin",
-    "description": "A simple yet powerful Obsidian plugin that helps you create files in specific folders with customizable naming options.",
-    "repo": "DudeThatsErin/FileCreator"
+    "description": "A comprehensive plugin that helps you organize, manage, and clean up attachments — plus create structured markdown and PDF files in your Obsidian vault.",
+    "repo": "DudeThatsErin/attachment-organizer"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17713,7 +17713,7 @@
     "id": "attachment-organizer",
     "name": "Attachment Organizer",
     "author": "DudeThatsErin",
-    "description": "A comprehensive plugin that helps you organize, manage, and clean up attachments — plus create structured markdown and PDF files in your vault",
+    "description": "A comprehensive plugin that helps you organize, manage, and clean up attachments — plus create structured markdown and PDF files in your vault.",
     "repo": "DudeThatsErin/attachment-organizer"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17708,5 +17708,12 @@
     "author": "vlwkaos",
     "description": "Change Excluded files setting per workspace, active note and more.",
     "repo": "vlwkaos/obsidian-smart-excluded"
+  },
+  {
+    "id": "filecreator",
+    "name": "File Creator",
+    "author": "DudeThatsErin",
+    "description": "A simple yet powerful Obsidian plugin that helps you create files in specific folders with customizable naming options.",
+    "repo": "DudeThatsErin/FileCreator"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17713,7 +17713,7 @@
     "id": "attachment-organizer",
     "name": "Attachment Organizer",
     "author": "DudeThatsErin",
-    "description": "A comprehensive plugin that helps you organize, manage, and clean up attachments — plus create structured markdown and PDF files in your Obsidian vault.",
+    "description": "A comprehensive plugin that helps you organize, manage, and clean up attachments — plus create structured markdown and PDF files in your vault.",
     "repo": "DudeThatsErin/attachment-organizer"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17713,7 +17713,7 @@
     "id": "attachment-organizer",
     "name": "Attachment Organizer",
     "author": "DudeThatsErin",
-    "description": "A comprehensive plugin that helps you organize, manage, and clean up attachments — plus create structured markdown and PDF files in your vault.",
+    "description": "A comprehensive plugin that helps you organize, manage, and clean up attachments — plus create structured markdown and PDF files in your vault",
     "repo": "DudeThatsErin/attachment-organizer"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17710,7 +17710,7 @@
     "repo": "vlwkaos/obsidian-smart-excluded"
   },
   {
-    "id": "filecreator",
+    "id": "file-creator",
     "name": "File Creator",
     "author": "DudeThatsErin",
     "description": "A simple yet powerful Obsidian plugin that helps you create files in specific folders with customizable naming options.",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/DudeThatsErin/attachment-organizer

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
- [x] I have given proper attribution to these other projects in my `README.md`.
