### PR TITLE
Add obsidian-auto-editing-mode plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18442,6 +18442,6 @@
   "name": "Auto Editing Mode",
   "author": "Kay Fang",
   "description": "Automatically toggle between reading and editing mode",
-  "repo": "Wenkay/obsidian-auto-editing-mode",
+  "repo": "Wenkay/obsidian-auto-editing-mode"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18437,4 +18437,11 @@
     "description": "View XMind files in your vault and connect to XMind software for editing.",
     "repo": "leafney/obsidian-xmind-linker"
   }
+  {
+  "id": "auto-editing-mode",
+  "name": "Auto Editing Mode",
+  "author": "Kay Fang",
+  "description": "Automatically toggle between reading and editing mode",
+  "repo": "Wenkay/obsidian-auto-editing-mode",
+  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18436,7 +18436,7 @@
     "author": "Leafney",
     "description": "View XMind files in your vault and connect to XMind software for editing.",
     "repo": "leafney/obsidian-xmind-linker"
-  }
+  },
   {
   "id": "auto-editing-mode",
   "name": "Auto Editing Mode",


### PR DESCRIPTION
This PR adds the obsidian-auto-editing-mode plugin
Repo：https://github.com/Wenkay/obsidian-auto-editing-mode
Description: 

- When you're in reading mode and click on the note content, it switches to editing mode immediately
- When you leave the document or minimize the window, after a configurable time it switches back to reading mode
- Smart control detection: When you click on Obsidian's mode toggle controls (toolbar buttons, status bar items), it allows manual switching without interference
- Debounced clicks: Prevents accidental double-clicks from causing mode switching issues

--Thanks