### PR TITLE
Update community-plugins.json - lawlerhwang/Obsidian-opacityslider

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18212,5 +18212,14 @@
     "author": "Jeffry",
     "description": "Collect related notes based on links/backlinks to provide focused context for external AI chatbots. Explore note relationships visually and export the bundle.",
     "repo": "shuxueshuxue/PackUp4AI"
-  }
+  },
+
+{
+  "id": "opacityslider",
+  "name": "Opacityslider",
+  "author": "ghu4ng",
+  "description": "A plugin to control Obsidian interface opacity with a simple slider.",
+  "repo": "lawlerhwang/Obsidian-opacityslider"
+}
+
 ]


### PR DESCRIPTION
A plugin to control Obsidian interface opacity with a simple slider

# I am submitting a new Community Plugin

- [x] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

<!--- lawlerhwang/Obsidian-opacityslider -->
Link to my plugin:

## Release Checklist
- [ ] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
