### PR TITLE
Update community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -15201,7 +15201,7 @@
     "name": "Memodack",
     "author": "memodack",
     "description": "Your second language memory tool",
-    "repo": "obsidian-memodack-plugin/obsidian-memodack-plugin"
+    "repo": "memodack/memodack"
   },
   {
     "id": "ai-hub",


### PR DESCRIPTION
The repository has been returned to the original profile.  https://github.com/memodack/memodack

I will delete the current repository (obsidian-memodack-plugin) only after merge this commit.

I apologize for the inconvenience.