### PR TITLE
Add Tag-Driven Notifications plugin entry

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18492,5 +18492,12 @@
     "author": "Jared Kelnhofer",
     "description": "Move cursor right then left briefly on startup --> first opened note. Makes DataView expressions 'activate' automatically instead of waiting for user interaction.",
     "repo": "Treadder/move-cursor-on-startup"
+  },
+  {
+    "id": "tag-driven-notifications",
+    "name": "Tag-Driven Notifications",
+    "author": "Alexander Stolz",
+    "description": "Generate date-based notifications from tags and frontmatter fields with configurable rules and offsets",
+    "repo": "blizzarac/obsidian-tag-driven-notifications"
   }
 ]


### PR DESCRIPTION
## Add Tag-Driven Notifications plugin

### Plugin Description
Tag-Driven Notifications is a powerful Obsidian plugin that generates smart, date-based notifications from tags and frontmatter fields using customizable rules and offsets. It helps users never miss important dates by automatically extracting dates from their notes and sending timely reminders.

### Key Features
- 📅 **Automatic Date Detection**: Extracts dates from both frontmatter fields and inline tags
- 🔔 **Smart Notification Rules**: Configure global rules with customizable offsets (e.g., notify 1 day before birthdays)
- 🔄 **Recurring Patterns**: Support for daily, weekly, monthly, and yearly notifications
- 📱 **Multi-Channel Support**: Send notifications via Obsidian (in-app) and/or system notifications
- 🎯 **Flexible Targeting**: Choose specific folders to scan or index the entire vault
- 🔐 **Privacy Mode**: Option to keep notification schedule in memory only
- 📋 **Rich UI**: Intuitive settings interface with rules table and upcoming notifications preview

### Use Cases
- Birthday and anniversary reminders
- Task and project deadline notifications
- Recurring meeting reminders
- Event countdown notifications
- Custom date-based alerts with flexible timing offsets