### PR TITLE
Add video-size plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18231,7 +18231,7 @@
     "id": "video-size",
     "name": "Video Size",
     "author": "Hanblade",
-    "description": "Resize videos in Obsidian preview: corner handles, presets (144–1920 + custom), 16:9 container for vertical clips, per-note sizes, and “Reveal in file explorer”."
+    "description": "Resize videos in Obsidian preview: corner handles, presets (144–1920 + custom), 16:9 container for vertical clips, per-note sizes, and “Reveal in file explorer”.",
     "repo": "hanblade67-cloud/video-size"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18231,7 +18231,8 @@
     "id": "video-size",
     "name": "Video Size",
     "author": "Hanblade",
-    "description": "Resize videos in Obsidian preview: corner handles, presets (144–1920 + custom), 16:9 container for vertical clips, per-note sizes, and “Reveal in file explorer”.",
-    "repo": "hanblade67-cloud/video-size"
-}
+    "repo": "hanblade67-cloud/video-size",
+    "isDesktopOnly": true,
+    "description": "Resize embedded videos in preview: corner handles, size presets (144–1920 + custom), 16:9 container for vertical clips, per-note sizes, and “Reveal in file explorer”."
+   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18232,7 +18232,6 @@
     "name": "Video Size",
     "author": "Hanblade",
     "repo": "hanblade67-cloud/video-size",
-    "isDesktopOnly": true,
     "description": "Resize embedded videos in preview: corner handles, size presets (144–1920 + custom), 16:9 container for vertical clips, per-note sizes, and “Reveal in file explorer”."
-   }
+ }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18226,5 +18226,12 @@
     "author": "Truong Gia Bao",
     "description": "Create the Markdown file from your Kindle Vocab Builder in your vault.",
     "repo": "bao-tg/kindle-vocab"
-  }
+  },
+  {
+    "id": "video-size",
+    "name": "Video Size",
+    "author": "Hanblade",
+    "description": "Resize videos in Obsidian preview: corner handles, presets (144–1920 + custom), 16:9 container for vertical clips, per-note sizes, and “Reveal in file explorer”."
+    "repo": "hanblade67-cloud/video-size"
+}
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

- [ ] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [ ] `main.js`
  - [ ] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ ] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [ ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.