### PR TITLE
Add plugin: Auto Capitalise File Name

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18240,5 +18240,12 @@
     "author": "Constantine Sazonov",
     "description": "Drag to scroll - just like on a touch device!",
     "repo": "constsz/obsidian-drag-to-scroll"
+  },
+  {
+  	"id": "auto-capitalise-file-names",
+    "name": "Auto Capitalise File Name",
+    "author": "Kiran",
+    "description": "Automatically capitalises new and modified markdown file names using sentence case or title case. Includes bulk commands and configurable delay.",
+    "repo": "marr00n/Auto-Capitalise-File-Names"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/marr00n/Auto-Capitalise-File-Names

## Release Checklist
- [x] I have tested the plugin on
  - [ ]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [x]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.