### PR TITLE
Initial submission of 'DOCX Exporter' plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18205,5 +18205,12 @@
     "author": "ikmolbo",
     "description": "Transform handwritten documents and scanned images into editable text with Handwriting OCR's AI-powered handwriting to text conversion.",
     "repo": "ikmolbo/handwriting-ocr-obsidian-plugin"
+  },
+  {
+  	"id": "obsidian-docx-exporter",
+  	"name": "DOCX Exporter",
+    "author": "Kanshurichard",
+  	"description": "Export notes to Microsoft Word docx files with mobile devices support.",
+    "repo": "kanshurichard/obsidian-docx-exporter"
   }
 ]


### PR DESCRIPTION
Summary:

This pull request adds the 'DOCX Exporter' plugin to the community plugin list. This plugin allows users to export their Obsidian notes to DOCX format.

Features:

Zero External Dependencies: The plugin does not require tools like Pandoc, allowing it to run natively on all platforms including desktop, mobile, and iPad.

Rich Text and Image Support: Exports a variety of Markdown formats including headings, lists, bold/italic text, as well as local and web images.

Cross-Platform Compatibility: The generated DOCX files are highly compatible with Microsoft Word.

Known Issues:

When opened with Apple Pages or the system's native Preview app, the exported DOCX file may have formatting issues.

Workaround: Opening and re-saving the file in Microsoft Word (desktop or mobile) resolves the issue, as Word automatically adds the necessary compatibility metadata.



Thank you for your review.