### PR TITLE
Add Image to Html Plus plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17172,10 +17172,10 @@
   },
   {
     "id": "img2html-plus",
-    "name": "Image to HTML",
-    "author": "0x1DA9430",
+    "name": "Image to HTML Plus",
+    "author": "cnzf1",
     "description": "Paste images as HTML format instead of wikilink or markdown format.",
-    "repo": "cnzf1/img2html"
+    "repo": "cnzf1/img2html-plus"
   },
   {
     "id": "themed-discord-rpc",

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17171,6 +17171,13 @@
     "repo": "rodolfo-terriquez/images-to-notes"
   },
   {
+    "id": "img2html-plus",
+    "name": "Image to HTML",
+    "author": "0x1DA9430",
+    "description": "Paste images as HTML format instead of wikilink or markdown format.",
+    "repo": "cnzf1/img2html"
+  },
+  {
     "id": "themed-discord-rpc",
     "name": "Themed Discord RPC",
     "author": "Mouadhbendjedidi",


### PR DESCRIPTION

插件信息

    名称: Image to Html Plus
    作者: cnzf1
    描述:  旨在将粘贴的图片转换为 HTML 格式，而非传统的 wikilink 或 Markdown 格式。该插件的主要功能包括：将粘贴的图片保存为文件并以 HTML 标签形式插入，支持图片对齐方式，支持自定义图片宽度和保存路径，提供可选的 alt 属性以增强可访问性，并支持粘贴通知。
    仓库: https://github.com/cnzf1/img2html-plus
    最新版本: v1.0.0

