### PR TITLE
Add Pomodoro Kanban plugin to community plugins

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "pomodoro-kanban",
+    "name": "Pomodoro Kanban",
+    "author": "ahhhh2016",
+    "description": "Pomodoro enhanced Kanban plugin for Obsidian.",
+    "repo": "ahhhh2016/pomodoro-kanban"
+  },
+  {
     "id": "nldates-obsidian",
     "name": "Natural Language Dates",
     "author": "Argentina Ortega Sainz",


### PR DESCRIPTION
Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)

This plugin provides a Pomodoro-enhanced kanban plugin for Obsidian. Tested and ready for community use.