### PR TITLE
Add plugin Center Your Text

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18450,5 +18450,12 @@
     "author": "William Liang",
     "description": "Retrieve and import research papers.",
     "repo": "willjhliang/obsidian-papers"
+  },
+  {
+    "id": "center-your-text",
+    "name": "Center Your Text",
+    "author": "Dayto",
+    "description": "Allows centering text using &Text& syntax",
+    "repo": "Dayto0/Obsidian_TextCenter"
   }
 ]


### PR DESCRIPTION
CenterYourText is a simple and convenient plugin for Obsidian that allows you to easily center text in your notes using the special syntax &Text&

# I am submitting a new Community Plugin

- [x] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [x]  Linux
  - [x]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
