### PR TITLE
Add Helix Editor Support plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -7,6 +7,13 @@
     "repo": "argenos/nldates-obsidian"
   },
   {
+    "id": "obsidian-helix",
+    "name": "Helix Editor Support",
+    "author": "Juan Vasquez",
+    "description": "Helix editor keybindings and editing philosophy for Obsidian",
+    "repo": "juanmvsa/obsidian-helix"
+  },
+  {
     "id": "hotkeysplus-obsidian",
     "name": "Hotkeys++",
     "author": "Argentina Ortega Sainz",


### PR DESCRIPTION
Adding Helix 
  Editor Support plugin that brings selection-first editing to Obsidian