### PR TITLE
Add Plugin: Open in new tab

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18429,5 +18429,5 @@
     "author": "prastavna",
     "description": "Open files in new tab",
     "repo": "Prastavna/obsidian-open-new-tab"
-  },
+  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18422,5 +18422,12 @@
     "author": "Pavel Sokolov",
     "description": "Display Yandex Tracker issues in your notes",
     "repo": "CubieProg/Obsidian-Yandex-Tracker-Issue"
+  },
+  {
+    "id": "obsidian-open-new-tab",
+    "name": "Open in New Tab",
+    "author": "prastavna",
+    "description": "Open files in new tab",
+    "repo": "Prastavna/obsidian-open-new-tab"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18429,5 +18429,5 @@
     "author": "prastavna",
     "description": "Open files in new tab",
     "repo": "Prastavna/obsidian-open-new-tab"
-  }
+  },
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

- [X] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/Prastavna/obsidian-open-new-tab

## More Info
This is a direct replacement of this plugin, which was unmaintained for over 2 years:
```json
  {
    "id": "open-in-new-tab",
    "name": "Open In New Tab",
    "author": "patleeman",
    "description": "Open files in new tabs.",
    "repo": "patleeman/obsidian-open-in-new-tab"
  },
```
This plugin add multiple features on top of the existing plugin.

## Release Checklist
- [X] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [X]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
