### PR TITLE
Add plugin [Center Your Text]

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18450,5 +18450,12 @@
     "author": "William Liang",
     "description": "Retrieve and import research papers.",
     "repo": "willjhliang/obsidian-papers"
-  }
+  },
+  {
+    "id": "center-your-text",
+    "name": "Center Your Text",
+    "author": "Dayto",
+    "descriptionAllows centering text using &Text& syntax", ",
+    "repo": "Dayto0/Obsidian_TextCenter"
+  }  
 ]


### PR DESCRIPTION
Center Your Text is a simple and convenient plugin for Obsidian that allows you to easily center text in your notes using the special syntax &Text&.
