### PR TITLE
Add plugin: RMD as Markdown

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -68,588 +68,588 @@
     "author": "Liam Cain",
     "description": "Simple calendar widget.",
     "repo": "liamcain/obsidian-calendar-plugin"
-  },
+  }，
   {
     "id": "mrj-text-expand",
     "name": "Text expand",
     "author": "MrJackphil",
     "description": "Search and paste/transclude links to found files.",
     "repo": "mrjackphil/obsidian-text-expand"
-  },
+  }，
   {
     "id": "mrj-jump-to-link",
     "name": "Jump to link",
     "author": "MrJackphil",
     "description": "Quickly navigate between links, or jump to any word on the page using hotkeys.",
     "repo": "mrjackphil/obsidian-jump-to-link"
-  },
+  }，
   {
     "id": "obsidian-reading-time",
     "name": "Reading Time",
     "author": "avr",
     "description": "Add the current note's reading time to the status bar.",
     "repo": "avr/obsidian-reading-time"
-  },
+  }，
   {
     "id": "todoist-sync-plugin",
     "name": "Todoist Sync",
     "author": "jamiebrynes7",
     "description": "Materialize Todoist tasks within your notes.",
     "repo": "jamiebrynes7/obsidian-todoist-plugin"
-  },
+  }，
   {
     "id": "obsidian-vimrc-support",
     "name": "Vimrc Support",
     "author": "esm",
     "description": "Auto-load a startup file with Vim commands.",
     "repo": "esm7/obsidian-vimrc-support"
-  },
+  }，
   {
     "id": "shortcuts-extender",
     "name": "Shortcuts extender",
     "author": "kitchenrunner",
     "description": "Use shortcuts for input special symbols without language switching.",
     "repo": "ryjjin/Obsidian-shortcuts-extender"
-  },
+  }，
   {
     "id": "mrj-crosslink-between-notes",
     "name": "Add links to current note",
     "author": "MrJackphil",
     "description": "A command to add a link to the current note at the bottom of selected notes.",
     "repo": "mrjackphil/obsidian-crosslink-between-notes"
-  },
+  }，
   {
     "id": "darlal-switcher-plus",
     "name": "Quick Switcher++",
     "author": "darlal",
-    "description": "Enhanced Quick Switcher, search open panels, and symbols.",
+    "description": "Enhanced Quick Switcher, search open panels, 和 symbols.",
     "repo": "darlal/obsidian-switcher-plus"
-  },
+  }，
   {
     "id": "obsidian-day-planner",
     "name": "Day Planner",
     "author": "James Lynch (continued by Ivan Lednev)",
     "description": "Day planning from a task list in a Markdown note with enhanced time block functionality.",
     "repo": "ivan-lednev/obsidian-day-planner"
-  },
+  }，
   {
     "id": "review-obsidian",
     "name": "Review",
     "author": "ryanjamurphy",
     "description": "Add a link to the current note to a daily note on a future date (or a past date, you time traveller).",
     "repo": "ryanjamurphy/review-obsidian"
-  },
+  }，
   {
     "id": "obsidian-hider",
     "name": "Hider",
     "author": "@kepano",
     "description": "Hide UI elements such as tooltips, status, titlebar and more.",
     "repo": "kepano/obsidian-hider"
-  },
+  }，
   {
     "id": "obsidian-minimal-settings",
     "name": "Minimal Theme Settings",
     "author": "@kepano",
     "description": "Control the colors and fonts in Minimal Theme.",
     "repo": "kepano/obsidian-minimal-settings"
-  },
+  }，
   {
     "id": "obsidian-discordrpc",
     "name": "Discord Rich Presence",
     "author": "Luke Leppan",
     "description": "Update your Discord Status to show your friends what you are working on.",
     "repo": "lukeleppan/obsidian-discordrpc"
-  },
+  }，
   {
     "id": "templater-obsidian",
     "name": "Templater",
     "author": "SilentVoid",
     "description": "Create and use templates.",
     "repo": "SilentVoid13/Templater"
-  },
+  }，
   {
     "id": "convert-url-to-iframe",
     "name": "Convert url to preview (iframe)",
     "author": "FHachez",
     "description": "Convert a URL (e.g. YouTube) into an iframe (preview).",
     "repo": "FHachez/obsidian-convert-url-to-iframe"
-  },
+  }，
   {
     "id": "searchpp",
     "name": "Search++",
     "author": "Noureddine Haouari",
     "description": "Insert text context search results in the active note.",
     "repo": "nhaouari/searchpp"
-  },
+  }，
   {
     "id": "better-word-count",
     "name": "Better Word Count",
     "author": "Luke Leppan",
     "description": "Count the words of selected text in the editor.",
     "repo": "lukeleppan/better-word-count"
-  },
+  }，
   {
     "id": "workbench-obsidian",
     "name": "Workbench",
     "author": "ryanjamurphy",
     "description": "Keep a workbench of knowledge materials.",
     "repo": "ryanjamurphy/workbench-obsidian"
-  },
+  }，
   {
     "id": "obsidian-latex-environments",
     "name": "Latex Environments",
     "author": "Zach Raines",
     "description": "Quickly insert and change LaTeX environments within math environments.",
     "repo": "raineszm/obsidian-latex-environments"
-  },
+  }，
   {
     "id": "obsidian-rtl",
     "name": "RTL Support",
     "author": "esm",
-    "description": "Right-to-left (RTL) text direction support for languages like Arabic, Hebrew, and Farsi.",
+    "description": "Right-to-left (RTL) text direction support for languages like Arabic, Hebrew, 和 Farsi.",
     "repo": "esm7/obsidian-rtl"
-  },
+  }，
   {
     "id": "markdown-prettifier",
     "name": "Markdown prettifier",
     "description": "Fix and reformats ugly Markdown.",
     "author": "pelao",
     "repo": "cristianvasquez/obsidian-prettify"
-  },
+  }，
   {
     "id": "css-snippets",
     "name": "css snippets",
     "description": "Load and manage CSS snippets.",
     "author": "Daniel Brandenburg",
     "repo": "jdbrice/obsidian-css-snippets"
-  },
+  }，
   {
     "id": "obsidian-link-indexer",
     "name": "Link indexer",
     "description": "Generate index notes with links based on various conditions.",
     "author": "Yuliya Bagriy",
     "repo": "aviskase/obsidian-link-indexer"
-  },
+  }，
   {
     "id": "macOS-keyboard-nav-obsidian",
     "name": "macOS Keyboard Navigation",
     "description": "Enable alt+\u2191 and alt+\u2193 keyboard navigation.",
     "author": "ryanjamurphy",
     "repo": "ryanjamurphy/macOS-keyboard-nav-obsidian"
-  },
+  }，
   {
     "id": "extract-highlights-plugin",
     "name": "Extract Highlights",
     "description": "Extract all ==highlights== in a note into your clipboard.",
     "author": "Alexis Rondeau",
     "repo": "akaalias/extract-highlights-plugin"
-  },
+  }，
   {
     "id": "find-unlinked-files",
     "name": "Find orphaned files and broken links",
     "description": "Find files that are not linked anywhere and would otherwise be lost in your vault. In other words: files with no backlinks.",
     "author": "Vinzent",
     "repo": "Vinzent03/find-unlinked-files"
-  },
+  }，
   {
     "id": "wikilinks-to-mdlinks-obsidian",
     "name": "Wikilinks to MDLinks",
     "author": "Agatha Uy",
     "description": "Convert wikilinks to Markdown links and vice versa.",
     "repo": "agathauy/wikilinks-to-mdlinks-obsidian"
-  },
+  }，
   {
     "id": "smart-random-note",
     "name": "Smart Random Note",
     "author": "Eric Hall",
     "description": "Open random notes with greater control.",
     "repo": "erichalldev/obsidian-smart-random-note"
-  },
+  }，
   {
     "id": "cycle-through-panes",
     "name": "Tab Switcher",
     "author": "Vinzent & phibr0",
     "description": "Switch your tabs with Ctrl + Tab in recently used order like in a browser.",
     "repo": "Vinzent03/tab-switcher"
-  },
+  }，
   {
     "id": "music-code-blocks",
     "name": "ABC Music Notation",
     "author": "Til Blechschmidt",
     "description": "Render music sheets directly from code blocks using ABC music notation via abcjs.",
     "repo": "abcjs-music/obsidian-plugin-abcjs"
-  },
+  }，
   {
     "id": "cm-typewriter-scroll-obsidian",
     "name": "Typewriter Scroll",
     "author": "death_au",
     "description": "Typewriter-style scrolling which keeps the view centered in the editor.",
     "repo": "deathau/cm-typewriter-scroll-obsidian"
-  },
+  }，
   {
     "id": "obsidian-youglish-plugin",
     "name": "Youglish",
     "description": "Use YouTube to improve your pronunciation. YouGlish gives you fast, unbiased answers about how words is spoken by real people and in context.",
     "author": "Noureddine Haouari",
     "repo": "nhaouari/obsidian-youglish-plugin"
-  },
+  }，
   {
     "id": "obsidian-dangling-links",
     "name": "Dangling links",
     "author": "Graydon Hoare",
     "description": "Add a sidebar showing any dangling links in a vault. Dangling links are orphaned links that don't point to anything in the vault.",
     "repo": "graydon/obsidian-dangling-links"
-  },
+  }，
   {
     "id": "dangerzone-writing-plugin",
     "name": "Dangerzone Writing",
     "author": "Alexis Rondeau",
-    "description": "This plugin is dangerous! When you start it, you have to write without stopping for 100 seconds. If you stop, think and look around, after 3 seconds the plugin will DELETE what you've written in this note.",
+    "description": "This plugin is dangerous! When you start it, you have to write without stopping for 100 秒之前. If you stop, think and look around, after 3 秒之前 the plugin will DELETE what you've written in this note.",
     "repo": "akaalias/dangerzone-writing-plugin"
-  },
+  }，
   {
     "id": "maximise-active-pane-obsidian",
     "name": "Maximise Active Pane",
     "author": "death_au",
     "description": "Fill the workspace with the active pane.",
     "repo": "deathau/maximise-active-pane-obsidian"
-  },
+  }，
   {
     "id": "obsidian-juliandate",
     "name": "Julian Date",
     "author": "thek3nger",
     "description": "Add a shortcut to insert the current Julian date for astronomical observations.",
     "repo": "THeK3nger/obsidian-juliandate"
-  },
+  }，
   {
     "id": "obsidian-emoji-toolbar",
     "name": "Emoji Toolbar",
     "author": "oliveryh",
     "description": "Quickly search for and insert emojis into your editor.",
     "repo": "oliveryh/obsidian-emoji-toolbar"
-  },
+  }，
   {
     "id": "obsidian-fullscreen-plugin",
     "name": "Fullscreen Focus Mode",
     "author": "Razum",
     "description": "Add a command to view a single document leaf in a fullscreen focus mode.",
     "repo": "Razumihin/obsidian-fullscreen-plugin"
-  },
+  }，
   {
     "id": "footlinks",
     "name": "Footlinks",
     "author": "Daha",
     "description": "Extract URLs from main text to footer.",
     "repo": "DahaWong/obsidian-footlinks"
-  },
+  }，
   {
     "id": "obsidian-mind-map",
     "name": "Mind Map",
     "author": "James Lynch",
     "description": "Display Markdown notes as mind maps using Markmap.",
     "repo": "lynchjames/obsidian-mind-map"
-  },
+  }，
   {
     "id": "flashcards-obsidian",
     "name": "Flashcards",
     "author": "Alex Colucci",
     "description": "Anki integration.",
     "repo": "reuseman/flashcards-obsidian"
-  },
+  }，
   {
     "id": "completed-area",
     "name": "Completed Area",
     "author": "Daha",
     "description": "Move completed to-do items to a separate completed area.",
     "repo": "DahaWong/obsidian-completed-area"
-  },
+  }，
   {
     "id": "obsidian-citation-plugin",
     "name": "Citations",
     "author": "Jon Gauthier",
     "description": "Automatically search and insert citations from a Zotero library.",
     "repo": "hans/obsidian-citation-plugin"
-  },
+  }，
   {
     "id": "obsidian-to-anki-plugin",
     "name": "Export to Anki",
     "author": "Pseudonium",
     "description": "Anki integration designed for efficient bulk exporting. Previously known as Obsidian_to_Anki.",
     "repo": "Pseudonium/Obsidian_to_Anki"
-  },
+  }，
   {
     "id": "obsidian-rollover-daily-todos",
     "name": "Rollover Daily Todos",
     "author": "Matt Sessions",
     "description": "Rollover any unchecked checkboxes from your last daily note into today's note.",
     "repo": "lumoe/obsidian-rollover-daily-todos"
-  },
+  }，
   {
     "id": "obsidian-reveal-active-file",
     "name": "Automatically reveal active file",
     "author": "Matt Sessions",
     "description": "Automatically reveal the currently active file in the side navigation.",
     "repo": "shichongrui/obsidian-reveal-active-file"
-  },
+  }，
   {
     "id": "obsidian-export-to-tex",
     "name": "Export To TeX",
     "author": "Zach Raines",
     "description": "Export vault files in a format amenable to pasting into a TeX document.",
     "repo": "raineszm/obsidian-export-to-tex"
-  },
+  }，
   {
     "id": "obsidian-latex",
     "name": "Extended MathJax",
     "author": "Xavier Denis & Ng Wei En",
     "description": "Enable additional MathJax packages and adds a global preamble for MathJax.",
     "repo": "wei2912/obsidian-latex"
-  },
+  }，
   {
     "id": "obsidian-apple-reminders-plugin",
     "name": "Apple Reminders",
     "author": "Rishi Raval",
     "description": "Import Apple Reminders.",
     "repo": "urishiraval/obsidian-apple-reminders-plugin"
-  },
+  }，
   {
     "id": "obsidian-contextual-typography",
     "name": "Contextual Typography",
     "author": "mgmeyers",
     "description": "Add a data-tag-name attribute to all top-level divs in preview mode containing the child's tag name, allowing contextual typography styling.",
     "repo": "mgmeyers/obsidian-contextual-typography"
-  },
+  }，
   {
     "id": "neo4j-graph-view",
     "name": "Neo4j Graph View",
     "author": "Emile van Krieken",
     "description": "Advanced graph visualization and querying using Neo4j.",
     "repo": "HEmile/obsidian-neo4j-graph-view"
-  },
+  }，
   {
     "id": "snippets",
     "name": "Snippets",
     "author": "Pelao",
     "description": "Execute simple scripts/snippets. This plugin is experimental.",
     "repo": "cristianvasquez/obsidian-snippets-plugin"
-  },
+  }，
   {
     "id": "obsidian-temple",
     "name": "Temple",
     "author": "garyng",
     "description": "Templating powered by Nunjucks.",
     "repo": "garyng/obsidian-temple"
-  },
+  }，
   {
     "id": "obsidian-relative-line-numbers",
     "name": "Relative Line Numbers",
     "author": "Nadav Spiegelman",
     "description": "Enable relative line numbers in editor mode.",
     "repo": "nadavspi/obsidian-relative-line-numbers"
-  },
+  }，
   {
     "id": "obsidian-charts",
     "name": "Charts",
     "author": "phibr0",
     "description": "Easily create interactive charts in your notes.",
     "repo": "phibr0/obsidian-charts"
-  },
+  }，
   {
     "id": "discordian-plugin",
     "name": "Discordian Theme",
     "author": "@radekkozak",
     "description": "Fine-grained control of Discordian Theme.",
     "repo": "radekkozak/discordian-plugin"
-  },
+  }，
   {
     "id": "obsidian-autocomplete-plugin",
     "name": "Autocomplete",
     "author": "Yeboster",
     "description": "Autocomplete text to increase your typing speed.",
     "repo": "Yeboster/autocomplete-obsidian"
-  },
+  }，
   {
     "id": "completed-task-display",
     "name": "Completed Task Display",
     "author": "Ben Lee-Cohen",
     "description": "Controls for displaying or hiding completed tasks.",
     "repo": "heliostatic/completed-task-display"
-  },
+  }，
   {
     "id": "obsidian-extract-pdf-highlights",
     "name": "PDF Highlights",
     "author": "Alexis Rondeau",
     "description": "Extract highlights, underlines and annotations from your PDFs.",
     "repo": "akaalias/obsidian-extract-pdf-highlights"
-  },
+  }，
   {
     "id": "youhavebeenstaring-plugin",
     "name": "YouHaveBeenStaring",
     "author": "Felix Almer",
     "description": "Add a status bar indicator showing how long your vault has been open.",
     "repo": "fxal/obsidian-youhavebeenstaring-plugin"
-  },
+  }，
   {
     "id": "obsidian-metatemplates",
     "name": "metatemplates",
     "author": "avirut",
     "description": "Generate notes from templates using YAML frontmatter.",
     "repo": "avirut/obsidian-metatemplates"
-  },
+  }，
   {
     "id": "obsidian-imgur-plugin",
     "name": "Imgur",
     "author": "Kirill Gavrilov",
     "description": "Upload images from your clipboard to imgur.com and embeds uploaded image to your note.",
     "repo": "gavvvr/obsidian-imgur-plugin"
-  },
+  }，
   {
     "id": "obsidian-checklist-plugin",
     "name": "Checklist",
     "author": "delashum",
     "description": "Consolidate checklists across all files into a single view.",
     "repo": "delashum/obsidian-checklist-plugin"
-  },
+  }，
   {
     "id": "search-on-internet",
     "name": "Search on Internet",
     "author": "Emile",
     "description": "Add context menu items to search the internet based on the title of your note.",
     "repo": "HEmile/obsidian-search-on-internet"
-  },
+  }，
   {
     "id": "obsidian-file-path-to-uri",
     "name": "File path to URI",
     "author": "Michal Bure\u0161",
     "description": "Convert file path to URI for easier use of links to local files outside of Obsidian.",
     "repo": "MichalBures/obsidian-file-path-to-uri"
-  },
+  }，
   {
     "id": "page-heading-from-links",
     "name": "Page Heading From Links",
     "author": "Mark Beattie",
     "description": "Populate page headings from the file name.",
     "repo": "beet/page-headings-obsidian-plugin"
-  },
+  }，
   {
     "id": "obsidian-icons-plugin",
     "name": "Icons",
     "author": "Camillo Visini",
     "description": "Add icons to your notes.",
     "repo": "visini/obsidian-icons-plugin"
-  },
+  }，
   {
     "id": "folder-note-plugin",
     "name": "Folder Note",
     "author": "xpgo",
     "description": "Add description note to a folder.",
     "repo": "xpgo/obsidian-folder-note-plugin"
-  },
+  }，
   {
     "id": "vantage-obsidian",
     "name": "Vantage - Advanced search builder",
     "author": "ryanjamurphy",
     "description": "Build advanced search queries.",
     "repo": "ryanjamurphy/vantage-obsidian"
-  },
+  }，
   {
     "id": "obsidian-sort-and-permute-lines",
     "name": "Sort & Permute lines",
     "description": "Sort and Permute lines in whole file or selection.",
     "author": "Vinzent",
     "repo": "Vinzent03/obsidian-sort-and-permute-lines"
-  },
+  }，
   {
     "id": "obsidian-min3ditorhotkeys-plugin",
     "name": "Min3ditorHotkeys",
     "author": "Davor Sauer",
     "description": "Additional editor hotkeys inspired by coding editors.",
     "repo": "d-sauer/Obsidian-Min3ditorHotkeys-plugin"
-  },
+  }，
   {
     "id": "obsidian-jsonifier",
     "name": "JSONifier",
     "author": "Kjell Connelly",
     "description": "JSON.stringify() or JSON.parse() highlighted text and copy to clipboard.",
     "repo": "KjellConnelly/obsidian-jsonifier"
-  },
+  }，
   {
     "id": "things-logbook",
     "name": "Things Logbook",
     "author": "Liam Cain",
     "description": "Sync your Things logbook with your daily notes.",
     "repo": "liamcain/obsidian-things-logbook"
-  },
+  }，
   {
     "id": "obsidian-shortcuts-for-starred-files",
     "name": "Hotkeys for Bookmarks",
     "description": "Set an individual hotkey for the first 9 bookmarked files and open them just with your keyboard.",
     "author": "Vinzent",
     "repo": "Vinzent03/obsidian-shortcuts-for-starred-files"
-  },
+  }，
   {
     "id": "obsidian-filename-heading-sync",
     "name": "Filename Heading Sync",
     "description": "Keep the filename with the first heading of a file in sync.",
     "author": "dvcrn",
     "repo": "dvcrn/obsidian-filename-heading-sync"
-  },
+  }，
   {
     "id": "obsidian-orthography",
     "name": "Orthography",
     "author": "denisoed",
     "description": "Check & fix orthography errors in text.",
     "repo": "denisoed/obsidian-orthography"
-  },
+  }，
   {
     "id": "obsidian-query-language",
     "name": "Obsidian Query Language",
     "author": "Joost Plattel",
     "description": "Query notes and represent data.",
     "repo": "jplattel/obsidian-query-language"
-  },
+  }，
   {
     "id": "obsidian-markdown-formatting-assistant-plugin",
     "name": "Markdown Formatting Assistant",
     "author": "Reocin",
     "description": "A formatting sidebar for Markdown and a command line interface to facilitate a faster workflow.",
     "repo": "Reocin/obsidian-markdown-formatting-assistant-plugin"
-  },
+  }，
   {
     "id": "obsidian-journey-plugin",
     "name": "Journey",
     "author": "Alexis Rondeau",
     "description": "Discover the story between your notes.",
     "repo": "akaalias/obsidian-journey-plugin"
-  },
+  }，
   {
     "id": "tag-wrangler",
     "name": "Tag Wrangler",
     "author": "PJ Eby",
     "description": "Rename, merge, toggle, and search tags from the tag pane.",
     "repo": "pjeby/tag-wrangler"
-  },
+  }，
   {
     "id": "better-pdf-plugin",
     "name": "Better PDF",
     "author": "MSzturc",
     "description": "Insert, scale, rotate and cut-out PDF pages into your notes.",
     "repo": "MSzturc/obsidian-better-pdf-plugin"
-  },
+  }，
   {
     "id": "dataview",
     "name": "Dataview",
     "author": "Michael Brenan",
     "description": "Advanced queries over your vault for the data-obsessed.",
     "repo": "blacksmithgu/obsidian-dataview"
-  },
+  }，
   {
     "id": "periodic-notes",
     "name": "Periodic Notes",
     "author": "Liam Cain",
     "description": "Create/manage your daily, weekly, and monthly notes.",
     "repo": "liamcain/obsidian-periodic-notes"
-  },
+  }，
   {
     "id": "obsidian-show-file-path",
     "name": "Show Current File Path",
@@ -663,91 +663,91 @@
     "author": "tadashi-aikawa",
     "description": "Complete words similar to auto-completion in an IDE.",
     "repo": "tadashi-aikawa/obsidian-various-complements-plugin"
-  },
+  }，
   {
     "id": "note-folder-autorename",
     "name": "Note Folder Autorename",
     "author": "PJ Eby",
     "description": "Turn notes into folders and automatically move/rename their folders when they move or are renamed.",
     "repo": "pjeby/note-folder-autorename"
-  },
+  }，
   {
     "id": "daily-activity",
     "name": "Daily Activity",
     "description": "Output a list of the files changed/created today in the active file.",
     "author": "trydalch",
     "repo": "trydalch/obsidian-daily-activity"
-  },
+  }，
   {
     "id": "obsidian-daily-stats",
     "name": "Daily Stats",
     "description": "Track your daily word count.",
     "author": "Dhruvik Parikh",
     "repo": "dhruvik7/obsidian-daily-stats"
-  },
+  }，
   {
     "id": "open-note-to-window-title",
     "name": "Custom window title",
     "description": "Show the current open note in the window title.",
     "author": "Joost Plattel",
     "repo": "jplattel/open-note-to-window-title"
-  },
+  }，
   {
     "id": "meld-encrypt",
     "name": "Meld Encrypt",
     "description": "Hide secrets in your notes.",
     "author": "meld-cp",
     "repo": "meld-cp/obsidian-encrypt"
-  },
+  }，
   {
     "id": "obsidian-vault-statistics-plugin",
     "name": "Vault Statistics",
-    "description": "Status bar item with vault statistics such as number of notes, files, attachments, and links.",
+    "description": "Status bar item with vault statistics such as number of notes, files, attachments, 和 links.",
     "author": "Bryan Kyle",
     "repo": "bkyle/obsidian-vault-statistics-plugin"
-  },
+  }，
   {
     "id": "obsidian-plugin-todo",
     "name": "TODO | Text-based GTD",
     "description": "Collect all outstanding TODOs from your vault and presents them in lists Today, Scheduled, Inbox and Someday/Maybe.",
     "author": "Lars Lockefeer",
     "repo": "larslockefeer/obsidian-plugin-todo"
-  },
+  }，
   {
     "id": "obsidian-hotkeys-for-specific-files",
     "name": "Hotkeys for specific files",
     "description": "Add commands for specific files and open them with a hotkey.",
     "author": "Vinzent",
     "repo": "Vinzent03/obsidian-hotkeys-for-specific-files"
-  },
+  }，
   {
     "id": "csv-obsidian",
     "name": "CSV Editor",
     "description": "Edit CSV files.",
     "author": "death_au",
     "repo": "deathau/csv-obsidian"
-  },
+  }，
   {
     "id": "obsidian-plugin-toc",
     "name": "Table of Contents",
     "description": "Create a table of contents for a note.",
     "author": "hipstersmoothie",
     "repo": "hipstersmoothie/obsidian-plugin-toc"
-  },
+  }，
   {
     "id": "mochi-cards-exporter",
     "name": "Mochi Cards Exporter",
     "description": "Export Markdown notes to Mochi cards.",
     "author": "kalbetre",
     "repo": "kalbetredev/mochi-cards-exporter"
-  },
+  }，
   {
     "id": "obsidian-plugin-prettier",
     "name": "Prettier Format",
     "description": "Opinionated formatting for your notes.",
     "author": "Andrew Lisowski",
     "repo": "hipstersmoothie/obsidian-plugin-prettier"
-  },
+  }，
   {
     "id": "obsidian-furigana",
     "name": "Furigana",
@@ -18392,7 +18392,7 @@
     "id": "notesmith",
     "name": "NoteSmith",
     "author": "csteamengine",
-    "description": "NoteSmith is a powerful note-refining plugin using OpenAI's API. It allows you to refine your notes, generate summaries, and create new content based on your existing notes.",
+    "description": "NoteSmith is a powerful note-refining plugin using OpenAI's API. It allows you to refine your notes, generate summaries, 和 create new content based on your existing notes.",
     "repo": "csteamengine/notesmith"
   },
   {
@@ -18424,3 +18424,16 @@
     "repo": "CubieProg/Obsidian-Yandex-Tracker-Issue"
   }
 ]
+
+  },
+  {
+      "id": "rmd-markdown-mapper",
+      "name": "RMD as Markdown",
+      "author": "Marksman",
+      "description": "Maps RMD (R Markdown) files to open as Markdown with enhanced       
+  outline view",
+      "repo": "Marksman4971/Obsidian-Rmd-As-Markdown"
+  }
+]
+
+


### PR DESCRIPTION
Add RMD as Markdown plugin for enhanced R Markdown support

# I am submitting a new Community Plugin

- [ ] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [ ] I have tested the plugin on
  - [ ]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [ ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [ ] `main.js`
  - [ ] `manifest.json`
  - [ ] `styles.css` _(optional)_
- [ ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [ ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [ ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [ ] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [ ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [ ] I have added a license in the LICENSE file.
- [ ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
