### PR TITLE
Add plugin: Toggle Public/Private Attachment

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18205,5 +18205,14 @@
     "author": "ikmolbo",
     "description": "Transform handwritten documents and scanned images into editable text with Handwriting OCR's AI-powered handwriting to text conversion.",
     "repo": "ikmolbo/handwriting-ocr-obsidian-plugin"
-  }
+  },
+  {
+    "id": "quartz-toggle-public-attachments",
+  	"name": "Toggle Public/Private Attachment",
+  	"version": "1.0.0",
+  	"minAppVersion": "0.15.0",
+  	"description": "Toggles file(s) as private or public by adding or removing a prefix, meant to work with a Quartz configuration called Explicit Publish and ignorePatterns https://oliverfalvai.com/evergreen/my-quartz-+-obsidian-note-publishing-setup#mixing-private-and-public-notes",
+  	"author": "Haroombe",
+    "repo": "Haroombe/obsidian-quartz-toggle-public-image-plugin"
+}
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL 
Link to my plugin:
[Repo](https://github.com/Haroombe/obsidian-quartz-toggle-public-image-plugin/tree/1.0.0)


## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
