### PR TITLE
add obsidian-todo-plus plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18058,5 +18058,12 @@
     "author": "ste",
     "description": "Uploads, downloads and deletes images on WebDAV server within notes.",
     "repo": "Koishiiko/obsidian-webdav-image-uploader"
+  },
+  {
+    "id": "obsidian-todo-plus",
+    "name": "Todo+",
+    "author": "Tanveer Khan",
+    "description": "Manage todo/task lists with ease. Powerful, easy to use",
+    "repo": "KnTanveer/obsidian-todo-plus"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [ ] `main.js`
  - [ ] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ ] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [ ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
