### PR TITLE
Add plugin: Canvas Link to Group

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5145,13 +5145,6 @@
     "repo": "Some-Regular-Person/obsidian-vega"
   },
   {
-    "id": "canvas-link-to-group",
-    "name": "Canvas Link to Group",
-    "author": "TGRRRR",
-    "description": "create link to specific group within canvas.",
-    "repo": "TGRRRR/Obsidian-canvas-link-to-group"
-  },
-  {
     "id": "link-nodes-in-canvas",
     "name": "Link Nodes in Canvas",
     "description": "Add edges between notes in Canvas based on their links.",
@@ -17911,5 +17904,12 @@
     "author": "algernon",
     "description": "Help you to study with ai-prompting",
     "repo": "mali-i/deepseek-ai-assistant"
+  },
+  {
+    "id": "canvas-link-to-group",
+    "name": "Canvas Link to Group",
+    "author": "TGRRRR",
+    "description": "create link to specific group within canvas.",
+    "repo": "TGRRRR/Obsidian-canvas-link-to-group"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

`https://github.com/TGRRRR/Obsidian-canvas-link-to-group`

## Release Checklist

-   [ ] I have tested the plugin on
    -   [x] Windows
    -   [ ] macOS
    -   [ ] Linux
    -   [x] Android (if applicable)
    -   [ ] iOS (if applicable)
-   [x] My GitHub release contains all required files (as individual files, not just in the `source.zip` / `source.tar.gz`)
    -   [x] `main.js`
    -   [x] `manifest.json`
    -   [ ] `styles.css` (optional)
-   [x] GitHub release name matches the exact version number specified in my `manifest.json` (Note: Use the exact version number, don't include a prefix `v`)
-   [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
-   [x] My `README.md` describes the plugin's purpose and provides clear usage instructions.
-   [x] I have read the developer policies at `https://docs.obsidian.md/Developer+policies`, and have assessed my plugin's adherence to these policies.
-   [x] I have read the tips in `https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines` and have self-reviewed my plugin to avoid these common pitfalls.
-   [x] I have added a license in the LICENSE file.
-   [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
-   [x] I have given proper attribution to these other projects in my `README.md`.