### PR TITLE
Add plugin: Scoped Search

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18422,5 +18422,12 @@
     "author": "Pavel Sokolov",
     "description": "Display Yandex Tracker issues in your notes",
     "repo": "CubieProg/Obsidian-Yandex-Tracker-Issue"
-  }
+  },
+  {
+  "id": "scoped-search",
+  "name": "Scoped Search",
+  "author": "Ragetrip",
+  "description": "Scoped Search is a robust search modal/tab that only searches within the folders you choose. Includes enhanced folder picker by List or Tree, and configurable extensions.",
+  "repo": "ragetrip/scoped-search"
+}
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18429,5 +18429,5 @@
   "author": "Ragetrip",
   "description": "Scoped Search is a robust search modal/tab that only searches within the folders you choose. Includes enhanced folder picker by List or Tree, and configurable extensions.",
   "repo": "ragetrip/scoped-search"
-}
+  }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

- [x] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

Link to my plugin: https://github.com/ragetrip/scoped-search

## Release Checklist
- [x] I have tested the plugin on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
  - [ ] Android _(if applicable)_
  - [ ] iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.

## Notes
- Release tag/version: 1.0.3
- `manifest.json` version: 1.0.3
- `versions.json`: { "1.0.2": "1.5.0", "1.0.3": "1.5.0" }
