### PR TITLE
Add plugin: Anki Trigger Flashcards

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18449,6 +18449,6 @@
     "name": "Anki Trigger Flashcards",
     "author": "JaKeoung Koo",
     "description": "Generates Anki flashcards fast with context from lines starting with customized triggers (e.g. prototypical example). Front: trigger with context (filename and header). Back: remaining line content.",
-    "repo": "jakeoung/anki-trigger-flashcards"
+    "repo": "jakeoung/obsidian-trigger-flashcards"
   }
 ]


### PR DESCRIPTION
Added Anki Trigger Flashcards plugin with details.

# I am submitting a new Community Plugin

- [x ] I attest that I have done my best to deliver a high-quality plugin, am proud of the code I have written, and would recommend it to others. I commit to maintaining the plugin and being responsive to bug reports. If I am no longer able to maintain it, I will make reasonable efforts to find a successor maintainer or withdraw the plugin from the directory.

## Repo URL

<!--- Paste a link to your repo here for easy access -->
Link to my plugin: https://github.com/jakeoung/obsidian-trigger-flashcards

## Release Checklist
- [x ] I have tested the plugin on
  - [ ]  Windows
  - [x ]  macOS
  - [ ]  Linux
  - [ ]  Android _(if applicable)_
  - [ ]  iOS _(if applicable)_
- [x ] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x ] `main.js`
  - [x ] `manifest.json`
  - [x ] `styles.css` _(optional)_
- [x ] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x ] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x ] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x ] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugin's adherence to these policies.
- [x ] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x ] I have added a license in the LICENSE file.
- [x ] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
