### PR TITLE
Add plugin: Training markdown editor

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17776,7 +17776,7 @@
     "id": "tmd-editor",
     "name": "Training markdown editor",
     "author": "Chashkov Daniil",
-    "description": "A plugin for Obsidian to manage and edit workout .tmd files in a convenient custom interface",
+    "description": "A plugin for Obsidian to manage and edit workout .tmd files in a convenient custom interface.",
     "repo": "chashkovdaniil/tmd-editor"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17776,7 +17776,7 @@
     "id": "tmd-editor",
     "name": "Training markdown editor",
     "author": "Chashkov Daniil",
-    "description": "A plugin for Obsidian to manage and edit workout .tmd files in a convenient custom interface.",
+    "description": "A plugin for Obsidian to manage and edit workout .tmd files in a convenient custom interface",
     "repo": "chashkovdaniil/tmd-editor"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17771,5 +17771,12 @@
     "author": "Pavel Sokolov",
     "description": "Integration with Yandex Wiki knowledge base",
     "repo": "CubieProg/Obsidian-Yandex-Wiki-Integration"
+  },
+  {
+    "id": "tmd-editor",
+    "name": "Training markdown editor",
+    "author": "Chashkov Daniil",
+    "description": "A plugin for Obsidian to manage and edit workout .tmd files in a convenient custom interface.",
+    "repo": "chashkovdaniil/tmd-editor"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [X]  macOS
  - [X]  Linux
  - [X]  Android _(if applicable)_
  - [X]  iOS _(if applicable)_
- [X] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ ] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [ ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
