### PR TITLE
Add Default Template plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18226,5 +18226,12 @@
     "author": "Truong Gia Bao",
     "description": "Create the Markdown file from your Kindle Vocab Builder in your vault.",
     "repo": "bao-tg/kindle-vocab"
+  },
+  {
+    "id": "obsidian-default-template",
+    "name": "Default Template",
+    "author": "raeperd",
+    "description": "Automatically apply templates to new notes with user-configurable template selection.",
+    "repo": "raeperd/obsidian-default-template"
   }
 ]


### PR DESCRIPTION
## Plugin Submission

**Plugin Name:** Default Template  
**Plugin ID:** obsidian-default-template  
**Author:** raeperd  
**Repository:** https://github.com/raeperd/obsidian-default-template

## Description

This plugin automatically applies user-selected templates to new empty notes, addressing a 3+ year old community feature request. It provides a minimal, focused solution that integrates seamlessly with Obsidian's existing template system.

## Key Features

- **Automatic template application** to new empty markdown files
- **User-configurable template selection** via fuzzy search modal
- **Template variable support** for {{date}}, {{time}}, and {{title}}
- **Format string compatibility** with moment.js ({{date:YYYY-MM-DD}}, etc.)
- **Mobile-friendly** implementation using Obsidian's built-in APIs
- **Minimal footprint** with single-purpose design philosophy

## Community Need

This plugin directly addresses multiple forum requests spanning 3+ years where users have consistently requested default template functionality that core Obsidian doesn't provide. The official Templates plugin requires manual template insertion, while this plugin automates the process for new notes.

## Technical Implementation

- Uses Obsidian's vault.on('create') event system
- Leverages built-in moment.js for template variables (zero bundle overhead)
- Implements FuzzySuggestModal for intuitive template selection
- Includes comprehensive error handling for missing/deleted templates
- Maintains compatibility with existing template workflows

## Repository Status

- ✅ Released version 1.0.1 with full functionality
- ✅ Comprehensive README with installation instructions
- ✅ MIT license with proper attribution
- ✅ GitHub Actions for automated releases
- ✅ CI workflow for pull request validation
- ✅ Mobile compatibility verified

The plugin is production-ready and actively addresses a long-standing community need.