### PR TITLE
Add local-image-compress

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18422,5 +18422,12 @@
     "author": "Pavel Sokolov",
     "description": "Display Yandex Tracker issues in your notes",
     "repo": "CubieProg/Obsidian-Yandex-Tracker-Issue"
+  },
+  {
+    "id":"local-image-compress",
+    "name":"Local Image Compress",
+    "author": "Haperone",
+    "description": "Local PNG/JPEG compression for Obsidian using system pngquant/mozjpeg. Works offline, supports batch/background compression, cache with backups, and safe move of compressed files.",
+    "repo":"Haperone/local-image-compress"
   }
 ]


### PR DESCRIPTION
Name: Local Image Compress
ID: local-image-compress
Author: Haperone (https://github.com/Haperone)
Repository: https://github.com/Haperone/local-image-compress
Description: Local PNG/JPEG compression using system pngquant/mozjpeg. Works offline, supports batch/background compression, cache with backups, and safe move of compressed files.

MinAppVersion: 1.0.0
Platforms: Desktop only
Release tag: 1.0.0

Checklist:
- [x] manifest.json version = 1.0.0
- [x] Release 1.0.0 exists with assets: manifest.json, main.js, styles.css, versions.json
- [x] Description does not include the word “Obsidian” 
