### PR TITLE
Add plugin: Paste as file link

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18427,7 +18427,7 @@
     "id": "paste-as-file-link",
     "name": "Paste as file link",
     "author": "Matthias Büge",
-    "description": "Allows pasting clipboard content as file links to existing notes.",
+    "description": "Paste clipboard content as file links into existing notes, when a file with this name is existing.",
     "repo": "mbedded/obsidian-paste-file-link"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18422,5 +18422,12 @@
     "author": "Pavel Sokolov",
     "description": "Display Yandex Tracker issues in your notes",
     "repo": "CubieProg/Obsidian-Yandex-Tracker-Issue"
+  },
+  {
+    "id": "paste-as-file-link",
+    "name": "Paste as file link",
+    "author": "Matthias Büge",
+    "description": "Allows pasting clipboard content as file links to existing notes.",
+    "repo": "mbedded/obsidian-paste-file-link"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/mbedded/obsidian-paste-file-link

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_ 
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.

---
Remarks:

The guidelines says, that `this.app.vault.getFiles().find(..)` should not be used. The idea behind my plugin is, that I can paste a file name (note) so a file-link is created. I've tested the method `this.app.vault.getFileByPath()` but when I'm looking for "my note" it does not find "folder/my note" for example.

In my workflow I use F2 to select the filename, press CTRL+C to copy it, switch to another note and paste the name. The selection with F2 does not contain the full path of the file. That's why I use `getFiles().find(..)`instead. If there is a way for improvement, I'm happy to update my plugin.

I'm not sure how big the impact is. In my personal vault (around 1000 files) I had no issues but this may depend on the system (e.g. dual-core instead of quad-core).