### PR TITLE
Add plugin checkboxes-everywhere

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18205,5 +18205,12 @@
     "author": "ikmolbo",
     "description": "Transform handwritten documents and scanned images into editable text with Handwriting OCR's AI-powered handwriting to text conversion.",
     "repo": "ikmolbo/handwriting-ocr-obsidian-plugin"
+  },
+    {
+    "id": "checkboxes-everywhere",
+    "name": "Checkboxes Everywhere",
+    "author": "ItsRhetorical",
+    "description": "Transform markdown checkboxes into interactive elements that persist state when clicked.",
+    "repo": "ItsRhetorical/CheckboxesEverywhere"
   }
 ]


### PR DESCRIPTION
Transform markdown checkboxes into interactive elements that persist state when clicked.
