### PR TITLE
Typo in languagetool plugin description

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -12316,7 +12316,7 @@
     "id": "languagetool",
     "name": "LanguageTool",
     "author": "Lars Wrenger, Clemens Ertle",
-    "description": "Inofficial integration of the LanguageTool spell and grammar checker.",
+    "description": "Unofficial integration of the LanguageTool spell and grammar checker.",
     "repo": "wrenger/obsidian-languagetool"
   },
   {


### PR DESCRIPTION
Just fixing a small typo.