### PR TITLE
Add theme: Claude Dark

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2698,5 +2698,12 @@
     "repo": "sspaeti/obsidian_osaka_jade",
     "screenshot": "dark.png",
     "modes": ["dark", "light"]
+  },
+  {
+    "name": "Claude Dark",
+    "author": "Nazzareno Giannelli",
+    "repo": "NazzarenoGiannelli/obsidian-claude-dark-theme",
+    "screenshot": "preview.png",
+    "modes": ["dark"]
   }
 ]

--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2700,7 +2700,7 @@
     "modes": ["dark", "light"]
   },
   {
-    "name": "Claude Dark",
+    "name": "Terracotta Dark",
     "author": "Nazzareno Giannelli",
     "repo": "NazzarenoGiannelli/obsidian-claude-dark-theme",
     "screenshot": "preview.png",


### PR DESCRIPTION
## Theme: Terracotta Dark

Adding a new dark theme inspired by Claude Desktop's warm, earthy design aesthetic.

### Theme Details
- **Name**: Terracotta Dark  
- **Author**: NazzarenoGiannelli
- **Repository**: https://github.com/NazzarenoGiannelli/obsidian-claude-dark-theme
- **Mode**: Dark only
- **Screenshot**: preview.png (included in repo)

### Features
- Clean 1px borders throughout for modern aesthetic
- Comprehensive UI coverage including headers, code blocks, tables, graph view
- Plugin compatibility tested with Calendar, Kanban, and other popular plugins

### Quality Checks
- [x] Theme follows Obsidian's CSS variable conventions
- [x] Comprehensive coverage of UI elements
- [x] Proper manifest.json with required fields
- [x] Screenshot/preview image included
- [x] Tested across different Obsidian features

### Updates Made
- Added MIT license to repository
- Resized preview.png to recommended dimensions (512x288)

The theme is already available on GitHub and has been tested thoroughly. Ready for community use!