### PR TITLE
Add 'Editor QoL' plugin to community plugins list

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,12 +1,5 @@
 [
   {
-    "id": "obsidian-editor-qol",
-    "name": "Editor QoL",
-    "author": "Slyverr",
-    "description": "Quality of life improvements to the obsidian's editor.",
-    "repo": "Slyverr/obsidian-editor-qol-plugin"
-  },  
-  {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",
@@ -18233,5 +18226,12 @@
     "author": "Truong Gia Bao",
     "description": "Create the Markdown file from your Kindle Vocab Builder in your vault.",
     "repo": "bao-tg/kindle-vocab"
-  }
+  },
+    {
+    "id": "obsidian-editor-qol",
+    "name": "Editor QoL",
+    "author": "Slyverr",
+    "description": "Quality of life improvements to the obsidian's editor.",
+    "repo": "Slyverr/obsidian-editor-qol-plugin"
+  },  
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "obsidian-editor-qol",
+    "name": "Editor QoL",
+    "author": "Slyverr",
+    "description": "Quality of life improvements to the obsidian's editor.",
+    "repo": "Slyverr/obsidian-editor-qol-plugin"
+  },  
+  {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18227,11 +18227,11 @@
     "description": "Create the Markdown file from your Kindle Vocab Builder in your vault.",
     "repo": "bao-tg/kindle-vocab"
   },
-    {
+  {
     "id": "obsidian-editor-qol",
     "name": "Editor QoL",
     "author": "Slyverr",
     "description": "Quality of life improvements to the obsidian's editor.",
     "repo": "Slyverr/obsidian-editor-qol-plugin"
-  },  
+  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18228,10 +18228,10 @@
     "repo": "bao-tg/kindle-vocab"
   },
   {
-    "id": "obsidian-editor-qol",
+    "id": "editor-qol",
     "name": "Editor QoL",
     "author": "Slyverr",
-    "description": "Quality of life improvements to the obsidian's editor.",
+    "description": "Quality of life improvements/features to the editor.",
     "repo": "Slyverr/obsidian-editor-qol-plugin"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

- [x] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: <https://github.com/Slyverr/obsidian-editor-qol-plugin>

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
