### PR TITLE
Add NoteRelay: a plugin for syncing notes to a remote server

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18030,5 +18030,12 @@
     "author": "Blue Heron",
     "description": "Provides methods to retrieve statistics about the vault, such as the number of notes, total word count, recently modified notes, and more.",
     "repo": "blueheron786/obsidian-stats-plugin"
+  },
+  {
+    "id": "obsidian-note-relay-plugin",
+    "name": "NoteRelay",
+    "author": "bak-libra26",
+    "description": "A robust Obsidian plugin for automatically and securely syncing your notes with a remote server, featuring flexible authentication, metadata management, and customizable sync options.",
+    "repo": "bak-libra26/obsidian-note-relay-plugin"
   }
 ]


### PR DESCRIPTION
NoteRelay is an Obsidian plugin that automatically syncs your notes to a specified remote server. It supports both Basic Auth and token-based authentication, allowing you to securely connect to your own custom backend. You can store and manage note data in your database through your server, with flexible options for server settings, sync exclusions, and unique identifier management using frontmatter.