### PR TITLE
Add Oscura and Monokai Ristretto themes

### DIFF
--- a/community-css-themes.json
+++ b/community-css-themes.json
@@ -2775,5 +2775,19 @@
     "repo": "IchiroFukuda/spy-terminal-theme",
     "screenshot": "screenshots/spy-terminal-atmosphere.png",
     "modes": ["dark"]
+  },
+  {
+    "name": "Oscura",
+    "author": "Vinit Kumar",
+    "repo": "vinitkumar/oscura-obsidian",
+    "screenshot": "screenshot.png",
+    "modes": ["dark"]
+  },
+  {
+    "name": "Monokai Ristretto",
+    "author": "Vinit Kumar",
+    "repo": "vinitkumar/monokai-ristretto-obsidian",
+    "screenshot": "screenshot.png",
+    "modes": ["dark"]
   }
 ]


### PR DESCRIPTION
This PR adds two new dark themes to Obsidian:

1. **Oscura** - A dark, elegant theme ported from oscura-vim colorscheme
   - Repo: https://github.com/vinitkumar/oscura-obsidian
   - Deep blacks with vibrant accents
   - Optimized for comfortable long-term use

2. **Monokai Ristretto** - A warm dark theme ported from Monokai Pro Ristretto
   - Repo: https://github.com/vinitkumar/monokai-ristretto-obsidian
   - Coffee-inspired warm color palette
   - Based on the popular Monokai Pro color scheme

Both themes are dark mode only and include proper manifest.json files.