### PR TITLE
Add plugin: Pandoc Lists

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18212,5 +18212,12 @@
     "author": "Jeffry",
     "description": "Collect related notes based on links/backlinks to provide focused context for external AI chatbots. Explore note relationships visually and export the bundle.",
     "repo": "shuxueshuxue/PackUp4AI"
+  },
+  {
+    "id": "pandoc-lists",
+    "name": "Pandoc Lists",
+    "author": "ErrorTzy",
+    "description": "Render Pandoc extended markdown lists including fancy lists with letters and roman numerals, definition lists with special formatting, and example lists with cross-references.",
+    "repo": "ErrorTzy/obsidian-pandoc-lists"
   }
 ]


### PR DESCRIPTION
## Plugin Description

**Plugin Name:** Pandoc Lists
**Plugin ID:** pandoc-lists
**Author:** ErrorTzy
**Repository:** https://github.com/ErrorTzy/obsidian-pandoc-lists

This plugin enables Obsidian to render Pandoc extended markdown lists, bringing powerful list formatting capabilities including:
- Fancy lists with letters and roman numerals (A., B., i., ii., etc.)
- Definition lists with special formatting
- Example lists with cross-references
- Hash auto-numbering lists (#.)

## Checklist

- [x] The plugin ID in the manifest.json file is the same as the ID in community-plugins.json
- [x] The plugin description in the manifest matches (or is a more elaborate version of) the description in community-plugins.json
- [x] The plugin repo has a LICENSE file
- [x] The plugin repo has a README file with instructions for users
- [x] The plugin releases at least one version containing a main.js, manifest.json and styles.css file
- [x] The plugin does not use any `innerHTML`, `outerHTML` or `insertAdjacentHTML`
- [x] The plugin follows the Obsidian plugin guidelines: https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines

## Additional Information

The plugin has been thoroughly tested and is ready for community use. It includes:
- Full support for all Pandoc extended list types
- Intelligent autocomplete for example references
- Proper handling of source mode, live preview mode, and reading mode
- Clean, maintainable codebase

Latest release: v1.1.0