### PR TITLE
Add plugin: Open Graph Fetcher

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17897,5 +17897,12 @@
     "author": "algernon",
     "description": "Help you to study with ai-prompting",
     "repo": "mali-i/deepseek-ai-assistant"
-  }
+  },
+  {
+   "id": "open-graph-fetcher",
+   "name": "Open Graph Fetcher",
+   "author": "The Lossless Group",
+   "description": "A plugin that fetches Open Graph data from a URL using OpenGraph.io.",
+   "repo": "lossless-group/open-graph-fetcher"
+ }
 ]


### PR DESCRIPTION
Add Open Graph Fetcher to community-plugins

# I am submitting a new Community Plugin

## Repo URL

Link to my plugin:
https://github.com/lossless-group/open-graph-fetcher

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
