### PR TITLE
Add plugin: Frontmatter Generator

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18228,10 +18228,10 @@
     "repo": "bao-tg/kindle-vocab"
   },
   {
-  "id": "frontmatter-generator",
-  "name": "Frontmatter Generator",
+  "id": "frontmatter-autogen",
+  "name": "Frontmatter Autogen",
   "author": "BurningHoryd",
-  "description": "Automatically generates and updates frontmatter (title, summary, and tags) for notes in Obsidian.",
+  "description": "Automatically generates and updates frontmatter (title, summary, and tags) for notes.",
   "repo": "BurningHoryd/frontmatter-generator"
-}
+  }
 ]


### PR DESCRIPTION
<!-- Please read the contributing guidelines before submitting your plugin. -->

### Checklist
- [x] I have tested this plugin on the latest version of Obsidian.
- [x] My `manifest.json` matches the entry I added in `community-plugins.json`.
- [x] I have created a GitHub release that contains the required files:
  - `main.js`
  - `manifest.json`
  - `styles.css` (if needed)
- [x] I have verified that the plugin ID is unique and not used by any existing plugin.
- [x] My plugin description does not include the word “Obsidian”.

### Repo & Release
- **Repository:** https://github.com/BurningHoryd/frontmatter-generator
- **Latest Release:** https://github.com/BurningHoryd/frontmatter-generator/releases/tag/1.0.1

### Plugin description
Automatically generates and updates frontmatter (title, summary, and tags) for notes.

### Additional notes
Initial submission.
