### PR TITLE
Rename Plugin: Virtual Footer → Virtual Content

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17059,11 +17059,11 @@
     "repo": "jaspersurmont/obsidian-comments"
   },
   {
-    "id": "virtual-footer",
-    "name": "Virtual Footer",
+    "id": "virtual-content",
+    "name": "Virtual Content",
     "author": "Signynt",
-    "description": "Display markdown text (including dataview queries) at the bottom of all notes in a folder, without modifying them.",
-    "repo": "Signynt/virtual-footer"
+    "description": "Display markdown text (including dataview queries or Obsidian bases) at the bottom, top or in the sidebar for all notes which match a specified rule, without modifying them.",
+    "repo": "Signynt/virtual-content"
   },
   {
     "id": "match-syntax",


### PR DESCRIPTION
# I am changing the name of an existing Community Plugin

Since I initially released my plugin it's scope has increased, and the original name is no longer accurate.
I will update the Repo url and release a new version of my plugin with the updated name once this PR has been merged.

## Repo URL
Link to my plugin: https://github.com/Signynt/virtual-footer
