### PR TITLE
Add plugin: ObsiRandom

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18240,5 +18240,12 @@
     "author": "Rootiest",
     "description": "Extracts text from images using AI Vision models.",
     "repo": "rootiest/obsidian-ai-image-ocr"
+  },
+  {
+    "id": "obsirandom",
+    "name": "ObsiRandom",
+    "author": "Tai",
+    "description": "Open random notes from your vault, specific time periods, or custom directories",
+    "repo": "taisukemino/ObsiRandom"
   }
 ]


### PR DESCRIPTION
## Plugin information

**Plugin ID:** obsirandom
**Plugin name:** ObsiRandom
**Repository URL:** https://github.com/taisukemino/ObsiRandom
**Release tag:** 1.0.0
**Minimum Obsidian version:** 0.15.0

## Submission checklist

- [x] I have read the plugin guidelines: https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines
- [x] I have read the submission requirements: https://docs.obsidian.md/Plugins/Releasing/Submission+requirements+for+plugins
- [x] The plugin meets all the submission requirements.
- [x] I have tested the plugin on the latest version of Obsidian.
- [x] The plugin doesn't violate the developer policies: https://docs.obsidian.md/Developer+policies
- [x] I have read Obsidian's privacy policy and the plugin respects user privacy: https://obsidian.md/privacy
- [x] The plugin is original work or I have permission to publish it.
- [x] The plugin doesn't already exist in the directory.

## Plugin description

ObsiRandom is a plugin that opens random notes from your vault. It supports:

- Random note from entire vault
- Random note from past 7 days, month, or year  
- Up to 3 custom directory configurations

The plugin provides simple commands accessible via the Command Palette to help users discover and revisit notes in their vault.