### PR TITLE
Relist Note Companion

### DIFF
--- a/community-plugins-removed.json
+++ b/community-plugins-removed.json
@@ -664,11 +664,5 @@
     "id": "privacy-glasses",
     "name": "Privacy Glasses",
     "reason": "Account deleted"
-  },
-  {
-    "id": "fileorganizer2000",
-    "name": "Note Companion AI",
-    "reason": "Abandoned, users are not receving answers from plugin support team, refund requests are not being replied to.",
-    "issue": "https://github.com/different-ai/note-companion/issues/411"
   }
 ]


### PR DESCRIPTION
Hi Obsidian team,

We're requesting to relist Note Companion (formerly FileOrganizer2000) in the community plugins directory.

## What we've addressed:

- **Support system restored**: We've responded to all pending support tickets and cleared our entire backlog
- **Email access recovered**: Fixed our support email access issue and updated all contact links
- **Refunds processed**: All disputed charges during the downtime have been refunded
- **Team restructured**: After losing a key team member in May, we've implemented a new support process to prevent future gaps
- **Communication commitment**: We understand the importance of maintaining active communication channels and have systems in place to ensure this won't happen again

We sincerely apologize for the disruption this caused to our users. The plugin was temporarily abandoned due to unforeseen circumstances when we lost our support lead, but we've now fully recovered and implemented measures to prevent this from recurring.

We're committed to providing reliable support moving forward and have already demonstrated this by clearing our entire support backlog.

Thank you for your consideration.

Reference: https://github.com/different-ai/note-companion/issues/411