### PR TITLE
Add Image Link Updater plugin

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18443,5 +18443,12 @@
     "author": "Obsidian",
     "description": "Adds a map layout to bases so you can display notes as an interactive map view.",
     "repo": "obsidianmd/obsidian-maps"
+  },
+  {
+    "id": "image-link-updater",
+    "name": "Image Link Updater",
+    "author": "Andy Lai",
+    "description": "Automatically updates markdown image links when image files are renamed or moved in the vault.",
+    "repo": "andy51002000/obsidian-image-link-updater"
   }
 ]


### PR DESCRIPTION
This PR adds the Image Link Updater plugin.

- Repo: https://github.com/andy51002000/obsidian-image-link-updater
- Description: Automatically updates markdown image links when image files are renamed or moved in the vault.
- Author: Andy Lai
- License: AGPL-3.0-or-later
- Version: 1.3.0