### PR TITLE
Add plugin: Korean Grammar Assistant

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17909,7 +17909,7 @@
     "id": "korean-grammar-assistant",
     "name": "Korean Grammar Assistant",
     "author": "hyungyunlim",
-    "description": "Advanced Korean grammar and spelling checker powered by Bareun.ai API. Features smart pagination, mobile optimization, and interactive correction interface.",
+    "description": "Korean grammar and spelling checker with real-time inline editing (BETA) and AI-powered suggestions. Features modular architecture and mobile optimization.",
     "repo": "hyungyunlim/obsidian-korean-grammar-assistant"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17904,5 +17904,12 @@
     "author": "algernon",
     "description": "Help you to study with ai-prompting",
     "repo": "mali-i/deepseek-ai-assistant"
+  },
+  {
+    "id": "korean-grammar-assistant",
+    "name": "Korean Grammar Assistant",
+    "author": "hyungyunlim",
+    "description": "Advanced Korean grammar and spelling checker powered by Bareun.ai API. Features smart pagination, mobile optimization, and interactive correction interface.",
+    "repo": "hyungyunlim/obsidian-korean-grammar-assistant"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -1,0 +1,1 @@
+korean-grammar-assistant

--- a/plugins.json
+++ b/plugins.json
@@ -1,1 +1,0 @@
-korean-grammar-assistant


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

https://github.com/hyungyunlim/obsidian-korean-grammar-assistant

## Release Checklist
- [x] I have tested the plugin on
  - [x] Windows
  - [x] macOS
  - [x] Linux
  - [x] Android _(if applicable)_
  - [x] iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.