### PR TITLE
Add AutoTitle plugin to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18025,7 +18025,7 @@
     "repo": "Apoo711/obsidian-3d-graph"
   },
   {
-    "id": "autotitle",
+    "id": "obsidian-autotitle",
     "name": "AutoTitle",
     "author": "zaharenok",
     "description": "Automatically generates a note title based on its content.",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18023,5 +18023,12 @@
     "author": "Aryan Gupta",
     "description": "Visualize your Vault in 3D with a powerful, highly customizable, and filterable graph.",
     "repo": "Apoo711/obsidian-3d-graph"
+  },
+  {
+    "id": "autotitle",
+    "name": "AutoTitle",
+    "author": "zaharenok",
+    "description": "Automatically generates a note title based on its content.",
+    "repo": "zaharenok/obsidian-autotitle"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

Link to my plugin:
https://github.com/zaharenok/obsidian-autotitle

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.