### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17841,5 +17841,12 @@
     "author": "shumadrid",
     "description": "Adds context menu actions for copying the full/vault-relative path of files and folders.",
     "repo": "shumadrid/obsidian-copy-path"
-  }
+  }, 
+  {
+  "id": "paste-with-source",
+  "name": "Paste With Source",
+  "author": "skitnik22",
+  "repo": "skitnik22/obsidian-autoquotation",
+  "description": "When pasting text, asks for the source: own thought, quote, AI, or another person. Helps you keep track of sources in your personal knowledge base."
+}
 ]


### PR DESCRIPTION
**Plugin Name:** Paste With Source  
**Author:** skitnik22  
**Repo:** https://github.com/skitnik22/obsidian-autoquotation  
**Description:** When pasting text, asks for the source: own thought, quote, AI, or another person. Helps you keep track of sources in your personal knowledge base.

**Why this plugin?**
Paste With Source helps you never forget to mark the source of pasted text. It ensures you always distinguish your own thoughts from quotes, AI, or other people’s words, making your knowledge base more trustworthy and organized.