### PR TITLE
Add plugin: Auto Capitalise File Name

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1759,9 +1759,9 @@
   {
     "id": "obsidian-image-toolkit",
     "name": "Image Toolkit",
-    "description": "When you click an image, it will be displayed in a popup layer and you can view, drag, zoom, rotate the image.",
+    "description": "Click images to preview with zoom, move, rotate, flip, invert, and copy.",
     "author": "sissilab",
-    "repo": "sissilab/obsidian-image-toolkit"
+    "repo": "obsidian-community/obsidian-image-toolkit"
   },
   {
     "id": "obsidian-shellcommands",
@@ -10017,6 +10017,13 @@
     "repo": "Benature/obsidian-metadata-icon"
   },
   {
+    "id": "fileorganizer2000",
+    "name": "Note Companion AI",
+    "author": "Benjamin Ashgan Shafii",
+    "description": "AI-powered note organization and chat. Requires subscription or self-hosting with your own API keys.",
+    "repo": "different-ai/file-organizer-2000"
+  },
+  {
     "id": "spotify-api",
     "name": "Spotify API",
     "author": "Darren-project",
@@ -16912,13 +16919,6 @@
     "repo": "tu2-atmanand/obsidian-notes-explorer"
   },
   {
-    "id": "markdown-flip",
-    "name": "Markdown Flip",
-    "author": "Jinmu Go",
-    "description": "flip markdown line types with smart shortcuts",
-    "repo": "JinmuGo/obsidian-markdown-flip"
-  },
-  {
     "id": "convert-base64-to-png",
     "name": "Convert Base64 to PNG",
     "author": "Nykko Lin",
@@ -18199,18 +18199,53 @@
     "description": "Export note with all its attachments and linked notes.",
     "repo": "the-c0d3r/obsidian-linked-note-exporter"
   },
- {
-  	"id": "auto-capitalise-file-names",
-    "name": "Auto Capitalise File Name",
-    "author": "Kiran",
-    "description": "Automatically capitalises new and modified markdown file names using sentence case or title case. Includes bulk commands and configurable delay.",
-    "repo": "marr00n/Auto-Capitalise-File-Names"
-  },
   {
     "id": "handwriting-ocr",
     "name": "Handwriting OCR",
     "author": "ikmolbo",
     "description": "Transform handwritten documents and scanned images into editable text with Handwriting OCR's AI-powered handwriting to text conversion.",
     "repo": "ikmolbo/handwriting-ocr-obsidian-plugin"
+  },
+  {
+    "id": "packup4ai",
+    "name": "packUp4AI",
+    "author": "Jeffry",
+    "description": "Collect related notes based on links/backlinks to provide focused context for external AI chatbots. Explore note relationships visually and export the bundle.",
+    "repo": "shuxueshuxue/PackUp4AI"
+  },
+  {
+    "id": "linear",
+    "name": "Linear",
+    "author": "Casey Becking",
+    "description": "Integrate Linear issues with advanced filtering, sorting, and visual enhancements. Features include due date indicators, status colors, and comprehensive debug logging.",
+    "repo": "caseybecking/obsidian-linear-plugin"
+  },
+  {
+    "id": "kindle-vocab",
+    "name": "Kindle Vocab",
+    "author": "Truong Gia Bao",
+    "description": "Create the Markdown file from your Kindle Vocab Builder in your vault.",
+    "repo": "bao-tg/kindle-vocab"
+  },
+  {
+    "id": "ai-image-ocr",
+    "name": "AI Image OCR",
+    "author": "Rootiest",
+    "description": "Extracts text from images using AI Vision models.",
+    "repo": "rootiest/obsidian-ai-image-ocr"
+  },
+  {
+    "id": "drag-to-scroll",
+    "name": "Drag To Scroll",
+    "author": "Constantine Sazonov",
+    "description": "Drag to scroll - just like on a touch device!",
+    "repo": "constsz/obsidian-drag-to-scroll"
+  },
+  {
+  	"id": "auto-capitalise-file-names",
+    "name": "Auto Capitalise File Name",
+    "author": "Kiran",
+    "description": "Automatically capitalises new and modified markdown file names using sentence case or title case. Includes bulk commands and configurable delay.",
+    "repo": "marr00n/Auto-Capitalise-File-Names"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/marr00n/Auto-Capitalise-File-Names

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
