### PR TITLE
adds the obsidian-auto-editing-mode plugin

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Kelvin Cao
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Kelvin Cao
+Copyright (c) 2025 Kay Fang
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18442,6 +18442,6 @@
   "name": "Auto Editing Mode",
   "author": "Kay Fang",
   "description": "Automatically toggle between reading and editing mode",
-  "repo": "Wenkay/obsidian-auto-editing-mode",
+  "repo": "Wenkay/obsidian-auto-editing-mode"
   }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18437,4 +18437,11 @@
     "description": "View XMind files in your vault and connect to XMind software for editing.",
     "repo": "leafney/obsidian-xmind-linker"
   }
+  {
+  "id": "auto-editing-mode",
+  "name": "Auto Editing Mode",
+  "author": "Kay Fang",
+  "description": "Automatically toggle between reading and editing mode",
+  "repo": "Wenkay/obsidian-auto-editing-mode",
+  }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18436,7 +18436,7 @@
     "author": "Leafney",
     "description": "View XMind files in your vault and connect to XMind software for editing.",
     "repo": "leafney/obsidian-xmind-linker"
-  }
+  },
   {
   "id": "auto-editing-mode",
   "name": "Auto Editing Mode",


### PR DESCRIPTION
# I am submitting a new Community Plugin

## Repo URL
https://github.com/Wenkay/obsidian-auto-editing-mode

## Release Checklist
- [x] I have tested this plugin on:
  - [x] Desktop
  - [ ] Mobile
- [x] My repo contains:
  - [x] The manifest.json file
  - [x] The main.js file
  - [ ] The styles.css file (optional)
- [x] GitHub release contains all required files (manifest.json, main.js, styles.css if applicable)

## Plugin description
Auto Editing Mode: Automatically switch between **Edit** and **Reading** mode in Obsidian based on context.
