### PR TITLE
Fix typo in deprecated plugins: Makrdown -> Markdown

### DIFF
--- a/community-plugins-removed.json
+++ b/community-plugins-removed.json
@@ -667,7 +667,7 @@
   },
   {
     "id": "markdown-flip",
-    "name": "Makrdown Flip",
+    "name": "Markdown Flip",
     "reason": "No longer maintained"
   }
 ]


### PR DESCRIPTION
I only noticed this after it was merged.
