### PR TITLE
Add plugin: obsidian-yuhanbo-task (pure minimal diff via new-plugins entry)

### DIFF
--- a/new-plugins/obsidian-yuhanbo-task.json
+++ b/new-plugins/obsidian-yuhanbo-task.json
@@ -1,0 +1,7 @@
+﻿{
+  "id": "obsidian-yuhanbo-task",
+  "name": "Yuhanbo Task",
+  "author": "yuhanbo758",
+  "description": "任务管理插件：在 Obsidian 中创建、管理和查询任务，支持标签、截止日期与状态过滤。",
+  "repo": "yuhanbo758/obsidian-yuhanbo-task"
+}


### PR DESCRIPTION
This PR adds a single new entry under new-plugins/obsidian-yuhanbo-task.json for maintainers to include in community-plugins.json.

No direct edits to community-plugins.json are included, ensuring a strictly minimal diff and avoiding merge conflicts.

Plugin details:
- id: obsidian-yuhanbo-task
- name: Yuhanbo Task
- author: yuhanbo758
- description: 任务管理插件：在 Obsidian 中创建、管理和查询任务，支持标签、截止日期与状态过滤。
- repo: yuhanbo758/obsidian-yuhanbo-task

Release info:
- Latest tag: v1.0.0
- Manifest.json and versions.json are present in the plugin repo.

If you'd prefer us to directly append this entry to community-plugins.json in this PR, we can update accordingly.