### PR TITLE
chore: add vync plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18443,5 +18443,12 @@
     "author": "Obsidian",
     "description": "Adds a map layout to bases so you can display notes as an interactive map view.",
     "repo": "obsidianmd/obsidian-maps"
+  },
+  {
+    "id": "vync",
+    "name": "Vync",
+    "author": "techsavvyash",
+    "description": "Sync your Obsidian vault using Google Drive as storage.",
+    "repo": "techsavvyash/vync"
   }
 ]


### PR DESCRIPTION
Vync is a local first plugin to allow using your google drive as the sync backend.

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
