### PR TITLE
Update community-plugins.json - eis granola sync 1.0.0

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18471,5 +18471,12 @@
     "author": "Thomas Snoeck",
     "description": "Automatically formats specific URLs pasted into your notes into clean Markdown links.",
     "repo": "thomassnoeck/url-formatter-obsidian"
-  }
+  },
+  {
+  "id": "eis-granola-sync",
+  "name": "Eis Granola Sync",
+  "author": "Diego Eis",
+  "description": "Based on Granola Sync plugin of Danny McClelland, Eis Granola AI syncs your notes from Granola AI to your vault with customizable settings.",
+  "repo": "diegoeis/Eis-Granola-to-Obsidian"
+ }
 ]


### PR DESCRIPTION
New granola sync for obsidian

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)


# I am submitting a new Community Plugin

- [x] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin:
[https://github.com/diegoeis/Eis-Granola-to-Obsidian](https://github.com/diegoeis/Eis-Granola-to-Obsidian)

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [x]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.