### PR TITLE
Add Fix Math for Obsidian plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18449,6 +18449,6 @@
   "name": "Fix Math",
   "author": "Vladislav Sorokin",
   "description": "Convert \\[...\\] to $$...$$ and \\(...\\) to $...$ in the current file, skipping code fences.",
-  "repo": "logux/fix-math-for-obsidian"
+  "repo": "loglux/fix-math-for-obsidian"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18443,5 +18443,12 @@
     "author": "Obsidian",
     "description": "Adds a map layout to bases so you can display notes as an interactive map view.",
     "repo": "obsidianmd/obsidian-maps"
-  }
+  },
+  {
+  "id": "fix-math-for-obsidian",
+  "name": "Fix Math for Obsidian",
+  "author": "Vladislav Sorokin",
+  "description": "Convert \\[...\\] to $$...$$ and \\(...\\) to $...$ in the current file, skipping code fences.",
+  "repo": "logux/fix-math-for-obsidian"
+}
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18445,8 +18445,8 @@
     "repo": "obsidianmd/obsidian-maps"
   },
   {
-  "id": "fix-math-for-obsidian",
-  "name": "Fix Math for Obsidian",
+  "id": "fix-math",
+  "name": "Fix Math",
   "author": "Vladislav Sorokin",
   "description": "Convert \\[...\\] to $$...$$ and \\(...\\) to $...$ in the current file, skipping code fences.",
   "repo": "logux/fix-math-for-obsidian"


### PR DESCRIPTION
Add Fix Math for Obsidian plugin

A simple plugin to convert LaTeX delimiters (\[...\] and \(...\))  to Obsidian format ($$...$$ and $...$) for easy copying from  ChatGPT and other AI assistants.

# I am submitting a new Community Plugin

- [x] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

Link to my plugin: https://github.com/logux/fix-math-for-obsidian

## Release Checklist
- [x] I have tested the plugin on
  - [x] Windows
  - [ ] macOS
  - [ ] Linux
  - [ ] Android _(if applicable)_
  - [ ] iOS _(if applicable)_
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [ ] `styles.css` _(optional - not needed)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (1.0.0)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file (fix-math-for-obsidian)
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugin's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.