### PR TITLE
Add NoteHelper (笔记同步助手) - Community Plugin Submission

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18497,7 +18497,7 @@
     "id": "notehelper",
     "name": "笔记同步助手",
     "author": "NoteHelper Team",
-    "description": "笔记同步助手 - 用于同步笔记和文章到 Obsidian 的插件",
+    "description": "Note synchronization assistant - sync notes and articles with intelligent content parsing and formatting",
     "repo": "notesynchelper/obsidian-notehelper"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18492,5 +18492,12 @@
     "author": "Jared Kelnhofer",
     "description": "Move cursor right then left briefly on startup --> first opened note. Makes DataView expressions 'activate' automatically instead of waiting for user interaction.",
     "repo": "Treadder/move-cursor-on-startup"
+  },
+  {
+    "id": "notehelper",
+    "name": "笔记同步助手",
+    "author": "NoteHelper Team",
+    "description": "笔记同步助手 - 用于同步笔记和文章到 Obsidian 的插件",
+    "repo": "notesynchelper/obsidian-notehelper"
   }
 ]


### PR DESCRIPTION
# I am submitting a new Community Plugin

- [x] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

Link to my plugin: https://github.com/notesynchelper/obsidian-notehelper

## Plugin Information

**Plugin Name**: NoteHelper (笔记同步助手)  
**Author**: NoteHelper Team  
**Description**: Note synchronization assistant - sync notes and articles with intelligent content parsing and formatting  
**Language**: This is a localized plugin primarily for Chinese users, with English interface support  

## Plugin Features

- Support for WeChat Work message synchronization
- Intelligent content parsing and formatting
- Automatic tagging and categorization management
- Real-time synchronization and incremental updates
- Compatible with version 0.15.0+

## Release Checklist
- [x] I have tested the plugin on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
  - [ ] Android _(if applicable)_
  - [ ] iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (Release: 1.10.4)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.

## Additional Notes

This plugin is designed specifically for Chinese users who need to synchronize notes from WeChat Work and other Chinese platforms. The plugin interface supports both Chinese and English, making it accessible to a broader user base.

**Repository**: https://github.com/notesynchelper/obsidian-notehelper  
**Release**: https://github.com/notesynchelper/obsidian-notehelper/releases/tag/1.10.4  
**License**: MIT

Note: Fixed release tag to match exact version number (1.10.4) without 'v' prefix as required by guidelines.