### PR TITLE
Fix typo in plugin validation action

### DIFF
--- a/.github/workflows/validate-plugin-entry.yml
+++ b/.github/workflows/validate-plugin-entry.yml
@@ -54,7 +54,7 @@ jobs:
                 'My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)', 'GitHub release name matches the exact version number specified in my manifest.json',
                 'The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.',
                 'My README.md describes the plugin\'s purpose and provides clear usage instructions.',
-                'I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins\'s adherence to these policies.',
+                'I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugin\'s adherence to these policies.',
                 'I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls',
                 'I have added a license in the LICENSE file.',
                 'My project respects and is compatible with the original license of any code from other plugins that I\'m using.',


### PR DESCRIPTION
Commit af462b6a23a41baa41d431521e4f4b897ee2c897 has introduced a typo in the github action / bot that checks the validity of the PR against the plugin template.