### PR TITLE
Add Font Size Slider plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18226,5 +18226,12 @@
     "author": "Truong Gia Bao",
     "description": "Create the Markdown file from your Kindle Vocab Builder in your vault.",
     "repo": "bao-tg/kindle-vocab"
+  },
+  {
+    "id": "font-size-slider",
+    "name": "Font Size Slider",
+    "author": "Stephen McKay",
+    "description": "A simple Obsidian plugin that adds a font size slider to the status bar.",
+    "repo": "ac3-stephenm/obsidian-font-size-slider"
   }
 ]


### PR DESCRIPTION
## Plugin Submission

**Plugin ID**: font-size-slider  
**Plugin Name**: Font Size Slider  
**Author**: Stephen McKay  
**Repository**: ac3-stephenm/obsidian-font-size-slider  

**Description**: A simple Obsidian plugin that adds a font size slider to the status bar.

## Features
- Adds a slider control to the status bar (🔤 16px)
- Drag to adjust font size in real-time (8-32px) 
- Settings to customize min/max sizes and slider width

## Submission Checklist
- [x] Plugin has unique ID: `font-size-slider`
- [x] Repository is public on GitHub
- [x] Contains manifest.json with proper metadata
- [x] Contains README.md with plugin description
- [x] Contains LICENSE file (MIT)
- [x] Has GitHub release v1.0.0 with main.js and manifest.json
- [x] Added to end of community-plugins.json
- [x] Follows plugin naming conventions

🤖 Generated with [Claude Code](https://claude.ai/code)