### PR TITLE
Remove "Privacy Glasses" plugin - account URL is giving 404

### DIFF
--- a/community-plugins-removed.json
+++ b/community-plugins-removed.json
@@ -659,5 +659,10 @@
     "id": "link-headers-directly",
     "name": "Link Headers Directly",
     "reason": "No longer maintained"
+  },
+  {
+    "id": "privacy-glasses",
+    "name": "Privacy Glasses",
+    "reason": "Account deleted"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -966,13 +966,6 @@
     "repo": "aidenlx/table-extended"
   },
   {
-    "id": "privacy-glasses",
-    "name": "Privacy Glasses",
-    "description": "A ribbon icon and command to blur onscreen text for better privacy.",
-    "author": "Jill Alberts",
-    "repo": "jillalberts/privacy-glasses"
-  },
-  {
     "id": "obsidian-highlightpublicnotes-plugin",
     "name": "Highlight Public Notes",
     "description": "Warn that a note is public (based on a frontmatter attribute) by coloring the note red.",


### PR DESCRIPTION
This removes the "Privacy Glasses" plugin, as the Obsidian Hub GitHub Actions logs have been reporting the repo as missing.

...as mentioned in https://discord.com/channels/686053708261228577/840286264964022302/1394576939230040104

Both of these give "404":

https://github.com/jillalberts/
https://github.com/jillalberts/privacy-glasses

In `community-plugins-removed.json`, I gave `"reason": "Account deleted"` - but in fact it could have just been made private, I have no way of knowing.
