### PR TITLE
Add plugin: status-bar-buddy

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18230,7 +18230,7 @@
 	{
     "id": "status-bar-buddy",
 	"name": "Status Bar Buddy",
-	"description": "Started as a way of literally just getting Dizzy in the corner so she can have a sippy. Now you can have any buddy you want right there in the corner!",
+	"description": "started as a way of literally just getting dizzy in the corner so she can have a sippy. now you can have any buddy you want right there in the corner!",
 	"author": "izzy s",
     "repo": "izzymandias1/status_bar_buddy"
   }

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,12 +1,5 @@
 [
   {
-    "id": "status-bar-buddy",
-	  "name": "Status Bar Buddy",
-	  "description": "Started as a way of literally just getting Dizzy in the corner so she can have a sippy. Now you can have any buddy you want right there in the corner!",
-	  "author": "izzy s",
-    "repo": "izzymandias1/status_bar_buddy"
-  },
-  {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",
@@ -18233,5 +18226,12 @@
     "author": "Truong Gia Bao",
     "description": "Create the Markdown file from your Kindle Vocab Builder in your vault.",
     "repo": "bao-tg/kindle-vocab"
+  },
+	{
+    "id": "status-bar-buddy",
+	  "name": "Status Bar Buddy",
+	  "description": "Started as a way of literally just getting Dizzy in the corner so she can have a sippy. Now you can have any buddy you want right there in the corner!",
+	  "author": "izzy s",
+    "repo": "izzymandias1/status_bar_buddy"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -5,7 +5,7 @@
 	  "description": "Started as a way of literally just getting Dizzy in the corner so she can have a sippy. Now you can have any buddy you want right there in the corner!",
 	  "author": "izzy s",
     "repo": "izzymandias1/status_bar_buddy"
-  }
+  },
   {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18229,9 +18229,9 @@
   },
 	{
     "id": "status-bar-buddy",
-	  "name": "Status Bar Buddy",
-	  "description": "Started as a way of literally just getting Dizzy in the corner so she can have a sippy. Now you can have any buddy you want right there in the corner!",
-	  "author": "izzy s",
+	"name": "Status Bar Buddy",
+	"description": "Started as a way of literally just getting Dizzy in the corner so she can have a sippy. Now you can have any buddy you want right there in the corner!",
+	"author": "izzy s",
     "repo": "izzymandias1/status_bar_buddy"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "status-bar-buddy",
+	  "name": "Status Bar Buddy",
+	  "description": "Started as a way of literally just getting Dizzy in the corner so she can have a sippy. Now you can have any buddy you want right there in the corner!",
+	  "author": "izzy s",
+    "repo": "izzymandias1/status_bar_buddy"
+  }
+  {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",


### PR DESCRIPTION
adding "status-bar-buddy" to the community plugins

# I am submitting a new Community Plugin

- [ x ] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/izzymandias1/status_bar_buddy/r

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
