### PR TITLE
Daywise community plugin added to community-plugin.js

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18442,6 +18442,6 @@
 	"name": "Daywise",
 	"author": "Dikshant Jangra",
 	"description": "Generate structured daily logs and organize your freeform notes effortlessly.",
-	"repo": "https://github.com/DikshantJangra/Daywise.git"
+	"repo": "https://github.com/DikshantJangra/Daywise"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18436,5 +18436,12 @@
     "author": "Lauloque",
     "description": "Format selected text into HTML <kbd> tags for representing keyboard keys and mouse inputs.",
     "repo": "Lauloque/Keyboard-Formatter"
-  }
+  },
+  {
+	"id": "daywise",
+	"name": "Daywise",
+	"author": "Dikshant Jangra",
+	"description": "Generate structured daily logs and organize your freeform notes effortlessly.",
+	"repo": "https://github.com/DikshantJangra/Daywise.git"
+}
 ]


### PR DESCRIPTION
This PR adds the Daywise plugin to the Obsidian Community Plugins list.

Daywise helps users generate structured daily summaries from freeform daily notes. It supports both a local parser and an AI-based Gemini provider for enhanced formatting. The plugin aims to organize daily notes efficiently by converting raw logs into clear markdown tables and can be expanded in the future with additional features like sectioning journals, goals, and tasks.

Repository: https://github.com/DikshantJangra/Daywise.git
Thank you for considering this plugin for inclusion!
