### PR TITLE
Add block-paste plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18128,5 +18128,12 @@
     "author": "Alec Sibilia",
     "description": "Quick, in-editor, emoji inserting. Type \":\" to start selecting an emoji to insert.",
     "repo": "asibilia/obsidian-quick-emoji"
+  },
+  {
+    "id": "block-paste",
+    "name": "Block Paste",
+    "author": "Zach Meador",
+    "description": "Automatically adds block quote formatting when pasting multi-line text into block quotes",
+    "repo": "zachmeador/obsidian-block-paste"
   }
 ]


### PR DESCRIPTION
Automatically adds block quote formatting when pasting multi-line text into block quotes

Repository: https://github.com/zachmeador/obsidian-block-paste
Release: https://github.com/zachmeador/obsidian-block-paste/releases/tag/v0.5.0