### PR TITLE
Add plugin: Cross-OS Name Guard

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17890,5 +17890,13 @@
     "author": "Utkarsh Raj",
     "description": "Visualize notes as interactive mind maps",
     "repo": "linem-davton/obsidian-better-mindmap"
+  },
+  {
+    "id": "cross-os-name-guard",
+    "name": "Cross-OS Name Guard",
+    "author": "Zameer Fouzan",
+    "description": "Warns about forbidden file and folder characters that may break sync across operating systems. Highlights file titles and shows notices when issues are found.",
+    "repo": "zmrfzn/cross-os-nameguard-plugin"
   }
+
 ]


### PR DESCRIPTION
This plugin warns about forbidden file and folder characters that may break sync across operating systems. Highlights file titles and shows notices when issues are found in the active file or folder

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
[zmrfzn/cross-os-nameguard-plugin](https://github.com/zmrfzn/cross-os-nameguard-plugin) 

Link to my plugin:

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
