### PR TITLE
Add plugin: Merge References Markdown Wiki Link 

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18422,5 +18422,12 @@
     "author": "Pavel Sokolov",
     "description": "Display Yandex Tracker issues in your notes",
     "repo": "CubieProg/Obsidian-Yandex-Tracker-Issue"
+  },
+  {
+    "id": "merge-references-markdown-wiki-link",
+    "name": "Merge References Markdown Wiki Link",
+    "author": "xuetengfei",
+    "description": "Merge Markdown links and Wiki links in Obsidian notes, allowing you to consolidate references and simplify note management.",
+    "repo": "xuetengfei/Obsidian-Plugin-Merge-References-Markdown-Wiki-Link"
   }
 ]


### PR DESCRIPTION
An Obsidian plugin to recursively merge the content of Wiki links in Markdown files into the current file.

