### PR TITLE
Add Mail Plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -233,7 +233,7 @@
   {
     "id": "macOS-keyboard-nav-obsidian",
     "name": "macOS Keyboard Navigation",
-    "description": "Enable alt+\u2191 and alt+\u2193 keyboard navigation.",
+    "description": "Enable alt+↑ and alt+↓ keyboard navigation.",
     "author": "ryanjamurphy",
     "repo": "ryanjamurphy/macOS-keyboard-nav-obsidian"
   },
@@ -520,7 +520,7 @@
   {
     "id": "obsidian-file-path-to-uri",
     "name": "File path to URI",
-    "author": "Michal Bure\u0161",
+    "author": "Michal Bureš",
     "description": "Convert file path to URI for easier use of links to local files outside of Obsidian.",
     "repo": "MichalBures/obsidian-file-path-to-uri"
   },
@@ -1095,7 +1095,7 @@
     "id": "obsidian-qrcode-plugin",
     "name": "QR Code Generator",
     "description": "QR code generator.",
-    "author": "Rudi H\u00e4usler",
+    "author": "Rudi Häusler",
     "repo": "rudimuc/obsidian-qrcode"
   },
   {
@@ -1170,7 +1170,7 @@
   },
   {
     "id": "obsidian-pangu",
-    "name": "\u76d8\u53e4 PanGu",
+    "name": "盘古 PanGu",
     "description": "Add spaces between Chinese characters and English alphabet. A boon for typographically compulsive people.",
     "author": "Natumsol",
     "repo": "Natumsol/obsidian-pangu"
@@ -2193,7 +2193,7 @@
   {
     "id": "obsidian-link-archive",
     "name": "Link Archive",
-    "author": "Tam\u00e1s Deme",
+    "author": "Tamás Deme",
     "description": "Archive links in your note so they're available to you even if the original site goes down or gets removed.",
     "repo": "tomzorz/obsidian-link-archive"
   },
@@ -2571,7 +2571,7 @@
   {
     "id": "obsidian-wrap-with-shortcuts",
     "name": "Wrap with shortcuts",
-    "description": "Wrap selected text in custom tags with shortcuts. E.g.: underline, sub, ruby(\u30d5\u30ea\u30ac\u30ca).",
+    "description": "Wrap selected text in custom tags with shortcuts. E.g.: underline, sub, ruby(フリガナ).",
     "author": "Manic Chuang",
     "repo": "manic/obsidian-wrap-with-shortcuts"
   },
@@ -2585,7 +2585,7 @@
   {
     "id": "obsidian-rant",
     "name": "Rant-Lang",
-    "author": "Leander Nei\u00df",
+    "author": "Leander Neiß",
     "description": "Thin wrapper around the high-level procedural templating language Rant.",
     "repo": "lanice/obsidian-rant"
   },
@@ -2957,7 +2957,7 @@
     "id": "heatmap-calendar",
     "name": "Heatmap Calendar",
     "author": "Richard Slettevoll",
-    "description": "Activity Year Overview for DataviewJS, Github style \u2013 Track Goals, Progress, Habits, Tasks, Exercise, Finances, \"Dont Break the Chain\" etc.",
+    "description": "Activity Year Overview for DataviewJS, Github style – Track Goals, Progress, Habits, Tasks, Exercise, Finances, \"Dont Break the Chain\" etc.",
     "repo": "Richardsl/heatmap-calendar-obsidian"
   },
   {
@@ -3313,7 +3313,7 @@
   {
     "id": "obsius-publish",
     "name": "Obsius Publish",
-    "author": "Jon Grythe St\u00f8dle",
+    "author": "Jon Grythe Stødle",
     "description": "Make single notes instantly available on the web.",
     "repo": "jonstodle/obsius-obsidian-plugin"
   },
@@ -3439,7 +3439,7 @@
   {
     "id": "obsidian-filename-emoji-remover",
     "name": "Filename Emoji Remover",
-    "author": "Y\u00fcksel Tolun",
+    "author": "Yüksel Tolun",
     "description": "Automatically remove emojis from filenames. Main purpose is to get rid of Dropbox sync issues for Readwise imported content.",
     "repo": "YTolun/obsidian-filename-emoji-remover"
   },
@@ -3873,7 +3873,7 @@
   {
     "id": "hard-breaks",
     "name": "Hard Breaks",
-    "author": "B\u00f6rge Kiss",
+    "author": "Börge Kiss",
     "description": "Turn soft line breaks in Markdown into hard line breaks.",
     "repo": "bkis/obsidian-hard-breaks"
   },
@@ -4287,7 +4287,7 @@
     "id": "actions-uri",
     "name": "Actions URI",
     "author": "Carlo Zottmann",
-    "description": "Add additional `x-callback-url` endpoints to the app for common actions \u2014 it's a clean, super-charged addition to Obsidian URI.",
+    "description": "Add additional `x-callback-url` endpoints to the app for common actions — it's a clean, super-charged addition to Obsidian URI.",
     "repo": "czottmann/obsidian-actions-uri"
   },
   {
@@ -4377,7 +4377,7 @@
   {
     "id": "obsidian-checkbox3states-plugin",
     "name": "Checkbox 3 states",
-    "author": "Renaud H\u00e9luin @ NovaGa\u00efa",
+    "author": "Renaud Héluin @ NovaGaïa",
     "description": "A third state to checkbox list.",
     "repo": "hrenaud/obsidian-checkbox3states-plugin"
   },
@@ -5204,7 +5204,7 @@
     "id": "obsidian-canvas-conversation",
     "name": "Canvas Conversation",
     "description": "Create a canvas conversation using ChatGPT.",
-    "author": "Andr\u00e9 Baltazar",
+    "author": "André Baltazar",
     "repo": "AndreBaltazar8/obsidian-canvas-conversation"
   },
   {
@@ -5336,7 +5336,7 @@
   {
     "id": "ytranscript",
     "name": "YTranscript",
-    "author": "\u0141ukasz Strz\u0119pek",
+    "author": "Łukasz Strzępek",
     "description": "Easily fetch transcription for any YouTube video.",
     "repo": "lstrzepek/obsidian-yt-transcript"
   },
@@ -5567,7 +5567,7 @@
   {
     "id": "optimize-canvas-connections",
     "name": "Optimize Canvas Connections",
-    "author": "F\u00e9lix Ch\u00e9nier",
+    "author": "Félix Chénier",
     "description": "Declutter a canvas by reconnecting notes using their nearest edges.",
     "repo": "felixchenier/obsidian-optimize-canvas-connections"
   },
@@ -5602,7 +5602,7 @@
   {
     "id": "perilous-writing",
     "name": "Perilous Writing",
-    "description": "Write continuously\u2014or lose all progress.",
+    "description": "Write continuously—or lose all progress.",
     "author": "Sameer Ismail",
     "repo": "sameersismail/obsidian-perilous-writing"
   },
@@ -5678,7 +5678,7 @@
   },
   {
     "id": "gene-ai",
-    "name": "Gene \ud83e\uddec",
+    "name": "Gene 🧬",
     "author": "Matiss Jurevics",
     "description": "Generate text using the OpenAI API.",
     "repo": "MatissJurevics/Gene-AI"
@@ -5826,7 +5826,7 @@
   {
     "id": "advanced-merger",
     "name": "Advanced Merger",
-    "author": "Anto Kein\u00e4nen",
+    "author": "Anto Keinänen",
     "description": "Merge a folder of notes for easier export.",
     "repo": "antoKeinanen/obsidian-advanced-merger"
   },
@@ -5896,7 +5896,7 @@
   {
     "id": "flashcard-learning",
     "name": "Flashcard Learning",
-    "author": "Ga\u00e9tan Muck",
+    "author": "Gaétan Muck",
     "description": "Improved flashcard learning system.",
     "repo": "gaetanmuck/obsidian-flashcard-learning"
   },
@@ -5911,7 +5911,7 @@
     "id": "wucai-highlights-official",
     "name": "WuCai highlights Official",
     "description": "Sync WuCai highlights into your notes.",
-    "author": "\u5e0c\u679c\u58f3\u4e94\u5f69",
+    "author": "希果壳五彩",
     "repo": "makediff/obsidian-wucai"
   },
   {
@@ -6092,7 +6092,7 @@
   {
     "id": "pocketbook-cloud-highlight-importer",
     "name": "Pocketbook Cloud Highlight Importer",
-    "author": "Lena Br\u00fcder",
+    "author": "Lena Brüder",
     "description": "Import notes and highlights from your Pocketbook Cloud account.",
     "repo": "lenalebt/obsidian-pocketbook-cloud-highlight-importer"
   },
@@ -6421,7 +6421,7 @@
   {
     "id": "chess-study",
     "name": "Chess Study",
-    "author": "Christoph Lindst\u00e4dt",
+    "author": "Christoph Lindstädt",
     "description": "A chess study helper and PGN viewer/editor.",
     "repo": "chrislicodes/obsidian-chess-study"
   },
@@ -6659,7 +6659,7 @@
   {
     "id": "movie-obsidian",
     "name": "Movie",
-    "author": "Onur Ay\u00e7i\u00e7ek",
+    "author": "Onur Ayçiçek",
     "description": "Search movies info and trailers.",
     "repo": "onuraycicek/obsidian-movie"
   },
@@ -7254,14 +7254,14 @@
   {
     "id": "finnish-spellcheck",
     "name": "Finnish Spellcheck",
-    "author": "Anto Kein\u00e4nen",
-    "description": "Spellchecker for the Finnish language using Voikko. / Oikolukija suomenkielell\u00e4, joka hy\u00f6dynt\u00e4\u00e4 Voikkoa.",
+    "author": "Anto Keinänen",
+    "description": "Spellchecker for the Finnish language using Voikko. / Oikolukija suomenkielellä, joka hyödyntää Voikkoa.",
     "repo": "antoKeinanen/obsidian-finnish-spellcheck"
   },
   {
     "id": "birthday-tracker",
     "name": "Birthday-Tracker",
-    "author": "Marius W\u00f6rfel",
+    "author": "Marius Wörfel",
     "description": "Keep track of all birthdays of your family and friends.",
     "repo": "Raboro/Obsidian-Birthday-Tracker-Plugin"
   },
@@ -7465,7 +7465,7 @@
     "id": "attachment-manager",
     "name": "Attachment Manager",
     "author": "chenfeicqq",
-    "description": "Attachment Manager: Attachment folder name binding note name, automatically rename, automatically delete, show/hide.\n\u9644\u4ef6\u7ba1\u7406\u5668\uff1a\u9644\u4ef6\u6587\u4ef6\u5939\u540d\u79f0\u7ed1\u5b9a\u7b14\u8bb0\u540d\u3001\u81ea\u52a8\u91cd\u547d\u540d\u3001\u81ea\u52a8\u5220\u9664\u3001\u663e\u793a/\u9690\u85cf\u3002",
+    "description": "Attachment Manager: Attachment folder name binding note name, automatically rename, automatically delete, show/hide.\n附件管理器：附件文件夹名称绑定笔记名、自动重命名、自动删除、显示/隐藏。",
     "repo": "chenfeicqq/obsidian-attachment-manager"
   },
   {
@@ -7751,7 +7751,7 @@
   {
     "id": "automatic-table-of-contents",
     "name": "Automatic Table Of Contents",
-    "author": "Johan Satg\u00e9",
+    "author": "Johan Satgé",
     "description": "Create a table of contents in a note that updates itself when the note changes.",
     "repo": "johansatge/obsidian-automatic-table-of-contents"
   },
@@ -7863,7 +7863,7 @@
   {
     "id": "expiration-date-tracker",
     "name": "Expiration-Date-Tracker",
-    "author": "Marius W\u00f6rfel",
+    "author": "Marius Wörfel",
     "description": "Keep track of all expiration dates, for example, for your groceries.",
     "repo": "Raboro/obsidian-expiration-date-tracker-plugin"
   },
@@ -7905,7 +7905,7 @@
   {
     "id": "sync-contacts-macos",
     "name": "Sync Contacts on macOS",
-    "author": "Marcel Sch\u00f6ckel",
+    "author": "Marcel Schöckel",
     "description": "Sync your macOS contacts.",
     "repo": "motschel123/Mac-Contact-Sync-Obsidian"
   },
@@ -8094,7 +8094,7 @@
   {
     "id": "timer",
     "name": "Timer",
-    "author": "Marius W\u00f6rfel",
+    "author": "Marius Wörfel",
     "description": "Measure time.",
     "repo": "Raboro/obsidian-timer-plugin"
   },
@@ -8108,7 +8108,7 @@
   {
     "id": "gpg-crypt",
     "name": "gpgCrypt",
-    "author": "Tjado M\u00e4cke",
+    "author": "Tjado Mäcke",
     "description": "Encrypt your notes using GPG. Supports smartcards for enhanced security! Keep your information safe and accessible only to you.",
     "repo": "tejado/obsidian-gpgCrypt"
   },
@@ -8130,7 +8130,7 @@
     "id": "screengarden-obsidian",
     "name": "screen.garden",
     "author": "screengarden, LLC",
-    "description": "Realtime multiplayer collaboration, live cursors without merge conflicts, folder sync, share links, web editing, and more\u2014for teams or working solo.",
+    "description": "Realtime multiplayer collaboration, live cursors without merge conflicts, folder sync, share links, web editing, and more—for teams or working solo.",
     "repo": "screendotgarden/screengarden-obsidian"
   },
   {
@@ -8228,7 +8228,7 @@
     "id": "lunar-calendar",
     "name": "Lunar Calendar",
     "author": "OSmile",
-    "description": "\u4e00\u4e2a\u652f\u6301\u519c\u5386\u7684\u65e5\u5386",
+    "description": "一个支持农历的日历",
     "repo": "WHG555/lunar-calendar"
   },
   {
@@ -8367,7 +8367,7 @@
   {
     "id": "moon-server-publisher",
     "name": "Moon server publisher",
-    "author": "Roman Provazn\u00edk",
+    "author": "Roman Provazník",
     "description": "Publish your notes directly to Moon server instance.",
     "repo": "Dzoukr/MoonServerObsidianPlugin"
   },
@@ -8423,7 +8423,7 @@
   {
     "id": "gladdis",
     "name": "Gladdis",
-    "author": "Aur\u00e9lien St\u00e9b\u00e9",
+    "author": "Aurélien Stébé",
     "description": "Gladdis (Generative Language Artificial Dedicated & Diligent Intelligence System) - it's an AI chatbot.",
     "repo": "AurelienStebe/Gladdis"
   },
@@ -9061,7 +9061,7 @@
     "id": "coder",
     "name": "Encoder/Decoder",
     "description": "Encoding and decoding text using Base64, ROT13 and Atbash ciphers.",
-    "author": "Rudi H\u00e4usler",
+    "author": "Rudi Häusler",
     "repo": "rudimuc/obsidian-coder"
   },
   {
@@ -9452,7 +9452,7 @@
   {
     "id": "markline",
     "name": "Markline",
-    "author": "\u95f2\u8018",
+    "author": "闲耘",
     "description": "Timeline view from Markdown",
     "repo": "hotoo/obsidian-markline"
   },
@@ -9614,7 +9614,7 @@
     "id": "better-order-list",
     "name": "Better Order List",
     "author": "Boninall",
-    "description": "Support new line order list like 1\u3001 or (1)., etc.",
+    "description": "Support new line order list like 1、 or (1)., etc.",
     "repo": "Quorafind/Obsidian-Better-Order-List"
   },
   {
@@ -10075,7 +10075,7 @@
   {
     "id": "augmented-canvas",
     "name": "Augmented Canvas",
-    "author": "L\u00e9opold Szabatura",
+    "author": "Léopold Szabatura",
     "description": "Augment Canvas with AI features.",
     "repo": "MetaCorp/obsidian-augmented-canvas"
   },
@@ -10139,7 +10139,7 @@
     "id": "mblog-publish",
     "name": "MBlog Publish",
     "author": "Jerry",
-    "description": "\u901a\u8fc7Obsidian\u53d1\u5e03\u6587\u7ae0\u5230MBlog\u5e73\u53f0",
+    "description": "通过Obsidian发布文章到MBlog平台",
     "repo": "kingwrcy/obsidian-mblog"
   },
   {
@@ -10383,7 +10383,7 @@
   {
     "id": "title-renamer",
     "name": "Title renamer",
-    "author": "Peter Str\u00f8iman",
+    "author": "Peter Strøiman",
     "description": "Keep top heading in note synced with file name.",
     "repo": "stroiman/obsidian-title-sync"
   },
@@ -10461,7 +10461,7 @@
     "id": "simsapa",
     "name": "Simsapa",
     "author": "gambhiro",
-    "description": "P\u0101li dictionary and sutta search using Simsapa Dhamma Reader. Open a sidebar or double-click to lookup P\u0101li words in the dictionary, or search in the suttas.",
+    "description": "Pāli dictionary and sutta search using Simsapa Dhamma Reader. Open a sidebar or double-click to lookup Pāli words in the dictionary, or search in the suttas.",
     "repo": "simsapa/simsapa-obsidian"
   },
   {
@@ -10593,7 +10593,7 @@
   {
     "id": "new-tab-plus",
     "name": "New Tab +",
-    "author": "Rapha\u00ebl Le Carval",
+    "author": "Raphaël Le Carval",
     "description": "Allow to open markdown files, graph and canvas in new tab as the default behavior.",
     "repo": "Raphlette/obsidian-new-tab-plus"
   },
@@ -10642,7 +10642,7 @@
   {
     "id": "hemingway-mode",
     "name": "Hemingway Mode",
-    "author": "Joaqu\u00edn Bernal",
+    "author": "Joaquín Bernal",
     "description": "Prevents any editing, only letting you write ahead.",
     "repo": "jobedom/obsidian-hemingway-mode"
   },
@@ -10943,8 +10943,8 @@
   {
     "id": "dust-calendar",
     "name": "Dust Calendar",
-    "author": "\u7eb3\u7c73\u7ea7\u5c18\u57c3",
-    "description": "\u66f4\u7b26\u5408\u4e2d\u56fd\u4e60\u60ef\u7684\u65e5\u5386\uff0c\u53ef\u4ee5\u663e\u793a\u519c\u5386\u3001\u8282\u6c14\u3001\u8282\u5047\u65e5\u3001\u8c03\u4f11\u4fe1\u606f\uff0c\u652f\u6301\u6708\u89c6\u56fe\u548c\u5e74\u89c6\u56fe\u5207\u6362\uff0c\u652f\u6301\u5173\u8054\u521b\u5efa\u5468\u671f\u6027\u7b14\u8bb0\u3002",
+    "author": "纳米级尘埃",
+    "description": "更符合中国习惯的日历，可以显示农历、节气、节假日、调休信息，支持月视图和年视图切换，支持关联创建周期性笔记。",
     "repo": "a-nano-dust/dust-obsidian-calendar"
   },
   {
@@ -11299,7 +11299,7 @@
   },
   {
     "id": "advanced-canvas-filter",
-    "name": "Advanced \u0421anvas Filter",
+    "name": "Advanced Сanvas Filter",
     "author": "CHex0K",
     "description": "Filter Canvas to show only items with specified tags.",
     "repo": "CHex0K/advanced-canvas-filter"
@@ -11383,9 +11383,9 @@
   },
   {
     "id": "legifrance-integration",
-    "name": "L\u00e9gifrance Int\u00e9gration",
+    "name": "Légifrance Intégration",
     "author": "hurj",
-    "description": "Int\u00e9gration de l'API L\u00e9gifrance.",
+    "description": "Intégration de l'API Légifrance.",
     "repo": "carnetdethese/legifrance-integration"
   },
   {
@@ -11405,7 +11405,7 @@
   {
     "id": "update-time",
     "name": "Update Time",
-    "author": "S\u00e9bastien Dubois",
+    "author": "Sébastien Dubois",
     "description": "Update front matter to include creation and last update times",
     "repo": "dsebastien/obsidian-update-time"
   },
@@ -11427,7 +11427,7 @@
     "id": "heti",
     "name": "heti",
     "author": "Moeyua",
-    "description": "\u4e13\u4e3a\u4e2d\u6587\u5185\u5bb9\u5c55\u793a\u8bbe\u8ba1\u7684\u6392\u7248\u6837\u5f0f\u589e\u5f3a\u3002\u5b83\u57fa\u4e8e\u901a\u884c\u7684\u4e2d\u6587\u6392\u7248\u89c4\u8303\u800c\u6765\uff0c\u53ef\u4ee5\u5e26\u6765\u66f4\u597d\u7684\u9605\u8bfb\u4f53\u9a8c\u3002",
+    "description": "专为中文内容展示设计的排版样式增强。它基于通行的中文排版规范而来，可以带来更好的阅读体验。",
     "repo": "moeyua/obsidian-heti"
   },
   {
@@ -12007,7 +12007,7 @@
   {
     "id": "dataview-serializer",
     "name": "Dataview Serializer",
-    "author": "S\u00e9bastien Dubois",
+    "author": "Sébastien Dubois",
     "description": "Serialize Dataview queries to Markdown, and keep the Markdown representation up to date",
     "repo": "dsebastien/obsidian-dataview-serializer"
   },
@@ -12042,7 +12042,7 @@
   {
     "id": "publish-to-dev",
     "name": "Publish to DEV",
-    "author": "Peter Str\u00f8iman",
+    "author": "Peter Strøiman",
     "description": "Publish and update notes as articles on DEV (https://dev.to)",
     "repo": "stroiman/obsidian-dev-publish"
   },
@@ -12106,7 +12106,7 @@
     "id": "virtual-linker",
     "name": "Virtual Linker / Glossary",
     "description": "Automatically creates virtual links for text within your notes that match the titles or aliases of other notes in your vault. Create a glossary-like functionality, show unlinked mentions and transform them to real links.",
-    "author": "Valentin Schr\u00f6ter",
+    "author": "Valentin Schröter",
     "repo": "vschroeter/obsidian-virtual-linker"
   },
   {
@@ -12119,7 +12119,7 @@
   {
     "id": "shrink-pinned-tabs",
     "name": "Shrink pinned tabs",
-    "author": "Nicolas L\u0153uillet",
+    "author": "Nicolas Lœuillet",
     "description": "Shrinks pinned tabs to save screen space.",
     "repo": "nicosomb/obsidian-shrink-pinned-tabs"
   },
@@ -12168,7 +12168,7 @@
   {
     "id": "hash-pasted-image",
     "name": "Hash Pasted Image",
-    "author": "Minh V\u01b0\u01a1ng",
+    "author": "Minh Vương",
     "description": "Auto rename pasted images added to the vault via hash algorithm SHA-512",
     "repo": "hardingadonis/hash-pasted-image"
   },
@@ -12259,7 +12259,7 @@
   {
     "id": "account-viewer",
     "name": "Account Viewer",
-    "author": "Muaz Yediy\u00fczk\u0131rkiki",
+    "author": "Muaz Yediyüzkırkiki",
     "description": "Automatically generate accounting tables from Markdown code blocks tagged with accounting.",
     "repo": "muaz742/obsidian-accointing-viewer"
   },
@@ -12309,7 +12309,7 @@
     "id": "chinese-calendar",
     "name": "Chinese Calendar",
     "author": "DevilRoshan",
-    "description": "\u7b26\u5408\u4e2d\u56fd\u4e60\u60ef\u7684\u65e5\u5386\uff0c\u53ef\u4ee5\u663e\u793a\u519c\u5386\u3001\u8282\u65e5\u3001\u8c03\u4f11\u3001\u8282\u6c14\u7b49\u4fe1\u606f\uff0c\u652f\u6301\u6708\u89c6\u56fe\u548c\u5e74\u89c6\u56fe\u5207\u6362\uff0c\u652f\u6301\u70b9\u51fb\u65e5\u671f\u521b\u5efa\u7b14\u8bb0\uff0c\u652f\u6301\u4f7f\u7528QuickAdd\u63d2\u4ef6\u521b\u5efa\u7b14\u8bb0\u3002",
+    "description": "符合中国习惯的日历，可以显示农历、节日、调休、节气等信息，支持月视图和年视图切换，支持点击日期创建笔记，支持使用QuickAdd插件创建笔记。",
     "repo": "DevilRoshan/obsidian-lunar-calendar"
   },
   {
@@ -12568,7 +12568,7 @@
     "id": "smart-templates",
     "name": "Smart Templates",
     "description": "AI powered templates for generating structured content. Works with Local Models, Anthropic Claude, Gemini, OpenAI & more.",
-    "author": "\ud83c\udf34 Brian Petro",
+    "author": "🌴 Brian Petro",
     "repo": "brianpetro/obsidian-smart-templates"
   },
   {
@@ -13224,8 +13224,8 @@
   },
   {
     "id": "newledge",
-    "name": "\u65b0\u679dNewledge",
-    "author": "\u65b0\u679dNewledge",
+    "name": "新枝Newledge",
+    "author": "新枝Newledge",
     "description": "Import Newledge data.",
     "repo": "DepartingAgain/obsidian-newledge"
   },
@@ -13268,7 +13268,7 @@
     "id": "bookxnote-sync",
     "name": "BookXNote Sync",
     "author": "CodeListening",
-    "description": "\u540c\u6b65bookxnote\u4e2d\u7684\u8bfb\u4e66\u7b14\u8bb0",
+    "description": "同步bookxnote中的读书笔记",
     "repo": "CodeListening/obsidian-bookxnote"
   },
   {
@@ -13330,7 +13330,7 @@
   {
     "id": "typefully",
     "name": "Typefully",
-    "author": "S\u00e9bastien Dubois",
+    "author": "Sébastien Dubois",
     "description": "Typefully integration. Publish social media posts with ease",
     "repo": "dsebastien/obsidian-typefully"
   },
@@ -13429,7 +13429,7 @@
     "id": "japanese-novel-ruby",
     "name": "Japanese Novel Ruby",
     "author": "quels <@k-quels>",
-    "description": "Treat ruby(Furigana) \u200b\u200bmarks commonly used in Japanese novels",
+    "description": "Treat ruby(Furigana) ​​marks commonly used in Japanese novels",
     "repo": "k-quels/japanese-novel-ruby"
   },
   {
@@ -13504,9 +13504,9 @@
   },
   {
     "id": "copy-image-text",
-    "name": "\u590d\u5236\u56fe\u6587 (Copy Image Text)",
+    "name": "复制图文 (Copy Image Text)",
     "author": "msgk",
-    "description": "Copy note content (including text and images) to clipboard. \u590d\u5236\u7b14\u8bb0\u5185\u5bb9\uff08\u5305\u62ec\u6587\u672c\u548c\u56fe\u7247\uff09\u5230\u526a\u8d34\u677f\u3002",
+    "description": "Copy note content (including text and images) to clipboard. 复制笔记内容（包括文本和图片）到剪贴板。",
     "repo": "msgk239/obsidian-copy-image-text"
   },
   {
@@ -13695,7 +13695,7 @@
     "id": "superstition",
     "name": "Superstition",
     "author": "Jeffry",
-    "description": "Manage routines with traditional calendar concept of \u5b9c/\u5fcc.",
+    "description": "Manage routines with traditional calendar concept of 宜/忌.",
     "repo": "shuxueshuxue/superstition"
   },
   {
@@ -13757,7 +13757,7 @@
   {
     "id": "brain-dump-mode",
     "name": "Brain Dump Mode",
-    "description": "Done is better than perfect. Complete your first-messy-draft before you make it perfect. Your delete key will be DISABLED and all you can do is JUST BURN YOUR KEYBOARDS\ud83d\udd25",
+    "description": "Done is better than perfect. Complete your first-messy-draft before you make it perfect. Your delete key will be DISABLED and all you can do is JUST BURN YOUR KEYBOARDS🔥",
     "author": "yesjinu",
     "repo": "yesjinu/brain-dump-mode"
   },
@@ -14135,7 +14135,7 @@
   {
     "id": "llm-workspace",
     "name": "LLM workspace",
-    "author": "Oliv\u00e9r Falvai",
+    "author": "Olivér Falvai",
     "description": "Use Large Language Models grounded in your notes.",
     "repo": "ofalvai/obsidian-llm-workspace"
   },
@@ -14157,7 +14157,7 @@
     "id": "heatmap-tracker",
     "name": "Heatmap Tracker",
     "author": "Maksim Rubanau",
-    "description": "Visualize your activity and track goals, progress, habits, tasks, exercise, finances, and more\u2014all in a single, interactive heatmap!",
+    "description": "Visualize your activity and track goals, progress, habits, tasks, exercise, finances, and more—all in a single, interactive heatmap!",
     "repo": "mokkiebear/heatmap-tracker"
   },
   {
@@ -14283,7 +14283,7 @@
     "id": "sync-cnblog",
     "name": "Sync Cnblog",
     "author": "zhanglei",
-    "description": "\u5c06\u7b14\u8bb0\u540c\u6b65\u5230\u535a\u5ba2\u56ed",
+    "description": "将笔记同步到博客园",
     "repo": "lei-ctyh/obsidian-sync-cnblog"
   },
   {
@@ -14388,7 +14388,7 @@
     "id": "ampliflow-page",
     "name": "AmpliFlow Page Publisher",
     "description": "Publish notes easily to AmpliFlow (https://www.ampliflow.se)",
-    "author": "Patrik Bj\u00f6rklund",
+    "author": "Patrik Björklund",
     "repo": "AmpliFlow/obsidian-ampliflow-page"
   },
   {
@@ -14422,7 +14422,7 @@
   {
     "id": "kkh",
     "name": "kkh",
-    "author": "\u5948\u5e7e\u4e43(uakms)",
+    "author": "奈幾乃(uakms)",
     "description": "Replace words in a string using kkh dictionary.",
     "repo": "okikae/obsid-kkh"
   },
@@ -14478,8 +14478,8 @@
   {
     "id": "smart-context",
     "name": "Smart Context",
-    "author": "\ud83c\udf34 Brian",
-    "description": "Instantly copy folder contents or open notes\u2014excluding specified headings\u2014into your clipboard. Perfect for providing curated context to tools like ChatGPT, improving responses, and streamlining your AI workflows.",
+    "author": "🌴 Brian",
+    "description": "Instantly copy folder contents or open notes—excluding specified headings—into your clipboard. Perfect for providing curated context to tools like ChatGPT, improving responses, and streamlining your AI workflows.",
     "repo": "brianpetro/smart-context-obsidian"
   },
   {
@@ -14506,7 +14506,7 @@
   {
     "id": "replicate",
     "name": "Replicate",
-    "author": "S\u00e9bastien Dubois",
+    "author": "Sébastien Dubois",
     "description": "Replicate.com integration. Generate images using AI.",
     "repo": "dsebastien/obsidian-replicate"
   },
@@ -14591,7 +14591,7 @@
     "id": "better-plugins-manager",
     "name": "Better Plugins Manager",
     "author": "zero",
-    "description": "\u6253\u9020\u60a8\u7684\u6781\u81f4\u63d2\u4ef6\u7ba1\u7406\u4f53\u9a8c\uff0c\u8ba9\u63d2\u4ef6\u7ba1\u7406\u53d8\u5f97\u66f4\u52a0\u76f4\u89c2\u3001\u9ad8\u6548\uff0c\u540c\u65f6\u63d0\u5347\u60a8\u7684\u5de5\u4f5c\u6d41\u7a0b\u548c\u4e2a\u6027\u5316\u8bbe\u7f6e\u3002",
+    "description": "打造您的极致插件管理体验，让插件管理变得更加直观、高效，同时提升您的工作流程和个性化设置。",
     "repo": "Obsidian-Forge/obsidian-manager"
   },
   {
@@ -15172,7 +15172,7 @@
     "id": "minote-sync",
     "name": "Minote Sync",
     "author": "Emac Shen",
-    "description": "Sync Minote(\u5c0f\u7c73\u7b14\u8bb0) into your vault.",
+    "description": "Sync Minote(小米笔记) into your vault.",
     "repo": "emac/obsidian-minote-plugin"
   },
   {
@@ -15234,7 +15234,7 @@
   {
     "id": "papyrus",
     "name": "Papyrus",
-    "author": "Andr\u00e9 Silva, Daniel Guerra, Diogo Ferreira, Eduardo Barrancos",
+    "author": "André Silva, Daniel Guerra, Diogo Ferreira, Eduardo Barrancos",
     "description": "The most amazing documentation assistant",
     "repo": "Papyrus-doc-ai/papyrus-obsidian"
   },
@@ -15577,7 +15577,7 @@
   {
     "id": "ascii-tree-generator",
     "name": "ASCII Tree Generator",
-    "author": "Mat\u011bj Mich\u00e1lek",
+    "author": "Matěj Michálek",
     "description": "Convert indented code blocks with hierarchy markers into formatted ASCII tree diagrams.",
     "repo": "michalekmatej/obsidian.md-ascii-tree-generator"
   },
@@ -15653,9 +15653,9 @@
   },
   {
     "id": "harn-weather",
-    "name": "H\u00e2rn Weather Generator",
-    "author": "Marc Andr\u00e9 Ueberall",
-    "description": "Weather generator for the H\u00e2rnMaster: Roleplaying in the World of K\u00e8th\u00eera rule system.",
+    "name": "Hârn Weather Generator",
+    "author": "Marc André Ueberall",
+    "description": "Weather generator for the HârnMaster: Roleplaying in the World of Kèthîra rule system.",
     "repo": "marcueberall/obsidian-harn-weather"
   },
   {
@@ -15732,7 +15732,7 @@
     "id": "tidit",
     "name": "tidit",
     "author": "codingthings.com",
-    "description": "tidit adds timestamps to your document as you type \u2014 when you want it, how you want it, where you want it.",
+    "description": "tidit adds timestamps to your document as you type — when you want it, how you want it, where you want it.",
     "repo": "codingthings-com/tidit-obsidian"
   },
   {
@@ -15886,7 +15886,7 @@
     "id": "smooth-cursor",
     "name": "Smooth Cursor",
     "author": "Busyo",
-    "description": "\u5e73\u6ed1\u5149\u6807 Smooth Cursor",
+    "description": "平滑光标 Smooth Cursor",
     "repo": "busyoGG/SmoothCursor"
   },
   {
@@ -15984,7 +15984,7 @@
     "id": "one-step-wiki-link",
     "name": "One Step Wiki Link",
     "author": "Busyo",
-    "description": "\u4e00\u6b65\u6dfb\u52a0 wiki \u94fe\u63a5",
+    "description": "一步添加 wiki 链接",
     "repo": "busyoGG/OneStepWikiLink"
   },
   {
@@ -16060,7 +16060,7 @@
   {
     "id": "smart-chatgpt",
     "name": "Smart ChatGPT",
-    "author": "\ud83c\udf34 Brian",
+    "author": "🌴 Brian",
     "description": "Integrate OpenAI's ChatGPT seamlessly in notes. Automatically saves links, allows marking threads as done, and integrates with Dataview.",
     "repo": "brianpetro/smart-chatgpt-obsidian"
   },
@@ -16138,7 +16138,7 @@
     "id": "xiaohongshu-importer",
     "name": "Xiaohongshu Importer",
     "author": "bnchiang96",
-    "description": "Import Xiaohongshu (\u5c0f\u7ea2\u4e66) notes with media and categorization.",
+    "description": "Import Xiaohongshu (小红书) notes with media and categorization.",
     "repo": "bnchiang96/xiaohongshu-importer"
   },
   {
@@ -16439,7 +16439,7 @@
     "id": "minimal-quiz",
     "name": "Minimal Quiz",
     "author": "Lutu-gl",
-    "description": "Start a quick Markdown-based quiz on your current note. Simple, straightforward, and fully integrated \u2014 similar to flashcards in Anki or Quizlet!",
+    "description": "Start a quick Markdown-based quiz on your current note. Simple, straightforward, and fully integrated — similar to flashcards in Anki or Quizlet!",
     "repo": "Lutu-gl/Obsidian-Minimal-Quiz"
   },
   {
@@ -16460,7 +16460,7 @@
     "id": "come-down",
     "name": "Come Down",
     "author": "mntno",
-    "description": "Maintains a cache of your notes\u2019 embedded external images.",
+    "description": "Maintains a cache of your notes’ embedded external images.",
     "repo": "mntno/obsidian-come-down"
   },
   {
@@ -16711,7 +16711,7 @@
   {
     "id": "yt-summarizer",
     "name": "YTSummarizer",
-    "author": "Arda Kalayc\u0131",
+    "author": "Arda Kalaycı",
     "description": "Fetch YouTube video transcripts and generate summaries using OpenAI models.",
     "repo": "ardakalayci/ytsummarizer"
   },
@@ -16873,7 +16873,7 @@
     "id": "enhanced-publisher",
     "name": "Enhanced Publisher",
     "author": "Cube",
-    "description": "\u589e\u5f3a\u53d1\u5e03\u63d2\u4ef6\uff0c\u652f\u6301\u56fe\u7247\u65f6\u81ea\u52a8\u5b58\u50a8\u3001HTML\u9884\u89c8\u548c\u53d1\u5e03\u5230\u5fae\u4fe1\u516c\u4f17\u53f7\u7b49\u5185\u5bb9\u5e73\u53f0\u3002",
+    "description": "增强发布插件，支持图片时自动存储、HTML预览和发布到微信公众号等内容平台。",
     "repo": "chararch/obsidian-enhanced-publisher"
   },
   {
@@ -17062,7 +17062,7 @@
     "id": "hadith-lookup",
     "name": "Hadith Lookup",
     "author": "Adnan Mukhtar",
-    "description": "Inserts Hadith and Quranic ayat and passages using a reference ID from the \u1e24ad\u012bth Unlocked API (https://hadithunlocked.com)",
+    "description": "Inserts Hadith and Quranic ayat and passages using a reference ID from the Ḥadīth Unlocked API (https://hadithunlocked.com)",
     "repo": "iadnanmukhtar/obsidian-hadith-lookup-plugin"
   },
   {
@@ -17285,7 +17285,7 @@
   {
     "id": "note-mover-shortcut",
     "name": "NoteMover shortcut",
-    "author": "Lars B\u00fccker",
+    "author": "Lars Bücker",
     "description": "Quickly and easily move notes to a predefined folder. Perfect for organizing your notes.",
     "repo": "bueckerlars/obsidian-note-mover-shortcut"
   },
@@ -17328,7 +17328,7 @@
     "id": "openwords",
     "name": "OpenWords",
     "author": "insile",
-    "description": "\u7528\u4e8e\u82f1\u8bed\u5b66\u4e60\u4e2d\u80cc\u5355\u8bcd\u4e0e\u5355\u8bcd\u7ba1\u7406\u7684\u63d2\u4ef6",
+    "description": "用于英语学习中背单词与单词管理的插件",
     "repo": "insile/OpenWords"
   },
   {
@@ -18007,7 +18007,7 @@
     "id": "cloud-sync",
     "name": "Cloud sync",
     "author": "Bing",
-    "description": "\u5c06\u7b14\u8bb0\u540c\u6b65\u5230\u591a\u79cd\u4e91\u76d8\u670d\u52a1\uff0c\u63d0\u4f9b\u7aef\u5230\u7aef\u52a0\u5bc6\u4fdd\u62a4\u3002",
+    "description": "将笔记同步到多种云盘服务，提供端到端加密保护。",
     "repo": "ai-bytedance/obsidian-cloud-sync"
   },
   {
@@ -18202,7 +18202,7 @@
   {
     "id": "long-sentence-highlighter",
     "name": "Long sentence highlighter",
-    "author": "Robert Mei\u00dfner",
+    "author": "Robert Meißner",
     "description": "Highlights sentences that exceed a configurable word count threshold to help improve writing clarity and readability.",
     "repo": "RobertMeissner/obsidian-long-sentence-highlighter"
   },
@@ -18230,7 +18230,7 @@
   {
     "id": "juliaplots",
     "name": "JuliaPlots",
-    "author": "Iv\u00e1n Mansilla",
+    "author": "Iván Mansilla",
     "description": "Plot a function graph inside of your notes using Julia.",
     "repo": "ivnmansi/juliaplots"
   },
@@ -18265,7 +18265,7 @@
   {
     "id": "accounting-journal-ledger",
     "name": "Accounting Journal and Ledger",
-    "author": "Javier Ribal del R\u00edo",
+    "author": "Javier Ribal del Río",
     "description": "Tool for recording simple journal entries in class, based on the Spanish libro diario and libro mayor (ledger). Uses double-entry bookkeeping.",
     "repo": "JavierRibaldelRio/accounting-journal-ledger"
   },
@@ -18293,7 +18293,7 @@
   {
     "id": "paste-as-file-link",
     "name": "Paste as file link",
-    "author": "Matthias B\u00fcge",
+    "author": "Matthias Büge",
     "description": "Paste clipboard content as file links into existing notes, when a file with this name is existing.",
     "repo": "mbedded/obsidian-paste-file-link"
   },
@@ -18464,5 +18464,12 @@
     "author": "Fan Li",
     "description": "A simple and light-weighted google calendar importer, allow injecting the events / tasks of a day automatically to your daily notes, or import it to anywhere with a command.",
     "repo": "lexafaxine/GoogleCalendarImporter"
+  },
+  {
+    "id": "mail",
+    "name": "Mail",
+    "author": "Dries Verbruggen",
+    "description": "Export notes as HTML emails. Opens your default email client with the note content converted to HTML.",
+    "repo": "droezel/obsidian-mail-plugin"
   }
 ]


### PR DESCRIPTION
## Plugin name
Mail

## Plugin description
Export notes as HTML emails. Opens your default email client with the note content converted to HTML.

## Repo URL
https://github.com/droezel/obsidian-mail-plugin

## Release notes URL
https://github.com/droezel/obsidian-mail-plugin/releases/tag/1.0.1

## Checklist
- [x] I have read the guidelines for plugin submissions
- [x] My plugin follows the Obsidian developer policies
- [x] I have tested my plugin with the latest version of Obsidian
- [x] My plugin ID does not contain "obsidian" or "plugin"
- [x] My plugin name does not contain "Plugin"
- [x] My plugin has been released on GitHub