### PR TITLE
Update task-list-kanban ownership

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -11888,7 +11888,7 @@
   {
     "id": "task-list-kanban",
     "name": "Task List Kanban",
-    "author": "Erika Rice Scherpelz",
+    "author": "Chris Kerr, Erika Rice Scherpelz",
     "description": "Organizes all of the tasks within your files into a kanban view.",
     "repo": "erikars/task-list-kanban"
   },


### PR DESCRIPTION
Transferring ownership of the task-list-kanban plugin from chrskerr to erikars per this conversation: https://github.com/ErikaRS/task-list-kanban/pull/44

Repo ownership has already been transferred.

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
