### PR TITLE
Add plugin: Yet Another Memos Sync

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18471,5 +18471,12 @@
     "author": "Thomas Snoeck",
     "description": "Automatically formats specific URLs pasted into your notes into clean Markdown links.",
     "repo": "thomassnoeck/url-formatter-obsidian"
+  },
+  {
+  	"id": "yet-another-memos-sync",
+  	"name": "Yet Another Memos Sync",
+  	"description": "Enhanced Memos sync plugin with emoji timeline and List Callout format support. Features intelligent sync, visual enhancements, and i18n support.",
+  	"author": "exusiaiwei",
+    "repo": "exusiaiwei/yet-another-memos-sync"
   }
 ]


### PR DESCRIPTION
Added 'Yet Another Memos Sync' plugin with enhanced features.

# I am submitting a new Community Plugin

- [x] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/exusiaiwei/yet-another-memos-sync

## Release Checklist
- [X] I have tested the plugin on
  - [X]  Windows
  - [ ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [X] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [X] `main.js`
  - [X] `manifest.json`
  - [X] `styles.css` _(optional)_
- [X] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [X] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [X] My README.md describes the plugin's purpose and provides clear usage instructions.
- [X] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [X] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [X] I have added a license in the LICENSE file.
- [X] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
