### PR TITLE
Add Context Toolkit plugin to community plugins list

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -168,11 +168,11 @@
     "repo": "SilentVoid13/Templater"
   },
   {
-    "id": "context-toolkit",
-    "name": "Context Toolkit",
-    "author": "ingap.dev",
-    "description": "Copy your notes with all linked context.",
-    "repo": "twrblog/obsidian-context-toolkit"
+    "id": "context-toolkit",
+    "name": "Context Toolkit",
+    "author": "ingap.dev",
+    "description": "Copy your notes with all linked context.",
+    "repo": "twrblog/obsidian-context-toolkit"
   },
   {
     "id": "convert-url-to-iframe",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18228,7 +18228,7 @@
     "repo": "bao-tg/kindle-vocab"
   },
   {
-    "id": "obsidian-context-toolkit",
+    "id": "context-toolkit",
     "name": "Context Toolkit",
     "author": "ingap.dev",
     "description": "Copy your notes with all linked context.",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -168,6 +168,13 @@
     "repo": "SilentVoid13/Templater"
   },
   {
+    "id": "context-toolkit",
+    "name": "Context Toolkit",
+    "author": "ingap.dev",
+    "description": "Copy your notes with all linked context.",
+    "repo": "twrblog/obsidian-context-toolkit"
+  },
+  {
     "id": "convert-url-to-iframe",
     "name": "Convert url to preview (iframe)",
     "author": "FHachez",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18228,7 +18228,7 @@
     "repo": "bao-tg/kindle-vocab"
   },
   {
-    "id": "context-toolkit",
+    "id": "obsidian-context-toolkit",
     "name": "Context Toolkit",
     "author": "ingap.dev",
     "description": "Copy your notes with all linked context.",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -168,13 +168,6 @@
     "repo": "SilentVoid13/Templater"
   },
   {
-    "id": "context-toolkit",
-    "name": "Context Toolkit",
-    "author": "ingap.dev",
-    "description": "Copy your notes with all linked context.",
-    "repo": "twrblog/obsidian-context-toolkit"
-  },
-  {
     "id": "convert-url-to-iframe",
     "name": "Convert url to preview (iframe)",
     "author": "FHachez",
@@ -18233,5 +18226,12 @@
     "author": "Truong Gia Bao",
     "description": "Create the Markdown file from your Kindle Vocab Builder in your vault.",
     "repo": "bao-tg/kindle-vocab"
+  },
+  {
+    "id": "context-toolkit",
+    "name": "Context Toolkit",
+    "author": "ingap.dev",
+    "description": "Copy your notes with all linked context.",
+    "repo": "twrblog/obsidian-context-toolkit"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

- [X] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

Link to my plugin: https://github.com/twrblog/obsidian-context-toolkit

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.