### PR TITLE
Add Qiita Note to community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17895,7 +17895,7 @@
     "id": "qiita-note",
     "name": "Qiita Note",
     "author": "Shizuka-Kujo",
-    "description": "Add Qiita-style :::note blocks to Obsidian with info, warn, and alert types, styled with Font Awesome icons.",
+    "description": "Add Qiita-style note blocks (info, warn, alert) with Font Awesome icons",
     "repo": "Shizuka-Kujo/Qiita-Note-Plugin-for-Obsidian"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17890,5 +17890,14 @@
     "author": "Utkarsh Raj",
     "description": "Visualize notes as interactive mind maps",
     "repo": "linem-davton/obsidian-better-mindmap"
+  },
+  {
+    "id": "qiita-note-plugin",
+    "name": "Qiita Note Plugin",
+    "author": "Shizuka-Kujo",
+    "description": "Add Qiita-style :::note blocks to Obsidian with info, warn, and alert types, styled with Font Awesome icons.",
+    "repo": "Shizuka-Kujo/Qiita-Note-Plugin-for-Obsidian",
+    "version": "1.0.0",
+    "minAppVersion": "0.15.0"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17895,7 +17895,7 @@
     "id": "qiita-note",
     "name": "Qiita Note",
     "author": "Shizuka-Kujo",
-    "description": "Add Qiita-style note blocks (info, warn, alert) with Font Awesome icons",
+    "description": "Add Qiita-style note blocks (info, warn, alert) with Font Awesome icons.",
     "repo": "Shizuka-Kujo/Qiita-Note-Plugin-for-Obsidian"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17892,12 +17892,10 @@
     "repo": "linem-davton/obsidian-better-mindmap"
   },
   {
-    "id": "qiita-note-plugin",
-    "name": "Qiita Note Plugin",
+    "id": "qiita-note",
+    "name": "Qiita Note",
     "author": "Shizuka-Kujo",
     "description": "Add Qiita-style :::note blocks to Obsidian with info, warn, and alert types, styled with Font Awesome icons.",
-    "repo": "Shizuka-Kujo/Qiita-Note-Plugin-for-Obsidian",
-    "version": "1.0.0",
-    "minAppVersion": "0.15.0"
+    "repo": "Shizuka-Kujo/Qiita-Note-Plugin-for-Obsidian"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:
https://github.com/Shizuka-Kujo/Qiita-Note-Plugin-for-Obsidian

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.