### PR TITLE
Add plugin: Periodic notes calendar

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18226,5 +18226,12 @@
     "author": "Truong Gia Bao",
     "description": "Create the Markdown file from your Kindle Vocab Builder in your vault.",
     "repo": "bao-tg/kindle-vocab"
+  },
+  {
+    "id": "periodic-notes-calendar",
+    "name": "Periodic notes calendar",
+    "author": "Luis Cadillo",
+    "description": "Organize periodic notes from daily to yearly with a calendar interface. Navigate and summarize entries using stickers in the calendar view.",
+    "repo": "luiisca/obsidian-periodic-notes-calendar"
   }
 ]


### PR DESCRIPTION
This PR reopens the submission of my plugin Periodic Notes Calendar to the community plugin list.

My previous PR (#5063) was closed after I left it unattended. Apologies for letting that happen. I’d still like to have this plugin included.

# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/luiisca/obsidian-periodic-notes-calendar

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.

