### PR TITLE
Add Dropbox Fetcher plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18448,7 +18448,7 @@
     "id": "drpbx-fetcher",
     "name": "Dropbox Fetcher",
     "author": "Jeroen de Zwart",
-    "description": "Sync files from Dropbox folders to your Obsidian vault",
+    "description": "Sync files from Dropbox folders to your vault",
     "repo": "jeroenwk/drpbx-fetcher"
   }
 ]


### PR DESCRIPTION
This PR adds the Dropbox Fetcher plugin to the community plugins directory.

**Plugin repository:** https://github.com/jeroenwk/drpbx-fetcher
**Release:** https://github.com/jeroenwk/drpbx-fetcher/releases/tag/v0.2.1

### Plugin Description
Dropbox Fetcher allows users to sync files from Dropbox folders to their Obsidian vault with automatic and manual sync options. Now with full cross-platform support for Desktop, iOS, and Android.

### Checklist
- [x] I have published a release on GitHub with main.js and manifest.json
- [x] My plugin follows Obsidian developer policies (no obfuscation, ads, or telemetry)
- [x] I have included a README.md with setup instructions
- [x] I have included a LICENSE file
- [x] The plugin supports desktop and mobile platforms (iOS and Android)